### PR TITLE
feat: add wiremock style funcitonality to ensure retry scenario with real world tests

### DIFF
--- a/exporter/chronicleexporter/go.mod
+++ b/exporter/chronicleexporter/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/goccy/go-json v0.10.5
 	github.com/golang/mock v1.7.0-rc.1
 	github.com/google/uuid v1.6.0
+	github.com/observiq/bindplane-otel-contrib/internal/testutils v1.0.0
 	github.com/observiq/bindplane-otel-contrib/pkg/expr v1.0.0
 	github.com/observiq/bindplane-otel-contrib/pkg/osinfo v1.0.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.147.0
@@ -105,6 +106,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/observiq/bindplane-otel-contrib/internal/testutils => ../../internal/testutils
 
 replace github.com/observiq/bindplane-otel-contrib/pkg/osinfo => ../../pkg/osinfo
 

--- a/exporter/chronicleexporter/http_exporter_test.go
+++ b/exporter/chronicleexporter/http_exporter_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/observiq/bindplane-otel-contrib/exporter/chronicleexporter/internal/metadatatest"
 	"github.com/observiq/bindplane-otel-contrib/exporter/chronicleexporter/protos/api"
+	"github.com/observiq/bindplane-otel-contrib/internal/testutils/retryserver"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
@@ -82,16 +83,22 @@ func TestHTTPExporter(t *testing.T) {
 		cfg.BackOffConfig.Enabled = false
 	}
 
-	defaultHandlers := map[string]http.HandlerFunc{
-		"FAKE": func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		},
+	singleLog := func() plog.Logs {
+		logs := plog.NewLogs()
+		rls := logs.ResourceLogs().AppendEmpty()
+		sls := rls.ScopeLogs().AppendEmpty()
+		lrs := sls.LogRecords().AppendEmpty()
+		lrs.Body().SetStr("Test")
+		return logs
 	}
+
+	// logTypePath is the Chronicle-style import path for the FAKE log type.
+	const logTypePath = "/logTypes/FAKE/logs:import"
 
 	testCases := []struct {
 		name             string
 		cfgMod           func(cfg *Config)
-		handlers         map[string]http.HandlerFunc
+		serverStatusCode int // 0 defaults to 200 OK
 		input            plog.Logs
 		expectedRequests int
 		expectedErr      string
@@ -103,128 +110,55 @@ func TestHTTPExporter(t *testing.T) {
 			expectedRequests: 0,
 		},
 		{
-			name: "single log record",
-			input: func() plog.Logs {
-				logs := plog.NewLogs()
-				rls := logs.ResourceLogs().AppendEmpty()
-				sls := rls.ScopeLogs().AppendEmpty()
-				lrs := sls.LogRecords().AppendEmpty()
-				lrs.Body().SetStr("Test")
-				return logs
-			}(),
+			name:             "single log record",
+			input:            singleLog(),
 			expectedRequests: 1,
 		},
 		// TODO test splitting large payloads
 		{
-			name: "retryable_error 429 Too Many Requests",
-			handlers: map[string]http.HandlerFunc{
-				"FAKE": func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusTooManyRequests)
-				},
-			},
-			input: func() plog.Logs {
-				logs := plog.NewLogs()
-				rls := logs.ResourceLogs().AppendEmpty()
-				sls := rls.ScopeLogs().AppendEmpty()
-				lrs := sls.LogRecords().AppendEmpty()
-				lrs.Body().SetStr("Test")
-				return logs
-			}(),
+			name:             "retryable_error 429 Too Many Requests",
+			serverStatusCode: http.StatusTooManyRequests,
+			input:            singleLog(),
 			expectedRequests: 1,
 			expectedErr:      "upload to chronicle: 429 Too Many Requests",
 			permanentErr:     false,
 		},
 		{
-			name: "retryable_error 500 Internal Server Error",
-			handlers: map[string]http.HandlerFunc{
-				"FAKE": func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusInternalServerError)
-				},
-			},
-			input: func() plog.Logs {
-				logs := plog.NewLogs()
-				rls := logs.ResourceLogs().AppendEmpty()
-				sls := rls.ScopeLogs().AppendEmpty()
-				lrs := sls.LogRecords().AppendEmpty()
-				lrs.Body().SetStr("Test")
-				return logs
-			}(),
+			name:             "retryable_error 500 Internal Server Error",
+			serverStatusCode: http.StatusInternalServerError,
+			input:            singleLog(),
 			expectedRequests: 1,
 			expectedErr:      "upload to chronicle: 500 Internal Server Error",
 			permanentErr:     false,
 		},
 		{
-			name: "retryable_error 502 Bad Gateway",
-			handlers: map[string]http.HandlerFunc{
-				"FAKE": func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusBadGateway)
-				},
-			},
-			input: func() plog.Logs {
-				logs := plog.NewLogs()
-				rls := logs.ResourceLogs().AppendEmpty()
-				sls := rls.ScopeLogs().AppendEmpty()
-				lrs := sls.LogRecords().AppendEmpty()
-				lrs.Body().SetStr("Test")
-				return logs
-			}(),
+			name:             "retryable_error 502 Bad Gateway",
+			serverStatusCode: http.StatusBadGateway,
+			input:            singleLog(),
 			expectedRequests: 1,
 			expectedErr:      "upload to chronicle: 502 Bad Gateway",
 			permanentErr:     false,
 		},
 		{
-			name: "retryable_error 503 Service Unavailable",
-			handlers: map[string]http.HandlerFunc{
-				"FAKE": func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusServiceUnavailable)
-				},
-			},
-			input: func() plog.Logs {
-				logs := plog.NewLogs()
-				rls := logs.ResourceLogs().AppendEmpty()
-				sls := rls.ScopeLogs().AppendEmpty()
-				lrs := sls.LogRecords().AppendEmpty()
-				lrs.Body().SetStr("Test")
-				return logs
-			}(),
+			name:             "retryable_error 503 Service Unavailable",
+			serverStatusCode: http.StatusServiceUnavailable,
+			input:            singleLog(),
 			expectedRequests: 1,
 			expectedErr:      "upload to chronicle: 503 Service Unavailable",
 			permanentErr:     false,
 		},
 		{
-			name: "retryable_error 504 Gateway Timeout",
-			handlers: map[string]http.HandlerFunc{
-				"FAKE": func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusGatewayTimeout)
-				},
-			},
-			input: func() plog.Logs {
-				logs := plog.NewLogs()
-				rls := logs.ResourceLogs().AppendEmpty()
-				sls := rls.ScopeLogs().AppendEmpty()
-				lrs := sls.LogRecords().AppendEmpty()
-				lrs.Body().SetStr("Test")
-				return logs
-			}(),
+			name:             "retryable_error 504 Gateway Timeout",
+			serverStatusCode: http.StatusGatewayTimeout,
+			input:            singleLog(),
 			expectedRequests: 1,
 			expectedErr:      "upload to chronicle: 504 Gateway Timeout",
 			permanentErr:     false,
 		},
 		{
-			name: "permanent_error",
-			handlers: map[string]http.HandlerFunc{
-				"FAKE": func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusUnauthorized)
-				},
-			},
-			input: func() plog.Logs {
-				logs := plog.NewLogs()
-				rls := logs.ResourceLogs().AppendEmpty()
-				sls := rls.ScopeLogs().AppendEmpty()
-				lrs := sls.LogRecords().AppendEmpty()
-				lrs.Body().SetStr("Test")
-				return logs
-			}(),
+			name:             "permanent_error",
+			serverStatusCode: http.StatusUnauthorized,
+			input:            singleLog(),
 			expectedRequests: 1,
 			expectedErr:      "upload to chronicle: Permanent error: 401 Unauthorized",
 			permanentErr:     true,
@@ -233,21 +167,28 @@ func TestHTTPExporter(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create a mock server so we are not dependent on the actual Chronicle service
-			handlers := defaultHandlers
-			if tc.handlers != nil {
-				handlers = tc.handlers
+			// Resolve status code: 0 means success (200 OK).
+			statusCode := tc.serverStatusCode
+			if statusCode == 0 {
+				statusCode = http.StatusOK
 			}
-			mockServer := newMockHTTPServer(handlers)
-			defer mockServer.srv.Close()
 
-			// Override the endpoint builder so that we can point to the mock server
+			// Use retryserver so the expected status code is returned for every
+			// request to the FAKE log type endpoint.
+			srv := retryserver.New(t, nil,
+				retryserver.WithRoute(logTypePath, []retryserver.Response{
+					{StatusCode: statusCode},
+				}),
+				retryserver.WithFallback(retryserver.Response{StatusCode: statusCode}),
+			)
+
+			// Override the endpoint builder to point at the retryserver.
 			secureHTTPEndpoint := httpEndpoint
 			defer func() {
 				httpEndpoint = secureHTTPEndpoint
 			}()
 			httpEndpoint = func(_ *Config, logType string) string {
-				return fmt.Sprintf("%s/logTypes/%s/logs:import", mockServer.srv.URL, logType)
+				return fmt.Sprintf("%s/logTypes/%s/logs:import", srv.URL(), logType)
 			}
 
 			f := NewFactory()
@@ -275,7 +216,140 @@ func TestHTTPExporter(t *testing.T) {
 				require.Equal(t, tc.permanentErr, consumererror.IsPermanent(err))
 			}
 
-			require.Equal(t, tc.expectedRequests, mockServer.requestCount)
+			require.Equal(t, tc.expectedRequests, srv.RouteRequestCount(logTypePath))
+		})
+	}
+}
+
+// TestHTTPExporterRetrySequences tests multi-attempt retry scenarios using retryserver
+// to simulate real-world backend failure patterns. Each ConsumeLogs call maps to one
+// HTTP request; the retryserver advances through its sequence on every hit, allowing
+// us to assert correct error classification at each step.
+func TestHTTPExporterRetrySequences(t *testing.T) {
+	secureTokenSource := tokenSource
+	defer func() { tokenSource = secureTokenSource }()
+	tokenSource = func(context.Context, *Config) (oauth2.TokenSource, error) {
+		return &emptyTokenSource{}, nil
+	}
+
+	singleLog := func() plog.Logs {
+		logs := plog.NewLogs()
+		rls := logs.ResourceLogs().AppendEmpty()
+		sls := rls.ScopeLogs().AppendEmpty()
+		lr := sls.LogRecords().AppendEmpty()
+		lr.Body().SetStr("Test")
+		return logs
+	}
+
+	const logTypePath = "/logTypes/FAKE/logs:import"
+
+	type callExpectation struct {
+		expectErr    bool
+		permanentErr bool
+	}
+
+	testCases := []struct {
+		name     string
+		sequence []retryserver.Response
+		calls    []callExpectation
+	}{
+		{
+			// Verifies the exporter treats consecutive 429s as retryable,
+			// allowing the caller (exporterhelper) to retry until the server recovers.
+			name: "consecutive rate-limits then success: 429 → 429 → success",
+			sequence: []retryserver.Response{
+				{StatusCode: http.StatusTooManyRequests, RetryAfter: "1"},
+				{StatusCode: http.StatusTooManyRequests, RetryAfter: "1"},
+				{StatusCode: http.StatusOK},
+			},
+			calls: []callExpectation{
+				{expectErr: true, permanentErr: false}, // 429 retryable
+				{expectErr: true, permanentErr: false}, // 429 retryable
+				{expectErr: false},                     // 200 success
+			},
+		},
+		{
+			name: "transient gateway cascade: 502 → 503 → 504 → success",
+			sequence: []retryserver.Response{
+				{StatusCode: http.StatusBadGateway},
+				{StatusCode: http.StatusServiceUnavailable},
+				{StatusCode: http.StatusGatewayTimeout},
+				{StatusCode: http.StatusOK},
+			},
+			calls: []callExpectation{
+				{expectErr: true, permanentErr: false}, // 502 retryable
+				{expectErr: true, permanentErr: false}, // 503 retryable
+				{expectErr: true, permanentErr: false}, // 504 retryable
+				{expectErr: false},                     // 200 success
+			},
+		},
+		{
+			name: "transient error then immediate success",
+			sequence: []retryserver.Response{
+				{StatusCode: http.StatusServiceUnavailable},
+				{StatusCode: http.StatusOK},
+			},
+			calls: []callExpectation{
+				{expectErr: true, permanentErr: false}, // 503 retryable
+				{expectErr: false},                     // 200 success
+			},
+		},
+		{
+			name: "retryable then permanent: 429 → 401 unauthorized",
+			sequence: []retryserver.Response{
+				{StatusCode: http.StatusTooManyRequests},
+				{StatusCode: http.StatusUnauthorized},
+			},
+			calls: []callExpectation{
+				{expectErr: true, permanentErr: false}, // 429 retryable
+				{expectErr: true, permanentErr: true},  // 401 permanent — do not retry
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := retryserver.New(t, nil,
+				retryserver.WithRoute(logTypePath, tc.sequence),
+			)
+
+			secureHTTPEndpoint := httpEndpoint
+			defer func() { httpEndpoint = secureHTTPEndpoint }()
+			httpEndpoint = func(_ *Config, logType string) string {
+				return fmt.Sprintf("%s/logTypes/%s/logs:import", srv.URL(), logType)
+			}
+
+			f := NewFactory()
+			cfg := f.CreateDefaultConfig().(*Config)
+			cfg.Protocol = protocolHTTPS
+			cfg.Location = "us"
+			cfg.CustomerID = "00000000-1111-2222-3333-444444444444"
+			cfg.Project = "fake"
+			cfg.Forwarder = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+			cfg.LogType = "FAKE"
+			cfg.QueueBatchConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+			cfg.BackOffConfig.Enabled = false
+			require.NoError(t, cfg.Validate())
+
+			ctx := context.Background()
+			exp, err := f.CreateLogs(ctx, exportertest.NewNopSettings(typ), cfg)
+			require.NoError(t, err)
+			require.NoError(t, exp.Start(ctx, componenttest.NewNopHost()))
+			defer func() { require.NoError(t, exp.Shutdown(ctx)) }()
+
+			for i, call := range tc.calls {
+				err := exp.ConsumeLogs(ctx, singleLog())
+				if call.expectErr {
+					require.Error(t, err, "call %d should return error", i)
+					require.Equal(t, call.permanentErr, consumererror.IsPermanent(err),
+						"call %d permanentErr mismatch", i)
+				} else {
+					require.NoError(t, err, "call %d should succeed", i)
+				}
+			}
+
+			require.Equal(t, len(tc.calls), srv.RouteRequestCount(logTypePath),
+				"request count should match number of ConsumeLogs calls")
 		})
 	}
 }

--- a/exporter/webhookexporter/exporter_logs_test.go
+++ b/exporter/webhookexporter/exporter_logs_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/observiq/bindplane-otel-contrib/internal/testutils/retryserver"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -201,78 +202,146 @@ func TestSendLogsRetryableVsPermanentErrors(t *testing.T) {
 		permanentErr bool
 	}{
 		// Retryable per OTLP spec
-		{
-			name:         "429 Too Many Requests is retryable",
-			statusCode:   http.StatusTooManyRequests,
-			permanentErr: false,
-		},
-		{
-			name:         "502 Bad Gateway is retryable",
-			statusCode:   http.StatusBadGateway,
-			permanentErr: false,
-		},
-		{
-			name:         "503 Service Unavailable is retryable",
-			statusCode:   http.StatusServiceUnavailable,
-			permanentErr: false,
-		},
-		{
-			name:         "504 Gateway Timeout is retryable",
-			statusCode:   http.StatusGatewayTimeout,
-			permanentErr: false,
-		},
+		{name: "429 Too Many Requests is retryable", statusCode: http.StatusTooManyRequests, permanentErr: false},
+		{name: "502 Bad Gateway is retryable", statusCode: http.StatusBadGateway, permanentErr: false},
+		{name: "503 Service Unavailable is retryable", statusCode: http.StatusServiceUnavailable, permanentErr: false},
+		{name: "504 Gateway Timeout is retryable", statusCode: http.StatusGatewayTimeout, permanentErr: false},
 		// Permanent errors
-		{
-			name:         "400 Bad Request is permanent",
-			statusCode:   http.StatusBadRequest,
-			permanentErr: true,
-		},
-		{
-			name:         "401 Unauthorized is permanent",
-			statusCode:   http.StatusUnauthorized,
-			permanentErr: true,
-		},
-		{
-			name:         "403 Forbidden is permanent",
-			statusCode:   http.StatusForbidden,
-			permanentErr: true,
-		},
-		{
-			name:         "404 Not Found is permanent",
-			statusCode:   http.StatusNotFound,
-			permanentErr: true,
-		},
-		{
-			name:         "500 Internal Server Error is permanent",
-			statusCode:   http.StatusInternalServerError,
-			permanentErr: true,
-		},
+		{name: "400 Bad Request is permanent", statusCode: http.StatusBadRequest, permanentErr: true},
+		{name: "401 Unauthorized is permanent", statusCode: http.StatusUnauthorized, permanentErr: true},
+		{name: "403 Forbidden is permanent", statusCode: http.StatusForbidden, permanentErr: true},
+		{name: "404 Not Found is permanent", statusCode: http.StatusNotFound, permanentErr: true},
+		{name: "500 Internal Server Error is permanent", statusCode: http.StatusInternalServerError, permanentErr: true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(tc.statusCode)
-			}))
-			defer server.Close()
+			// Use retryserver so the response sequence is explicit and the server
+			// auto-cleans up via t.Cleanup (no manual defer needed).
+			srv := retryserver.New(t, []retryserver.Response{
+				{StatusCode: tc.statusCode},
+			})
 
 			cfg := &SignalConfig{
-				ClientConfig: confighttp.ClientConfig{
-					Endpoint: server.URL,
-				},
-				Verb:        POST,
-				ContentType: "application/json",
+				ClientConfig: confighttp.ClientConfig{Endpoint: srv.URL()},
+				Verb:         POST,
+				ContentType:  "application/json",
 			}
 
 			exp, err := newLogsExporter(context.Background(), cfg, exportertest.NewNopSettings(component.MustNewType("webhook")))
 			require.NoError(t, err)
-			err = exp.start(context.Background(), componenttest.NewNopHost())
-			require.NoError(t, err)
+			require.NoError(t, exp.start(context.Background(), componenttest.NewNopHost()))
 
 			err = exp.sendLogs(context.Background(), []any{"test log"})
 			require.Error(t, err)
 			require.Equal(t, tc.permanentErr, consumererror.IsPermanent(err),
 				"expected permanentErr=%v for status %d", tc.permanentErr, tc.statusCode)
+
+			require.Equal(t, 1, srv.RequestCount())
+		})
+	}
+}
+
+// TestWebhookRetrySequences tests multi-attempt retry scenarios using retryserver to
+// simulate real-world backend failure patterns. Each sendLogs call maps to one HTTP
+// request; the retryserver advances its sequence on every hit, letting us verify that
+// the exporter correctly classifies each response (retryable vs. permanent) across
+// a realistic failure sequence.
+func TestWebhookRetrySequences(t *testing.T) {
+	newExp := func(t *testing.T, endpoint string) *logsExporter {
+		t.Helper()
+		cfg := &SignalConfig{
+			ClientConfig: confighttp.ClientConfig{Endpoint: endpoint},
+			Verb:         POST,
+			ContentType:  "application/json",
+		}
+		exp, err := newLogsExporter(context.Background(), cfg, exportertest.NewNopSettings(component.MustNewType("webhook")))
+		require.NoError(t, err)
+		require.NoError(t, exp.start(context.Background(), componenttest.NewNopHost()))
+		return exp
+	}
+
+	type callExpectation struct {
+		expectErr    bool
+		permanentErr bool
+	}
+
+	testCases := []struct {
+		name     string
+		sequence []retryserver.Response
+		calls    []callExpectation
+	}{
+		{
+			// Verifies consecutive rate-limit responses are retried until the server recovers.
+			name: "consecutive rate-limits then success: 429 → 429 → success",
+			sequence: []retryserver.Response{
+				{StatusCode: http.StatusTooManyRequests, RetryAfter: "1"},
+				{StatusCode: http.StatusTooManyRequests, RetryAfter: "1"},
+				{StatusCode: http.StatusOK},
+			},
+			calls: []callExpectation{
+				{expectErr: true, permanentErr: false}, // 429 retryable
+				{expectErr: true, permanentErr: false}, // 429 retryable
+				{expectErr: false},                     // 200 success
+			},
+		},
+		{
+			name: "gateway cascade: 502 → 503 → 504 → success",
+			sequence: []retryserver.Response{
+				{StatusCode: http.StatusBadGateway},
+				{StatusCode: http.StatusServiceUnavailable},
+				{StatusCode: http.StatusGatewayTimeout},
+				{StatusCode: http.StatusOK},
+			},
+			calls: []callExpectation{
+				{expectErr: true, permanentErr: false}, // 502 retryable
+				{expectErr: true, permanentErr: false}, // 503 retryable
+				{expectErr: true, permanentErr: false}, // 504 retryable
+				{expectErr: false},                     // 200 success
+			},
+		},
+		{
+			name: "retryable then permanent: 429 → 401 unauthorized",
+			sequence: []retryserver.Response{
+				{StatusCode: http.StatusTooManyRequests},
+				{StatusCode: http.StatusUnauthorized},
+			},
+			calls: []callExpectation{
+				{expectErr: true, permanentErr: false}, // 429 retryable
+				{expectErr: true, permanentErr: true},  // 401 permanent — do not retry
+			},
+		},
+		{
+			name: "single transient failure then success",
+			sequence: []retryserver.Response{
+				{StatusCode: http.StatusServiceUnavailable},
+				{StatusCode: http.StatusOK},
+			},
+			calls: []callExpectation{
+				{expectErr: true, permanentErr: false}, // 503 retryable
+				{expectErr: false},                     // 200 success
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := retryserver.New(t, tc.sequence)
+			exp := newExp(t, srv.URL())
+
+			for i, call := range tc.calls {
+				err := exp.sendLogs(context.Background(), []any{"test log"})
+				if call.expectErr {
+					require.Error(t, err, "call %d should return error", i)
+					require.Equal(t, call.permanentErr, consumererror.IsPermanent(err),
+						"call %d permanentErr mismatch", i)
+				} else {
+					require.NoError(t, err, "call %d should succeed", i)
+				}
+			}
+
+			require.Equal(t, len(tc.calls), srv.RequestCount(),
+				"request count should match number of sendLogs calls")
 		})
 	}
 }

--- a/exporter/webhookexporter/go.mod
+++ b/exporter/webhookexporter/go.mod
@@ -4,6 +4,7 @@ go 1.25.7
 
 require (
 	github.com/observiq/bindplane-otel-contrib/internal/exporterutils v1.0.0
+	github.com/observiq/bindplane-otel-contrib/internal/testutils v1.0.0
 	github.com/observiq/bindplane-otel-contrib/pkg/version v1.0.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.53.0
@@ -97,5 +98,7 @@ require (
 )
 
 replace github.com/observiq/bindplane-otel-contrib/internal/exporterutils => ../../internal/exporterutils
+
+replace github.com/observiq/bindplane-otel-contrib/internal/testutils => ../../internal/testutils
 
 replace github.com/observiq/bindplane-otel-contrib/pkg/version => ../../pkg/version

--- a/internal/testutils/retryserver/server.go
+++ b/internal/testutils/retryserver/server.go
@@ -1,0 +1,237 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package retryserver provides a WireMock-style configurable HTTP mock server
+// for testing retry behavior in exporters. It simulates real-world failure
+// scenarios — rate limiting, gateway errors, transient failures — by responding
+// with a predefined sequence of HTTP responses, after which it falls back to a
+// default response.
+//
+// # Usage
+//
+// Create a server with a sequence of responses and point your exporter at it:
+//
+//	srv := retryserver.New(t, []retryserver.Response{
+//	    {StatusCode: 429, RetryAfter: "1"},
+//	    {StatusCode: 429},
+//	    {StatusCode: 200},
+//	})
+//	// srv.URL() returns the base URL to configure your exporter against
+//	// After the test, check srv.RequestCount() to assert retry attempts
+//
+// # Routing
+//
+// By default the server matches all paths. Use WithRoute to register
+// path-specific sequences (useful for exporters that use distinct endpoints):
+//
+//	srv := retryserver.New(t, nil,
+//	    retryserver.WithRoute("/api/logs", []retryserver.Response{
+//	        {StatusCode: 503},
+//	        {StatusCode: 200},
+//	    }),
+//	)
+package retryserver //import "github.com/observiq/bindplane-otel-contrib/internal/testutils/retryserver"
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// Response defines a single HTTP response in a sequence.
+type Response struct {
+	// StatusCode is the HTTP status code to return. Defaults to 200 if zero.
+	StatusCode int
+	// RetryAfter is the optional value for the Retry-After response header.
+	// Accepts seconds as a string ("2") or an HTTP date (RFC1123 format).
+	RetryAfter string
+	// Body is the optional response body.
+	Body string
+	// Headers contains additional response headers to set.
+	Headers map[string]string
+}
+
+// route holds a path-specific response sequence and its request counter.
+type route struct {
+	mu           sync.Mutex
+	responses    []Response
+	requestCount int
+	fallback     Response
+}
+
+// next returns the next response from the sequence, or the fallback.
+func (r *route) next() Response {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requestCount++
+	idx := r.requestCount - 1
+	if idx < len(r.responses) {
+		return r.responses[idx]
+	}
+	return r.fallback
+}
+
+// count returns the total number of requests handled by this route.
+func (r *route) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.requestCount
+}
+
+// Server is a configurable mock HTTP server that responds with predefined
+// sequences of HTTP responses to simulate real-world retry scenarios.
+type Server struct {
+	srv          *httptest.Server
+	defaultRoute *route
+	routes       map[string]*route
+	mu           sync.RWMutex
+}
+
+// Option is a functional option for configuring a Server.
+type Option func(*Server)
+
+// WithFallback sets the default response used after the global sequence is
+// exhausted. Defaults to 200 OK if not specified.
+func WithFallback(r Response) Option {
+	return func(s *Server) {
+		s.defaultRoute.fallback = r
+	}
+}
+
+// WithRoute registers a path-specific response sequence. Requests matching
+// the path exactly will use this sequence instead of the default one.
+// The fallback for the route defaults to 200 OK.
+func WithRoute(path string, responses []Response, opts ...RouteOption) Option {
+	return func(s *Server) {
+		r := &route{
+			responses: responses,
+			fallback:  Response{StatusCode: http.StatusOK},
+		}
+		for _, opt := range opts {
+			opt(r)
+		}
+		s.mu.Lock()
+		s.routes[path] = r
+		s.mu.Unlock()
+	}
+}
+
+// RouteOption is a functional option for configuring an individual route.
+type RouteOption func(*route)
+
+// WithRouteFallback sets the fallback response for a specific route after
+// its sequence is exhausted.
+func WithRouteFallback(resp Response) RouteOption {
+	return func(r *route) {
+		r.fallback = resp
+	}
+}
+
+// New creates and starts a mock HTTP server with the given default response
+// sequence. The server is automatically stopped via t.Cleanup when the test
+// ends. Pass nil or an empty slice for responses to use only the fallback.
+func New(t *testing.T, responses []Response, opts ...Option) *Server {
+	t.Helper()
+
+	s := &Server{
+		defaultRoute: &route{
+			responses: responses,
+			fallback:  Response{StatusCode: http.StatusOK},
+		},
+		routes: make(map[string]*route),
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	s.srv = httptest.NewServer(http.HandlerFunc(s.handler))
+	t.Cleanup(s.srv.Close)
+
+	return s
+}
+
+// URL returns the base URL of the mock server (e.g. "http://127.0.0.1:PORT").
+func (s *Server) URL() string {
+	return s.srv.URL
+}
+
+// RequestCount returns the total number of requests received by the default
+// (catch-all) route. For path-specific counts use RouteRequestCount.
+func (s *Server) RequestCount() int {
+	return s.defaultRoute.count()
+}
+
+// RouteRequestCount returns the number of requests received by the given path.
+// Returns 0 if the path was never registered or never received requests.
+func (s *Server) RouteRequestCount(path string) int {
+	s.mu.RLock()
+	r, ok := s.routes[path]
+	s.mu.RUnlock()
+	if !ok {
+		return 0
+	}
+	return r.count()
+}
+
+// Reset resets the request counters and sequence position for all routes,
+// allowing the same server to be reused across sub-tests.
+func (s *Server) Reset() {
+	s.defaultRoute.mu.Lock()
+	s.defaultRoute.requestCount = 0
+	s.defaultRoute.mu.Unlock()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, r := range s.routes {
+		r.mu.Lock()
+		r.requestCount = 0
+		r.mu.Unlock()
+	}
+}
+
+// handler dispatches incoming requests to the matching route or the default.
+func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	rt, ok := s.routes[r.URL.Path]
+	s.mu.RUnlock()
+
+	if !ok {
+		rt = s.defaultRoute
+	}
+
+	resp := rt.next()
+	writeResponse(w, resp)
+}
+
+// writeResponse writes a Response to the http.ResponseWriter.
+func writeResponse(w http.ResponseWriter, resp Response) {
+	for k, v := range resp.Headers {
+		w.Header().Set(k, v)
+	}
+	if resp.RetryAfter != "" {
+		w.Header().Set("Retry-After", resp.RetryAfter)
+	}
+
+	code := resp.StatusCode
+	if code == 0 {
+		code = http.StatusOK
+	}
+	w.WriteHeader(code)
+
+	if resp.Body != "" {
+		_, _ = w.Write([]byte(resp.Body))
+	}
+}

--- a/internal/testutils/retryserver/server_test.go
+++ b/internal/testutils/retryserver/server_test.go
@@ -1,0 +1,259 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retryserver_test
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/observiq/bindplane-otel-contrib/internal/testutils/retryserver"
+)
+
+// get is a tiny helper that issues a GET to url and returns the response.
+func get(t *testing.T, url string) *http.Response {
+	t.Helper()
+	resp, err := http.Get(url) //nolint:noctx
+	require.NoError(t, err)
+	return resp
+}
+
+// getPath issues a GET to url+path.
+func getPath(t *testing.T, base, path string) *http.Response {
+	t.Helper()
+	resp, err := http.Get(base + path) //nolint:noctx
+	require.NoError(t, err)
+	return resp
+}
+
+func TestNew_DefaultFallback200(t *testing.T) {
+	srv := retryserver.New(t, nil)
+	resp := get(t, srv.URL())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 1, srv.RequestCount())
+}
+
+func TestNew_Sequence(t *testing.T) {
+	responses := []retryserver.Response{
+		{StatusCode: http.StatusTooManyRequests},
+		{StatusCode: http.StatusServiceUnavailable},
+		{StatusCode: http.StatusOK},
+	}
+
+	srv := retryserver.New(t, responses)
+
+	require.Equal(t, http.StatusTooManyRequests, get(t, srv.URL()).StatusCode)
+	require.Equal(t, http.StatusServiceUnavailable, get(t, srv.URL()).StatusCode)
+	require.Equal(t, http.StatusOK, get(t, srv.URL()).StatusCode)
+	// Beyond the sequence → fallback (200)
+	require.Equal(t, http.StatusOK, get(t, srv.URL()).StatusCode)
+
+	require.Equal(t, 4, srv.RequestCount())
+}
+
+func TestNew_RealWorldRateLimitScenario(t *testing.T) {
+	// Simulates consecutive rate-limit responses followed by a successful retry.
+	srv := retryserver.New(t, []retryserver.Response{
+		{StatusCode: http.StatusTooManyRequests, RetryAfter: "1"},
+		{StatusCode: http.StatusTooManyRequests, RetryAfter: "1"},
+		{StatusCode: http.StatusOK},
+	})
+
+	r1 := get(t, srv.URL())
+	require.Equal(t, http.StatusTooManyRequests, r1.StatusCode)
+	require.Equal(t, "1", r1.Header.Get("Retry-After"))
+
+	r2 := get(t, srv.URL())
+	require.Equal(t, http.StatusTooManyRequests, r2.StatusCode)
+	require.Equal(t, "1", r2.Header.Get("Retry-After"))
+
+	r3 := get(t, srv.URL())
+	require.Equal(t, http.StatusOK, r3.StatusCode)
+
+	require.Equal(t, 3, srv.RequestCount())
+}
+
+func TestNew_RetryAfterHeader(t *testing.T) {
+	srv := retryserver.New(t, []retryserver.Response{
+		{StatusCode: http.StatusTooManyRequests, RetryAfter: "30"},
+	})
+
+	resp := get(t, srv.URL())
+	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	require.Equal(t, "30", resp.Header.Get("Retry-After"))
+}
+
+func TestNew_ResponseBody(t *testing.T) {
+	srv := retryserver.New(t, []retryserver.Response{
+		{StatusCode: http.StatusOK, Body: `{"status":"ok"}`},
+	})
+
+	resp := get(t, srv.URL())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, `{"status":"ok"}`, string(body))
+}
+
+func TestNew_CustomHeaders(t *testing.T) {
+	srv := retryserver.New(t, []retryserver.Response{
+		{
+			StatusCode: http.StatusOK,
+			Headers:    map[string]string{"X-Custom": "value123"},
+		},
+	})
+
+	resp := get(t, srv.URL())
+	require.Equal(t, "value123", resp.Header.Get("X-Custom"))
+}
+
+func TestWithFallback(t *testing.T) {
+	srv := retryserver.New(t,
+		[]retryserver.Response{
+			{StatusCode: http.StatusServiceUnavailable},
+		},
+		retryserver.WithFallback(retryserver.Response{StatusCode: http.StatusAccepted}),
+	)
+
+	require.Equal(t, http.StatusServiceUnavailable, get(t, srv.URL()).StatusCode)
+	// Sequence exhausted → custom fallback
+	require.Equal(t, http.StatusAccepted, get(t, srv.URL()).StatusCode)
+	require.Equal(t, http.StatusAccepted, get(t, srv.URL()).StatusCode)
+}
+
+func TestWithRoute_PathSpecificSequence(t *testing.T) {
+	srv := retryserver.New(t, nil,
+		retryserver.WithRoute("/api/logs", []retryserver.Response{
+			{StatusCode: http.StatusTooManyRequests},
+			{StatusCode: http.StatusOK},
+		}),
+	)
+
+	// /api/logs uses the route sequence
+	require.Equal(t, http.StatusTooManyRequests, getPath(t, srv.URL(), "/api/logs").StatusCode)
+	require.Equal(t, http.StatusOK, getPath(t, srv.URL(), "/api/logs").StatusCode)
+	require.Equal(t, 2, srv.RouteRequestCount("/api/logs"))
+
+	// default route (catch-all) is independent
+	require.Equal(t, http.StatusOK, get(t, srv.URL()).StatusCode)
+	require.Equal(t, 1, srv.RequestCount())
+}
+
+func TestWithRoute_MultiplePaths(t *testing.T) {
+	srv := retryserver.New(t, nil,
+		retryserver.WithRoute("/ingest/logs", []retryserver.Response{
+			{StatusCode: http.StatusBadGateway},
+			{StatusCode: http.StatusOK},
+		}),
+		retryserver.WithRoute("/ingest/metrics", []retryserver.Response{
+			{StatusCode: http.StatusGatewayTimeout},
+			{StatusCode: http.StatusOK},
+		}),
+	)
+
+	require.Equal(t, http.StatusBadGateway, getPath(t, srv.URL(), "/ingest/logs").StatusCode)
+	require.Equal(t, http.StatusOK, getPath(t, srv.URL(), "/ingest/logs").StatusCode)
+
+	require.Equal(t, http.StatusGatewayTimeout, getPath(t, srv.URL(), "/ingest/metrics").StatusCode)
+	require.Equal(t, http.StatusOK, getPath(t, srv.URL(), "/ingest/metrics").StatusCode)
+
+	require.Equal(t, 2, srv.RouteRequestCount("/ingest/logs"))
+	require.Equal(t, 2, srv.RouteRequestCount("/ingest/metrics"))
+}
+
+func TestWithRouteFallback(t *testing.T) {
+	srv := retryserver.New(t, nil,
+		retryserver.WithRoute("/api/data",
+			[]retryserver.Response{
+				{StatusCode: http.StatusServiceUnavailable},
+			},
+			retryserver.WithRouteFallback(retryserver.Response{StatusCode: http.StatusCreated}),
+		),
+	)
+
+	require.Equal(t, http.StatusServiceUnavailable, getPath(t, srv.URL(), "/api/data").StatusCode)
+	// Route sequence exhausted → route-specific fallback
+	require.Equal(t, http.StatusCreated, getPath(t, srv.URL(), "/api/data").StatusCode)
+}
+
+func TestReset(t *testing.T) {
+	srv := retryserver.New(t, []retryserver.Response{
+		{StatusCode: http.StatusTooManyRequests},
+		{StatusCode: http.StatusOK},
+	})
+
+	require.Equal(t, http.StatusTooManyRequests, get(t, srv.URL()).StatusCode)
+	require.Equal(t, http.StatusOK, get(t, srv.URL()).StatusCode)
+	require.Equal(t, 2, srv.RequestCount())
+
+	srv.Reset()
+	require.Equal(t, 0, srv.RequestCount())
+
+	// Sequence replays from the beginning after reset
+	require.Equal(t, http.StatusTooManyRequests, get(t, srv.URL()).StatusCode)
+	require.Equal(t, 1, srv.RequestCount())
+}
+
+func TestReset_WithRoutes(t *testing.T) {
+	srv := retryserver.New(t,
+		[]retryserver.Response{{StatusCode: http.StatusBadGateway}},
+		retryserver.WithRoute("/api", []retryserver.Response{
+			{StatusCode: http.StatusServiceUnavailable},
+		}),
+	)
+
+	get(t, srv.URL())
+	getPath(t, srv.URL(), "/api")
+	require.Equal(t, 1, srv.RequestCount())
+	require.Equal(t, 1, srv.RouteRequestCount("/api"))
+
+	srv.Reset()
+	require.Equal(t, 0, srv.RequestCount())
+	require.Equal(t, 0, srv.RouteRequestCount("/api"))
+}
+
+func TestRouteRequestCount_UnknownPath(t *testing.T) {
+	srv := retryserver.New(t, nil)
+	require.Equal(t, 0, srv.RouteRequestCount("/never-registered"))
+}
+
+func TestGatewayErrorScenarios(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"502 Bad Gateway", http.StatusBadGateway},
+		{"503 Service Unavailable", http.StatusServiceUnavailable},
+		{"504 Gateway Timeout", http.StatusGatewayTimeout},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := retryserver.New(t, []retryserver.Response{
+				{StatusCode: tc.statusCode},
+				{StatusCode: tc.statusCode},
+				{StatusCode: http.StatusOK},
+			})
+
+			require.Equal(t, tc.statusCode, get(t, srv.URL()).StatusCode)
+			require.Equal(t, tc.statusCode, get(t, srv.URL()).StatusCode)
+			require.Equal(t, http.StatusOK, get(t, srv.URL()).StatusCode)
+			require.Equal(t, 3, srv.RequestCount())
+		})
+	}
+}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Added wiremock style funcitonality to ensure retry scenario with real world tests

New files (2)                                                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  `internal/testutils/retryserver/server.go`                                                                                                                                                                                                                                                                                                                                                                                                  
  A WireMock-style HTTP mock server for testing retry behavior . Features:
  - New(t, responses, ...opts) — creates a server with a response sequence, auto-cleanup via t.Cleanup                                                                                                                                                                                                                                                                                                                                      
  - Response struct — StatusCode, RetryAfter, Body, Headers                                                                                                                                                                                                                                                                                                                                                                                 
  - WithFallback(r) — override the default response after the sequence is exhausted                                                                                                                                                                                                                                                                                                                                                         
  - WithRoute(path, responses, ...opts) — per-path sequences (for exporters using multiple endpoints like Chronicle)                                                                                                                                                                                                                                                                                                                        
  - WithRouteFallback(r) — per-route fallback
  - RequestCount() / RouteRequestCount(path) — assertion helpers
  - Reset() — replay sequences from scratch in table-driven tests
  - Thread-safe via per-route sync.Mutex

  `internal/testutils/retryserver/server_test.go`
14 tests covering: default fallback, sequence exhaustion, real-world rate limit scenario, Retry-After headers, custom bodies/headers, multi-path routing, Reset(), all gateway error codes.

Reviewed and approved in : https://github.com/observIQ/bindplane-otel-collector/pull/3319

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
