### PR TITLE
fix(receiver/windowseventrace): Fix failed session controller shutdown

### DIFF
--- a/receiver/windowseventtracereceiver/internal/etw/advapi32/api.go
+++ b/receiver/windowseventtracereceiver/internal/etw/advapi32/api.go
@@ -277,8 +277,11 @@ func StopTrace(sessionName string) error {
 		buffer[offset+1] = byte(ch >> 8)
 	}
 
-	_, err = ControlTrace(nil, EVENT_TRACE_CONTROL_STOP, nil, props)
-	return err
+	r1, err := ControlTrace(nil, EVENT_TRACE_CONTROL_STOP, &sessionNamePtr[0], props)
+	if r1 != 0 {
+		return fmt.Errorf("failed to stop trace(%d): %w", r1, err)
+	}
+	return nil
 }
 
 type Event struct {

--- a/receiver/windowseventtracereceiver/internal/etw/session_controller.go
+++ b/receiver/windowseventtracereceiver/internal/etw/session_controller.go
@@ -84,17 +84,8 @@ func (s *SessionController) Start() error {
 		s.logger.Debug("Session already exists, attempting to stop and restart")
 
 		// We need to aggressively close and reopen the session
-		propsCopy := *s.properties
-		r1, err := advapi32.ControlTrace(
-			nil,
-			advapi32.EVENT_TRACE_CONTROL_STOP,
-			namePtrU16,
-			&propsCopy,
-		)
-		if r1 != 0 {
-			s.logger.Warn("Failed to close existing trace, trying to continue anyway",
-				zap.Uint64("error_code", uint64(r1)),
-				zap.Error(err))
+		if err := s.stopTrace(s.name); err != nil {
+			s.logger.Warn("Failed to close existing trace, trying to continue anyway", zap.Error(err))
 		} else {
 			s.logger.Debug("Successfully stopped existing session", zap.String("name", s.name))
 		}
@@ -114,29 +105,14 @@ func (s *SessionController) Start() error {
 	return nil
 }
 
-func (s *SessionController) Stop(ctx context.Context) error {
+func (s *SessionController) Stop(_ context.Context) error {
 	if s.handle == 0 || s.isAttached {
 		s.logger.Debug("Session already stopped or not attached", zap.String("name", s.name), zap.Uintptr("handle", uintptr(s.handle)))
 		return nil
 	}
 
-	var namePtrU16 *uint16
-	var err error
-
-	if namePtrU16, err = syscall.UTF16PtrFromString(s.name); err != nil {
-		return fmt.Errorf("failed to convert session name to UTF-16: %w", err)
-	}
-
-	propsCopy := *s.properties
-	r1, err := advapi32.ControlTrace(
-		&s.handle,
-		advapi32.EVENT_TRACE_CONTROL_STOP,
-		namePtrU16,
-		&propsCopy,
-	)
-
-	if r1 != 0 {
-		return fmt.Errorf("failed to stop trace(%d): %w", r1, err)
+	if err := s.stopTrace(s.name); err != nil {
+		return err
 	}
 
 	s.handle = 0


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Corresponding BDOT PR: https://github.com/observIQ/bindplane-otel-collector/pull/3322

Intermittently during service shutdown, this log was being produced. I found it more consistent when the providers being queried were producing heavy traffic.

```
{"level":"error","ts":"2026-03-11T20:11:01.449Z","caller":"etw/consumer.go:382","msg":"session controller stop failed","resource":{"service.instance.id":"019cde7b-1722-7dcf-aa10-ad6c26d6b4b2","service.name":"C:\\Program Files\\observIQ OpenTelemetry Collector\\observiq-otel-collector.exe","service.version":"v1.95.0"},"otelcol.component.id":"windowseventtrace/s-01KKCTKWVS66PTQZW5GNDXWVRN__logs","otelcol.component.kind":"receiver","otelcol.signal":"logs","error":"failed to stop trace(4201): The instance name passed was not recognized as valid by a WMI data provider.","stacktrace":"github.com/observiq/bindplane-otel-collector/receiver/windowseventtracereceiver/internal/etw.(*Consumer).Stop\n\tD:/a/bindplane-otel-collector/bindplane-otel-collector/receiver/windowseventtracereceiver/internal/etw/consumer.go:382\ngithub.com/observiq/bindplane-otel-collector/receiver/windowseventtracereceiver.(*logsReceiver).initializeSubscriptions.func1\n\tD:/a/bindplane-otel-collector/bindplane-otel-collector/receiver/windowseventtracereceiver/receiver.go:128\ngithub.com/observiq/bindplane-otel-collector/receiver/windowseventtracereceiver.(*logsReceiver).Shutdown\n\tD:/a/bindplane-otel-collector/bindplane-otel-collector/receiver/windowseventtracereceiver/receiver.go:275\ngo.opentelemetry.io/collector/service/internal/graph.(*Graph).ShutdownAll\n\tC:/Users/runneradmin/go/pkg/mod/go.opentelemetry.io/collector/service@v0.147.0/internal/graph/graph.go:478\ngo.opentelemetry.io/collector/service.(*Service).Shutdown\n\tC:/Users/runneradmin/go/pkg/mod/go.opentelemetry.io/collector/service@v0.147.0/service.go:284\ngo.opentelemetry.io/collector/otelcol.(*Collector).shutdown\n\tC:/Users/runneradmin/go/pkg/mod/go.opentelemetry.io/collector/otelcol@v0.147.0/collector.go:405\ngo.opentelemetry.io/collector/otelcol.(*Collector).Run\n\tC:/Users/runneradmin/go/pkg/mod/go.opentelemetry.io/collector/otelcol@v0.147.0/collector.go:391\ngithub.com/observiq/bindplane-otel-collector/collector.(*collector).Run.func1\n\tD:/a/bindplane-otel-collector/bindplane-otel-collector/collector/collector.go:160"}
```

As we can see in receiver/windowseventtracereceiver/internal/etw/advapi32/api.go:StopTrace, simply copying the value of the properties over is insufficient - they must be explicitly copied, and appropriate space in the buffer allocated. The best fix is to simply use StopTrace instead of a nonstandard reimplementation. This additionally fixes a small bug in the previously-uncalled StopTrace API call.

Since reproduction is not consistent, confidence in this fix cannot be 100%, but I've started and stopped the collector 5+ times with this binary and not seen the error log once, which was previously not ever the case with v1.95.0.

Utilized config:
```yaml
receivers:
    windowseventtrace/s-01KKCTKWVS66PTQZW5GNDXWVRN__logs:
        providers:
            - level: verbose
              name: Microsoft-Windows-Kernel-Process
            - level: verbose
              name: Microsoft-Windows-DNS-Client
        raw: false
        require_all_providers: false
        session_buffer_size: 512
        session_name: Bindplane-ETW-Session-Kernel
```

##### Checklist 
- [X] Changes are tested
- [X] CI has passed
