### PR TITLE
fix(receiver/windowseventtrace): Improve parsing of UserData and EventData into OTel structures

### DIFF
--- a/receiver/windowseventtracereceiver/receiver.go
+++ b/receiver/windowseventtracereceiver/receiver.go
@@ -217,7 +217,7 @@ func (lr *logsReceiver) parseEventData(event *etw.Event, record plog.LogRecord) 
 	if len(event.EventData) > 0 {
 		message := record.Body().Map().PutEmptyMap("event_data")
 		for key, data := range event.EventData {
-			message.PutStr(key, fmt.Sprintf("%v", data))
+			putAnyValue(message, key, data)
 		}
 	}
 
@@ -260,7 +260,7 @@ func (lr *logsReceiver) parseEventData(event *etw.Event, record plog.LogRecord) 
 	if len(event.UserData) > 0 {
 		userData := record.Body().Map().PutEmptyMap("user_data")
 		for key, data := range event.UserData {
-			userData.PutStr(key, fmt.Sprintf("%v", data))
+			putAnyValue(userData, key, data)
 		}
 	}
 }
@@ -279,6 +279,49 @@ func (lr *logsReceiver) Shutdown(ctx context.Context) error {
 
 	lr.wg.Wait()
 	return nil
+}
+
+// putAnyValue writes a value of unknown type into a pcommon.Map entry,
+// preserving nested maps and slices as proper OTel attributes rather than
+// flattening them via fmt.Sprintf.
+func putAnyValue(dest pcommon.Map, key string, value any) {
+	switch v := value.(type) {
+	case string:
+		dest.PutStr(key, v)
+	case map[string]any:
+		nested := dest.PutEmptyMap(key)
+		for k, val := range v {
+			putAnyValue(nested, k, val)
+		}
+	case []any:
+		slice := dest.PutEmptySlice(key)
+		for _, item := range v {
+			appendAnyValue(slice, item)
+		}
+	default:
+		dest.PutStr(key, fmt.Sprintf("%v", v))
+	}
+}
+
+// appendAnyValue appends a value of unknown type to a pcommon.Slice,
+// preserving nested maps and slices as proper OTel attributes.
+func appendAnyValue(dest pcommon.Slice, value any) {
+	switch v := value.(type) {
+	case string:
+		dest.AppendEmpty().SetStr(v)
+	case map[string]any:
+		nested := dest.AppendEmpty().SetEmptyMap()
+		for k, val := range v {
+			putAnyValue(nested, k, val)
+		}
+	case []any:
+		nested := dest.AppendEmpty().SetEmptySlice()
+		for _, item := range v {
+			appendAnyValue(nested, item)
+		}
+	default:
+		dest.AppendEmpty().SetStr(fmt.Sprintf("%v", v))
+	}
 }
 
 /*

--- a/receiver/windowseventtracereceiver/receiver_test.go
+++ b/receiver/windowseventtracereceiver/receiver_test.go
@@ -1,0 +1,109 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package windowseventtracereceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestPutAnyValue_String(t *testing.T) {
+	m := pcommon.NewMap()
+	putAnyValue(m, "key", "value")
+	v, ok := m.Get("key")
+	assert.True(t, ok)
+	assert.Equal(t, "value", v.Str())
+}
+
+func TestPutAnyValue_NestedMap(t *testing.T) {
+	m := pcommon.NewMap()
+	putAnyValue(m, "nested", map[string]any{
+		"a": "1",
+		"b": "2",
+	})
+	v, ok := m.Get("nested")
+	assert.True(t, ok)
+	assert.Equal(t, pcommon.ValueTypeMap, v.Type())
+	inner := v.Map()
+	a, ok := inner.Get("a")
+	assert.True(t, ok)
+	assert.Equal(t, "1", a.Str())
+	b, ok := inner.Get("b")
+	assert.True(t, ok)
+	assert.Equal(t, "2", b.Str())
+}
+
+func TestPutAnyValue_Slice(t *testing.T) {
+	m := pcommon.NewMap()
+	putAnyValue(m, "items", []any{"x", "y", "z"})
+	v, ok := m.Get("items")
+	assert.True(t, ok)
+	assert.Equal(t, pcommon.ValueTypeSlice, v.Type())
+	s := v.Slice()
+	assert.Equal(t, 3, s.Len())
+	assert.Equal(t, "x", s.At(0).Str())
+	assert.Equal(t, "y", s.At(1).Str())
+	assert.Equal(t, "z", s.At(2).Str())
+}
+
+func TestPutAnyValue_SliceOfMaps(t *testing.T) {
+	m := pcommon.NewMap()
+	putAnyValue(m, "records", []any{
+		map[string]any{"id": "1", "name": "foo"},
+		map[string]any{"id": "2", "name": "bar"},
+	})
+	v, ok := m.Get("records")
+	assert.True(t, ok)
+	assert.Equal(t, pcommon.ValueTypeSlice, v.Type())
+	s := v.Slice()
+	assert.Equal(t, 2, s.Len())
+
+	first := s.At(0).Map()
+	id, ok := first.Get("id")
+	assert.True(t, ok)
+	assert.Equal(t, "1", id.Str())
+
+	name, ok := first.Get("name")
+	assert.True(t, ok)
+	assert.Equal(t, "foo", name.Str())
+}
+
+func TestPutAnyValue_DeeplyNested(t *testing.T) {
+	m := pcommon.NewMap()
+	putAnyValue(m, "outer", map[string]any{
+		"inner": map[string]any{
+			"leaf": "value",
+		},
+	})
+	v, ok := m.Get("outer")
+	assert.True(t, ok)
+	inner, ok := v.Map().Get("inner")
+	assert.True(t, ok)
+	leaf, ok := inner.Map().Get("leaf")
+	assert.True(t, ok)
+	assert.Equal(t, "value", leaf.Str())
+}
+
+func TestPutAnyValue_UnknownTypeFallback(t *testing.T) {
+	m := pcommon.NewMap()
+	putAnyValue(m, "num", 42)
+	v, ok := m.Get("num")
+	assert.True(t, ok)
+	assert.Equal(t, "42", v.Str())
+}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This PR improves the parsing of Windows Event Trace EventData and UserData. Previously, complex data structures were flattened into a Go %v string - now, they are parsed more thoroughly into an OTel pcommon.Map.

BDOT PR: https://github.com/observIQ/bindplane-otel-collector/pull/3253

##### Checklist
- [x] Changes are tested
- [x] CI has passed