### PR TITLE
feat(`restapireceiver`): Support epoch timestamp formats

### DIFF
--- a/receiver/restapireceiver/README.md
+++ b/receiver/restapireceiver/README.md
@@ -5,6 +5,7 @@ The REST API receiver is a generic receiver that can pull data from any REST API
 ## Supported Pipelines
 
 Alpha:
+
 - Logs
 - Metrics
 
@@ -27,23 +28,23 @@ Alpha:
 
 ## Configuration
 
-| Field | Type | Default | Required | Description |
-|-------|------|---------|----------|-------------|
-| `url` | string | | `true` | The base URL for the REST API endpoint |
-| `response_field` | string | | `false` | The name of the field in the response that contains the array of items. If empty, the response is assumed to be a top-level array. For nested fields, use dot notation (e.g., `response.data`) |
-| `metrics` | object | | `false` | Metrics configuration (see below) |
-| `auth_mode` | string | `none` | `false` | Authentication mode: `none`, `apikey`, `bearer`, `basic`, `oauth2`, or `akamai_edgegrid` |
-| `apikey` | object | | `false` | API Key configuration (see below) |
-| `bearer` | object | | `false` | Bearer Token configuration (see below) |
-| `basic` | object | | `false` | Basic Auth configuration (see below) |
-| `oauth2` | object | | `false` | OAuth2 Client Credentials configuration (see below) |
-| `akamai_edgegrid` | object | | `false` | Akamai EdgeGrid configuration (see below) |
-| `pagination` | object | | `false` | Pagination configuration (see below) |
-| `min_poll_interval` | duration | `10s` | `false` | Minimum interval between API polls. The receiver resets to this interval when data is received. Increase this to prevent hitting API rate limits. |
-| `max_poll_interval` | duration | `5m` | `false` | Maximum interval between API polls. The receiver uses adaptive polling that starts at `min_poll_interval` and backs off when no data is returned, up to this maximum. |
-| `backoff_multiplier` | float | `2.0` | `false` | Multiplier for increasing the poll interval when no data or a partial page is returned. Must be greater than 1.0. |
-| `storage` | component | | `false` | The component ID of a storage extension for checkpointing |
-| `timeout` | duration | `10s` | `false` | HTTP client timeout |
+| Field                | Type      | Default | Required | Description                                                                                                                                                                                    |
+| -------------------- | --------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`                | string    |         | `true`   | The base URL for the REST API endpoint                                                                                                                                                         |
+| `response_field`     | string    |         | `false`  | The name of the field in the response that contains the array of items. If empty, the response is assumed to be a top-level array. For nested fields, use dot notation (e.g., `response.data`) |
+| `metrics`            | object    |         | `false`  | Metrics configuration (see below)                                                                                                                                                              |
+| `auth_mode`          | string    | `none`  | `false`  | Authentication mode: `none`, `apikey`, `bearer`, `basic`, `oauth2`, or `akamai_edgegrid`                                                                                                       |
+| `apikey`             | object    |         | `false`  | API Key configuration (see below)                                                                                                                                                              |
+| `bearer`             | object    |         | `false`  | Bearer Token configuration (see below)                                                                                                                                                         |
+| `basic`              | object    |         | `false`  | Basic Auth configuration (see below)                                                                                                                                                           |
+| `oauth2`             | object    |         | `false`  | OAuth2 Client Credentials configuration (see below)                                                                                                                                            |
+| `akamai_edgegrid`    | object    |         | `false`  | Akamai EdgeGrid configuration (see below)                                                                                                                                                      |
+| `pagination`         | object    |         | `false`  | Pagination configuration (see below)                                                                                                                                                           |
+| `min_poll_interval`  | duration  | `10s`   | `false`  | Minimum interval between API polls. The receiver resets to this interval when data is received. Increase this to prevent hitting API rate limits.                                              |
+| `max_poll_interval`  | duration  | `5m`    | `false`  | Maximum interval between API polls. The receiver uses adaptive polling that starts at `min_poll_interval` and backs off when no data is returned, up to this maximum.                          |
+| `backoff_multiplier` | float     | `2.0`   | `false`  | Multiplier for increasing the poll interval when no data or a partial page is returned. Must be greater than 1.0.                                                                              |
+| `storage`            | component |         | `false`  | The component ID of a storage extension for checkpointing                                                                                                                                      |
+| `timeout`            | duration  | `10s`   | `false`  | HTTP client timeout                                                                                                                                                                            |
 
 ### Auth Mode Configuration
 
@@ -53,105 +54,108 @@ Use `auth_mode: none` for public APIs that don't require authentication. No addi
 
 #### API Key
 
-| Field | Type | Default | Required | Description |
-|-------|------|---------|----------|-------------|
-| `header_name` | string | | `true` | Header name for API key (required if `auth_mode` is `apikey`) |
-| `value` | string | | `true` | API key value (required if `auth_mode` is `apikey`) |
+| Field         | Type   | Default | Required | Description                                                   |
+| ------------- | ------ | ------- | -------- | ------------------------------------------------------------- |
+| `header_name` | string |         | `true`   | Header name for API key (required if `auth_mode` is `apikey`) |
+| `value`       | string |         | `true`   | API key value (required if `auth_mode` is `apikey`)           |
 
 #### Bearer Token
 
-| Field | Type | Default | Required | Description |
-|-------|------|---------|----------|-------------|
-| `token` | string | | `true` | Bearer token value (required if `auth_mode` is `bearer`) |
+| Field   | Type   | Default | Required | Description                                              |
+| ------- | ------ | ------- | -------- | -------------------------------------------------------- |
+| `token` | string |         | `true`   | Bearer token value (required if `auth_mode` is `bearer`) |
 
 #### Basic Auth
 
-| Field | Type | Default | Required | Description |
-|-------|------|---------|----------|-------------|
-| `username` | string | | `true` | Username for basic auth (required if `auth_mode` is `basic`) |
-| `password` | string | | `true` | Password for basic auth |
+| Field      | Type   | Default | Required | Description                                                  |
+| ---------- | ------ | ------- | -------- | ------------------------------------------------------------ |
+| `username` | string |         | `true`   | Username for basic auth (required if `auth_mode` is `basic`) |
+| `password` | string |         | `true`   | Password for basic auth                                      |
 
 #### OAuth2 Client Credentials
 
-| Field | Type | Default | Required | Description |
-|-------|------|---------|----------|-------------|
-| `client_id` | string | | `true` | OAuth2 client ID (required if `auth_mode` is `oauth2`) |
-| `client_secret` | string | | `true` | OAuth2 client secret (required if `auth_mode` is `oauth2`) |
-| `token_url` | string | | `true` | OAuth2 token endpoint URL (required if `auth_mode` is `oauth2`) |
-| `scopes` | []string | | `false` | OAuth2 scopes to request |
-| `endpoint_params` | map[string]string | | `false` | Additional parameters to send to the token endpoint |
+| Field             | Type              | Default | Required | Description                                                     |
+| ----------------- | ----------------- | ------- | -------- | --------------------------------------------------------------- |
+| `client_id`       | string            |         | `true`   | OAuth2 client ID (required if `auth_mode` is `oauth2`)          |
+| `client_secret`   | string            |         | `true`   | OAuth2 client secret (required if `auth_mode` is `oauth2`)      |
+| `token_url`       | string            |         | `true`   | OAuth2 token endpoint URL (required if `auth_mode` is `oauth2`) |
+| `scopes`          | []string          |         | `false`  | OAuth2 scopes to request                                        |
+| `endpoint_params` | map[string]string |         | `false`  | Additional parameters to send to the token endpoint             |
 
 #### Akamai EdgeGrid
 
 **The Akamai API requires an enterprise license. This authentication method has not been tested against an Akamai API.**
 
-| Field | Type | Default | Required | Description |
-|-------|------|---------|----------|-------------|
-| `akamai_access_token` | string || `true` | Akamai EdgeGrid access token |
-| `akamai_client_token` | string || `true` | Akamai EdgeGrid client token |
-| `akamai_client_secret` | string || `true` | Akamai EdgeGrid client secret |
+| Field                  | Type   | Default | Required | Description                   |
+| ---------------------- | ------ | ------- | -------- | ----------------------------- |
+| `akamai_access_token`  | string |         | `true`   | Akamai EdgeGrid access token  |
+| `akamai_client_token`  | string |         | `true`   | Akamai EdgeGrid client token  |
+| `akamai_client_secret` | string |         | `true`   | Akamai EdgeGrid client secret |
 
 ### Pagination Configuration
 
-| Field | Type | Default | Required | Description |
-|-------|------|---------|----------|-------------|
-| `pagination.mode` | string | `none` | `false` | Pagination mode: `none`, `offset_limit`, `page_size`, or `timestamp` |
-| `pagination.total_record_count_field` | string | | `false` | Field name in response containing total record count |
-| `pagination.page_limit` | int | `0` | `false` | Maximum number of pages to fetch (0 = no limit) |
-| `pagination.zero_based_index` | bool | `false` | `false` | Indicates that the requested data starts at index 0 |
+| Field                                 | Type   | Default | Required | Description                                                          |
+| ------------------------------------- | ------ | ------- | -------- | -------------------------------------------------------------------- |
+| `pagination.mode`                     | string | `none`  | `false`  | Pagination mode: `none`, `offset_limit`, `page_size`, or `timestamp` |
+| `pagination.total_record_count_field` | string |         | `false`  | Field name in response containing total record count                 |
+| `pagination.page_limit`               | int    | `0`     | `false`  | Maximum number of pages to fetch (0 = no limit)                      |
+| `pagination.zero_based_index`         | bool   | `false` | `false`  | Indicates that the requested data starts at index 0                  |
 
 #### Offset/Limit Pagination
 
-| Field | Type | Default | Required | Description |
-|-------|------|---------|----------|-------------|
-| `pagination.offset_limit.offset_field_name` | string | | `false` | Query parameter name for offset |
-| `pagination.offset_limit.limit_field_name` | string | | `false` | Query parameter name for limit |
-| `pagination.offset_limit.starting_offset` | int | `0` | `false` | Starting offset value |
+| Field                                       | Type   | Default | Required | Description                     |
+| ------------------------------------------- | ------ | ------- | -------- | ------------------------------- |
+| `pagination.offset_limit.offset_field_name` | string |         | `false`  | Query parameter name for offset |
+| `pagination.offset_limit.limit_field_name`  | string |         | `false`  | Query parameter name for limit  |
+| `pagination.offset_limit.starting_offset`   | int    | `0`     | `false`  | Starting offset value           |
 
 #### Page/Size Pagination
 
-| Field | Type | Default | Required | Description |
-|-------|------|---------|----------|-------------|
-| `pagination.page_size.page_num_field_name` | string | | `false` | Query parameter name for page number |
-| `pagination.page_size.page_size_field_name` | string | | `false` | Query parameter name for page size |
-| `pagination.page_size.starting_page` | int | `1` | `false` | Starting page number |
-| `pagination.page_size.total_pages_field_name` | string | | `false` | Field name in response containing total page count |
+| Field                                         | Type   | Default | Required | Description                                        |
+| --------------------------------------------- | ------ | ------- | -------- | -------------------------------------------------- |
+| `pagination.page_size.page_num_field_name`    | string |         | `false`  | Query parameter name for page number               |
+| `pagination.page_size.page_size_field_name`   | string |         | `false`  | Query parameter name for page size                 |
+| `pagination.page_size.starting_page`          | int    | `1`     | `false`  | Starting page number                               |
+| `pagination.page_size.total_pages_field_name` | string |         | `false`  | Field name in response containing total page count |
 
 #### Timestamp-Based Pagination
 
-| Field | Type | Default | Required | Description |
-|-------|------|---------|----------|-------------|
-| `pagination.timestamp.param_name` | string | | `true` | Query parameter name for timestamp (e.g., "t0", "since", "after", "start_time") |
-| `pagination.timestamp.timestamp_field_name` | string | | `true` | Field name in each response item containing the timestamp (e.g., "ts", "timestamp") |
-| `pagination.timestamp.timestamp_format` | string | RFC3339 | `false` | Format for the timestamp query parameter. Accepts Go time format strings or epoch formats (see below) |
-| `pagination.timestamp.page_size_field_name` | string | | `false` | Query parameter name for page size (e.g., "perPage", "limit") |
-| `pagination.timestamp.page_size` | int | `100` | `false` | Page size to use |
-| `pagination.timestamp.initial_timestamp` | string | | `false` | Initial timestamp to start from. For string formats, use RFC3339 (e.g., `2025-01-01T00:00:00Z`) or the configured `timestamp_format`. For epoch formats, use a numeric value (e.g., `1704067200`). If not set, starts from beginning |
+| Field                                       | Type   | Default | Required | Description                                                                                                                                                                                                                          |
+| ------------------------------------------- | ------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pagination.timestamp.param_name`           | string |         | `true`   | Query parameter name for timestamp (e.g., "t0", "since", "after", "start_time")                                                                                                                                                      |
+| `pagination.timestamp.timestamp_field_name` | string |         | `true`   | Field name in each response item containing the timestamp (e.g., "ts", "timestamp")                                                                                                                                                  |
+| `pagination.timestamp.timestamp_format`     | string | RFC3339 | `false`  | Format for the timestamp query parameter. Accepts Go time format strings or epoch formats (see below)                                                                                                                                |
+| `pagination.timestamp.page_size_field_name` | string |         | `false`  | Query parameter name for page size (e.g., "perPage", "limit")                                                                                                                                                                        |
+| `pagination.timestamp.page_size`            | int    | `100`   | `false`  | Page size to use                                                                                                                                                                                                                     |
+| `pagination.timestamp.initial_timestamp`    | string |         | `false`  | Initial timestamp to start from. For string formats, use RFC3339 (e.g., `2025-01-01T00:00:00Z`) or the configured `timestamp_format`. For epoch formats, use a numeric value (e.g., `1704067200`). If not set, starts from beginning |
 
 Common timestamp formats:
+
 - `2006-01-02T15:04:05Z07:00` - RFC3339 (default)
 - `20060102150405` - YYYYMMDDHHMMSS
 - `2006-01-02 15:04:05` - Date and time with space separator
 - `2006-01-02` - Date only
 
 Epoch timestamp formats (sends numeric values instead of formatted strings):
+
 - `epoch_s` - Unix epoch seconds (e.g., `1704067200`)
 - `epoch_ms` - Unix epoch milliseconds (e.g., `1704067200000`)
 - `epoch_us` - Unix epoch microseconds (e.g., `1704067200000000`)
 - `epoch_ns` - Unix epoch nanoseconds (e.g., `1704067200000000000`)
+- `epoch_s_frac` - Fractional epoch seconds (e.g., `1704067200.123456`). The integer part is seconds and the fractional digits represent sub-second precision (`.123` = milliseconds, `.123456` = microseconds, `.123456789` = nanoseconds). Used by APIs that expect `seconds.fraction` format in both responses and query parameters.
 
 ### Metrics Configuration
 
 The metrics configuration allows you to customize how metrics are extracted from API responses.
 
-| Field | Type | Default | Required | Description |
-|-------|------|---------|----------|-------------|
-| `metrics.name_field` | string | | `true` | Field name in each response item containing the metric name. If not found, the metric will be dropped and a warning will be logged. |
-| `metrics.description_field` | string | | `false` | Field name in each response item containing the metric description. If not specified or not found, defaults to `Metric from REST API` |
-| `metrics.type_field` | string | | `false` | Field name in each response item containing the metric type (`gauge`, `sum`, `histogram`, `summary`). If not specified or not found, defaults to `gauge` |
-| `metrics.unit_field` | string | | `false` | Field name in each response item containing the metric unit. If not specified or not found, no unit is set |
-| `metrics.monotonic_field` | string | | `false` | Field name in each response item indicating if a sum metric is monotonic (boolean). Only applies to `sum` metrics. If not specified or not found, defaults to `false` for safety |
-| `metrics.aggregation_temporality_field` | string | | `false` | Field name in each response item containing the aggregation temporality (`cumulative` or `delta`). If not specified or not found, defaults to `cumulative` |
+| Field                                   | Type   | Default | Required | Description                                                                                                                                                                      |
+| --------------------------------------- | ------ | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `metrics.name_field`                    | string |         | `true`   | Field name in each response item containing the metric name. If not found, the metric will be dropped and a warning will be logged.                                              |
+| `metrics.description_field`             | string |         | `false`  | Field name in each response item containing the metric description. If not specified or not found, defaults to `Metric from REST API`                                            |
+| `metrics.type_field`                    | string |         | `false`  | Field name in each response item containing the metric type (`gauge`, `sum`, `histogram`, `summary`). If not specified or not found, defaults to `gauge`                         |
+| `metrics.unit_field`                    | string |         | `false`  | Field name in each response item containing the metric unit. If not specified or not found, no unit is set                                                                       |
+| `metrics.monotonic_field`               | string |         | `false`  | Field name in each response item indicating if a sum metric is monotonic (boolean). Only applies to `sum` metrics. If not specified or not found, defaults to `false` for safety |
+| `metrics.aggregation_temporality_field` | string |         | `false`  | Field name in each response item containing the aggregation temporality (`cumulative` or `delta`). If not specified or not found, defaults to `cumulative`                       |
 
 **Note:** When field names are configured, those fields are automatically excluded from metric attributes to avoid duplication. If the `name_field` isn't found, the metric will be dropped.
 
@@ -303,7 +307,7 @@ receivers:
       timestamp:
         param_name: "min-date"
         timestamp_field_name: "timestamp"
-        timestamp_format: "20060102150405"  # YYYYMMDDHHMMSS format
+        timestamp_format: "20060102150405" # YYYYMMDDHHMMSS format
         initial_timestamp: "2025-01-01T00:00:00Z"
 ```
 
@@ -325,8 +329,8 @@ receivers:
       timestamp:
         param_name: "since"
         timestamp_field_name: "created_at"
-        timestamp_format: "epoch_s"          # sends ?since=1704067200
-        initial_timestamp: "1704067200"      # 2024-01-01T00:00:00Z
+        timestamp_format: "epoch_s" # sends ?since=1704067200
+        initial_timestamp: "1704067200" # 2024-01-01T00:00:00Z
         page_size_field_name: "limit"
         page_size: 100
     storage: file_storage
@@ -366,6 +370,7 @@ service:
 ```
 
 This configuration would work with an API response like:
+
 ```json
 {
   "metrics": [
@@ -398,19 +403,21 @@ This configuration would work with an API response like:
 The receiver expects JSON responses in one of two formats:
 
 1. **Top-level array:**
+
 ```json
 [
-  {"id": "1", "message": "log entry 1"},
-  {"id": "2", "message": "log entry 2"}
+  { "id": "1", "message": "log entry 1" },
+  { "id": "2", "message": "log entry 2" }
 ]
 ```
 
 2. **Object with data field:**
+
 ```json
 {
   "data": [
-    {"id": "1", "message": "log entry 1"},
-    {"id": "2", "message": "log entry 2"}
+    { "id": "1", "message": "log entry 1" },
+    { "id": "2", "message": "log entry 2" }
   ],
   "total": 2
 }
@@ -435,6 +442,7 @@ To poll at a fixed interval, set `min_poll_interval` and `max_poll_interval` to 
 When a storage extension is configured, the receiver saves its pagination state to storage. This allows the receiver to resume from where it left off after a restart, preventing duplicate data collection.
 
 The checkpoint includes:
+
 - Current pagination state (offset/page number/timestamp)
 - Number of pages fetched
 

--- a/receiver/restapireceiver/README.md
+++ b/receiver/restapireceiver/README.md
@@ -123,16 +123,22 @@ Use `auth_mode: none` for public APIs that don't require authentication. No addi
 |-------|------|---------|----------|-------------|
 | `pagination.timestamp.param_name` | string | | `true` | Query parameter name for timestamp (e.g., "t0", "since", "after", "start_time") |
 | `pagination.timestamp.timestamp_field_name` | string | | `true` | Field name in each response item containing the timestamp (e.g., "ts", "timestamp") |
-| `pagination.timestamp.timestamp_format` | string | RFC3339 | `false` | Go time format string for the timestamp query parameter (e.g., "20060102150405" for YYYYMMDDHHMMSS) |
+| `pagination.timestamp.timestamp_format` | string | RFC3339 | `false` | Format for the timestamp query parameter. Accepts Go time format strings or epoch formats (see below) |
 | `pagination.timestamp.page_size_field_name` | string | | `false` | Query parameter name for page size (e.g., "perPage", "limit") |
 | `pagination.timestamp.page_size` | int | `100` | `false` | Page size to use |
-| `pagination.timestamp.initial_timestamp` | string | | `false` | Initial timestamp to start from (RFC3339 format). If not set, starts from beginning |
+| `pagination.timestamp.initial_timestamp` | string | | `false` | Initial timestamp to start from. For string formats, use RFC3339 (e.g., `2025-01-01T00:00:00Z`) or the configured `timestamp_format`. For epoch formats, use a numeric value (e.g., `1704067200`). If not set, starts from beginning |
 
 Common timestamp formats:
 - `2006-01-02T15:04:05Z07:00` - RFC3339 (default)
 - `20060102150405` - YYYYMMDDHHMMSS
 - `2006-01-02 15:04:05` - Date and time with space separator
 - `2006-01-02` - Date only
+
+Epoch timestamp formats (sends numeric values instead of formatted strings):
+- `epoch_s` - Unix epoch seconds (e.g., `1704067200`)
+- `epoch_ms` - Unix epoch milliseconds (e.g., `1704067200000`)
+- `epoch_us` - Unix epoch microseconds (e.g., `1704067200000000`)
+- `epoch_ns` - Unix epoch nanoseconds (e.g., `1704067200000000000`)
 
 ### Metrics Configuration
 
@@ -300,6 +306,37 @@ receivers:
         timestamp_format: "20060102150405"  # YYYYMMDDHHMMSS format
         initial_timestamp: "2025-01-01T00:00:00Z"
 ```
+
+### Timestamp Pagination with Epoch Format
+
+Some APIs expect timestamps as numeric epoch values (e.g., Unix seconds or milliseconds). Use `epoch_s`, `epoch_ms`, `epoch_us`, or `epoch_ns` as the `timestamp_format`:
+
+```yaml
+receivers:
+  restapi:
+    url: "https://api.example.com/events"
+    response_field: "events"
+    max_poll_interval: 5m
+    auth_mode: bearer
+    bearer:
+      token: "token"
+    pagination:
+      mode: timestamp
+      timestamp:
+        param_name: "since"
+        timestamp_field_name: "created_at"
+        timestamp_format: "epoch_s"          # sends ?since=1704067200
+        initial_timestamp: "1704067200"      # 2024-01-01T00:00:00Z
+        page_size_field_name: "limit"
+        page_size: 100
+    storage: file_storage
+
+extensions:
+  file_storage:
+    directory: /var/lib/otelcol/storage
+```
+
+The receiver can also parse epoch timestamps from API responses (both integer and float values) regardless of the configured `timestamp_format`, so this works with APIs that return numeric timestamps in their response data.
 
 ### Metrics with Custom Field Mappings
 

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -27,11 +27,11 @@ import (
 const (
 	// Epoch timestamp format constants for use in TimestampFormat.
 	// These send the timestamp as a numeric epoch value instead of a formatted string.
-	epochSeconds            = "epoch_s"
-	epochMilliseconds       = "epoch_ms"
-	epochMicroseconds       = "epoch_us"
-	epochNanoseconds        = "epoch_ns"
-	epochSecondsFractional  = "epoch_s_frac"
+	epochSeconds           = "epoch_s"
+	epochMilliseconds      = "epoch_ms"
+	epochMicroseconds      = "epoch_us"
+	epochNanoseconds       = "epoch_ns"
+	epochSecondsFractional = "epoch_s_frac"
 )
 
 // AuthMode defines the authentication mode for the REST API receiver.

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -246,7 +246,6 @@ type TimestampPagination struct {
 
 	// TimestampFieldName is the name of the field in each response item that contains the timestamp value.
 	// This is used to extract the timestamp from the last item for the next page.
-	// For Meraki API, this is typically "ts" (timestamp).
 	TimestampFieldName string `mapstructure:"timestamp_field_name"`
 
 	// TimestampFormat is the format for the timestamp query parameter.

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -17,6 +17,7 @@ package restapireceiver // import "github.com/observiq/bindplane-otel-contrib/re
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -26,10 +27,11 @@ import (
 const (
 	// Epoch timestamp format constants for use in TimestampFormat.
 	// These send the timestamp as a numeric epoch value instead of a formatted string.
-	epochSeconds      = "epoch_s"
-	epochMilliseconds = "epoch_ms"
-	epochMicroseconds = "epoch_us"
-	epochNanoseconds  = "epoch_ns"
+	epochSeconds            = "epoch_s"
+	epochMilliseconds       = "epoch_ms"
+	epochMicroseconds       = "epoch_us"
+	epochNanoseconds        = "epoch_ns"
+	epochSecondsFractional  = "epoch_s_frac"
 )
 
 // AuthMode defines the authentication mode for the REST API receiver.
@@ -370,7 +372,7 @@ func (c *Config) Validate() error {
 			var parsed bool
 			// For epoch formats, validate that initial_timestamp is a numeric value
 			if isEpochFormat(c.Pagination.Timestamp.TimestampFormat) {
-				if _, err := strconv.ParseInt(c.Pagination.Timestamp.InitialTimestamp, 10, 64); err == nil {
+				if _, err := strconv.ParseFloat(c.Pagination.Timestamp.InitialTimestamp, 64); err == nil {
 					parsed = true
 				}
 				if !parsed {
@@ -436,7 +438,7 @@ func (c *Config) Validate() error {
 // isEpochFormat returns true if the given format string is one of the epoch timestamp formats.
 func isEpochFormat(format string) bool {
 	switch format {
-	case epochSeconds, epochMilliseconds, epochMicroseconds, epochNanoseconds:
+	case epochSeconds, epochMilliseconds, epochMicroseconds, epochNanoseconds, epochSecondsFractional:
 		return true
 	}
 	return false
@@ -453,13 +455,47 @@ func formatTimestampEpoch(t time.Time, format string) string {
 		return strconv.FormatInt(t.UnixMicro(), 10)
 	case epochNanoseconds:
 		return strconv.FormatInt(t.UnixNano(), 10)
+	case epochSecondsFractional:
+		nsec := int64(t.Nanosecond())
+		if nsec == 0 {
+			return strconv.FormatInt(t.Unix(), 10)
+		}
+		frac := strings.TrimRight(fmt.Sprintf("%09d", nsec), "0")
+		return fmt.Sprintf("%d.%s", t.Unix(), frac)
 	default:
 		return strconv.FormatInt(t.Unix(), 10)
 	}
 }
 
 // parseEpochTimestamp parses a numeric epoch string into a time.Time based on the epoch format.
+// For epoch_s, epoch_ms, epoch_us, epoch_ns: the value must be an integer in the configured unit.
+// For epoch_s_frac: the value is fractional seconds (e.g., "1704067200.123456") where the integer
+// part is seconds and the fractional digits are sub-second precision.
 func parseEpochTimestamp(value string, format string) (time.Time, error) {
+	// epoch_s_frac: fractional seconds (e.g., "1704067200.123456")
+	if format == epochSecondsFractional {
+		parts := strings.SplitN(value, ".", 2)
+		sec, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("failed to parse epoch timestamp %q: %w", value, err)
+		}
+		var nsec int64
+		if len(parts) == 2 && len(parts[1]) > 0 {
+			fracStr := parts[1]
+			if len(fracStr) < 9 {
+				fracStr += strings.Repeat("0", 9-len(fracStr))
+			} else if len(fracStr) > 9 {
+				fracStr = fracStr[:9]
+			}
+			nsec, err = strconv.ParseInt(fracStr, 10, 64)
+			if err != nil {
+				return time.Time{}, fmt.Errorf("failed to parse fractional epoch timestamp %q: %w", value, err)
+			}
+		}
+		return time.Unix(sec, nsec), nil
+	}
+
+	// All other epoch formats: integer value in the configured unit
 	n, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to parse epoch timestamp %q: %w", value, err)

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -16,10 +16,20 @@ package restapireceiver // import "github.com/observiq/bindplane-otel-contrib/re
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
+)
+
+const (
+	// Epoch timestamp format constants for use in TimestampFormat.
+	// These send the timestamp as a numeric epoch value instead of a formatted string.
+	epochSeconds      = "epoch_s"
+	epochMilliseconds = "epoch_ms"
+	epochMicroseconds = "epoch_us"
+	epochNanoseconds  = "epoch_ns"
 )
 
 // AuthMode defines the authentication mode for the REST API receiver.
@@ -239,11 +249,15 @@ type TimestampPagination struct {
 	// For Meraki API, this is typically "ts" (timestamp).
 	TimestampFieldName string `mapstructure:"timestamp_field_name"`
 
-	// TimestampFormat is the Go time format string for the timestamp query parameter.
+	// TimestampFormat is the format for the timestamp query parameter.
 	// Common formats:
 	//   - "2006-01-02T15:04:05Z07:00" (RFC3339, default)
 	//   - "20060102150405" (YYYYMMDDHHMMSS)
 	//   - "2006-01-02 15:04:05"
+	//   - "epoch_s" (Unix epoch seconds)
+	//   - "epoch_ms" (Unix epoch milliseconds)
+	//   - "epoch_us" (Unix epoch microseconds)
+	//   - "epoch_ns" (Unix epoch nanoseconds)
 	// If not set, defaults to RFC3339.
 	TimestampFormat string `mapstructure:"timestamp_format"`
 
@@ -256,6 +270,7 @@ type TimestampPagination struct {
 	// InitialTimestamp is the initial timestamp to start from (optional).
 	// If not set, will start from the beginning.
 	// Accepts the configured timestamp_format or RFC3339 (e.g., "2025-01-01T00:00:00Z").
+	// For epoch formats, accepts a numeric string (e.g., "1704067200" for epoch_s).
 	InitialTimestamp string `mapstructure:"initial_timestamp"`
 }
 
@@ -354,24 +369,34 @@ func (c *Config) Validate() error {
 		// Validate initial_timestamp format if provided
 		if c.Pagination.Timestamp.InitialTimestamp != "" {
 			var parsed bool
-			// First try the user's configured format (they likely copied the timestamp from the API)
-			if c.Pagination.Timestamp.TimestampFormat != "" {
-				if _, err := time.Parse(c.Pagination.Timestamp.TimestampFormat, c.Pagination.Timestamp.InitialTimestamp); err == nil {
+			// For epoch formats, validate that initial_timestamp is a numeric value
+			if isEpochFormat(c.Pagination.Timestamp.TimestampFormat) {
+				if _, err := strconv.ParseInt(c.Pagination.Timestamp.InitialTimestamp, 10, 64); err == nil {
 					parsed = true
 				}
-			}
-			// Fall back to RFC3339 (the default format)
-			if !parsed {
-				if _, err := time.Parse(time.RFC3339, c.Pagination.Timestamp.InitialTimestamp); err == nil {
-					parsed = true
+				if !parsed {
+					return fmt.Errorf("initial_timestamp %q must be a numeric value when using epoch timestamp_format (%s)", c.Pagination.Timestamp.InitialTimestamp, c.Pagination.Timestamp.TimestampFormat)
 				}
-			}
-			if !parsed {
-				formatHint := "RFC3339 (e.g., 2025-01-01T00:00:00Z)"
+			} else {
+				// First try the user's configured format (they likely copied the timestamp from the API)
 				if c.Pagination.Timestamp.TimestampFormat != "" {
-					formatHint = fmt.Sprintf("configured timestamp_format (%s) or RFC3339", c.Pagination.Timestamp.TimestampFormat)
+					if _, err := time.Parse(c.Pagination.Timestamp.TimestampFormat, c.Pagination.Timestamp.InitialTimestamp); err == nil {
+						parsed = true
+					}
 				}
-				return fmt.Errorf("initial_timestamp %q could not be parsed; must match %s", c.Pagination.Timestamp.InitialTimestamp, formatHint)
+				// Fall back to RFC3339 (the default format)
+				if !parsed {
+					if _, err := time.Parse(time.RFC3339, c.Pagination.Timestamp.InitialTimestamp); err == nil {
+						parsed = true
+					}
+				}
+				if !parsed {
+					formatHint := "RFC3339 (e.g., 2025-01-01T00:00:00Z)"
+					if c.Pagination.Timestamp.TimestampFormat != "" {
+						formatHint = fmt.Sprintf("configured timestamp_format (%s) or RFC3339", c.Pagination.Timestamp.TimestampFormat)
+					}
+					return fmt.Errorf("initial_timestamp %q could not be parsed; must match %s", c.Pagination.Timestamp.InitialTimestamp, formatHint)
+				}
 			}
 		}
 	}
@@ -407,4 +432,49 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// isEpochFormat returns true if the given format string is one of the epoch timestamp formats.
+func isEpochFormat(format string) bool {
+	switch format {
+	case epochSeconds, epochMilliseconds, epochMicroseconds, epochNanoseconds:
+		return true
+	}
+	return false
+}
+
+// formatTimestampEpoch formats a time.Time as an epoch numeric string.
+func formatTimestampEpoch(t time.Time, format string) string {
+	switch format {
+	case epochSeconds:
+		return strconv.FormatInt(t.Unix(), 10)
+	case epochMilliseconds:
+		return strconv.FormatInt(t.UnixMilli(), 10)
+	case epochMicroseconds:
+		return strconv.FormatInt(t.UnixMicro(), 10)
+	case epochNanoseconds:
+		return strconv.FormatInt(t.UnixNano(), 10)
+	default:
+		return strconv.FormatInt(t.Unix(), 10)
+	}
+}
+
+// parseEpochTimestamp parses a numeric epoch string into a time.Time based on the epoch format.
+func parseEpochTimestamp(value string, format string) (time.Time, error) {
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse epoch timestamp %q: %w", value, err)
+	}
+	switch format {
+	case epochSeconds:
+		return time.Unix(n, 0), nil
+	case epochMilliseconds:
+		return time.Unix(0, n*int64(time.Millisecond)), nil
+	case epochMicroseconds:
+		return time.Unix(0, n*int64(time.Microsecond)), nil
+	case epochNanoseconds:
+		return time.Unix(0, n), nil
+	default:
+		return time.Unix(n, 0), nil
+	}
 }

--- a/receiver/restapireceiver/config_test.go
+++ b/receiver/restapireceiver/config_test.go
@@ -645,6 +645,69 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			name: "valid timestamp pagination with epoch_s_frac format (milliseconds)",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeAPIKey,
+				APIKeyConfig: APIKeyConfig{
+					HeaderName: "X-API-Key",
+					Value:      "test-key",
+				},
+				Pagination: PaginationConfig{
+					Mode: paginationModeTimestamp,
+					Timestamp: TimestampPagination{
+						ParamName:          "since",
+						TimestampFieldName: "timestamp",
+						TimestampFormat:    "epoch_s_frac",
+						InitialTimestamp:   "1704067200.123",
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "valid timestamp pagination with epoch_s_frac format (microseconds)",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeAPIKey,
+				APIKeyConfig: APIKeyConfig{
+					HeaderName: "X-API-Key",
+					Value:      "test-key",
+				},
+				Pagination: PaginationConfig{
+					Mode: paginationModeTimestamp,
+					Timestamp: TimestampPagination{
+						ParamName:          "since",
+						TimestampFieldName: "timestamp",
+						TimestampFormat:    "epoch_s_frac",
+						InitialTimestamp:   "1704067200.123456",
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "valid timestamp pagination with epoch_s_frac format (whole seconds)",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeAPIKey,
+				APIKeyConfig: APIKeyConfig{
+					HeaderName: "X-API-Key",
+					Value:      "test-key",
+				},
+				Pagination: PaginationConfig{
+					Mode: paginationModeTimestamp,
+					Timestamp: TimestampPagination{
+						ParamName:          "since",
+						TimestampFieldName: "timestamp",
+						TimestampFormat:    "epoch_s_frac",
+						InitialTimestamp:   "1704067200",
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
 			name: "invalid epoch initial_timestamp (not numeric)",
 			config: &Config{
 				URL:      "https://api.example.com/data",

--- a/receiver/restapireceiver/config_test.go
+++ b/receiver/restapireceiver/config_test.go
@@ -603,6 +603,69 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: `initial_timestamp "invalid-timestamp" could not be parsed`,
 		},
 		{
+			name: "valid timestamp pagination with epoch_s format",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeAPIKey,
+				APIKeyConfig: APIKeyConfig{
+					HeaderName: "X-API-Key",
+					Value:      "test-key",
+				},
+				Pagination: PaginationConfig{
+					Mode: paginationModeTimestamp,
+					Timestamp: TimestampPagination{
+						ParamName:          "since",
+						TimestampFieldName: "timestamp",
+						TimestampFormat:    "epoch_s",
+						InitialTimestamp:   "1704067200",
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "valid timestamp pagination with epoch_ms format",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeAPIKey,
+				APIKeyConfig: APIKeyConfig{
+					HeaderName: "X-API-Key",
+					Value:      "test-key",
+				},
+				Pagination: PaginationConfig{
+					Mode: paginationModeTimestamp,
+					Timestamp: TimestampPagination{
+						ParamName:          "since",
+						TimestampFieldName: "timestamp",
+						TimestampFormat:    "epoch_ms",
+						InitialTimestamp:   "1704067200000",
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "invalid epoch initial_timestamp (not numeric)",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeAPIKey,
+				APIKeyConfig: APIKeyConfig{
+					HeaderName: "X-API-Key",
+					Value:      "test-key",
+				},
+				Pagination: PaginationConfig{
+					Mode: paginationModeTimestamp,
+					Timestamp: TimestampPagination{
+						ParamName:          "since",
+						TimestampFieldName: "timestamp",
+						TimestampFormat:    "epoch_s",
+						InitialTimestamp:   "not-a-number",
+					},
+				},
+			},
+			expectedErr: "initial_timestamp \"not-a-number\" must be a numeric value when using epoch timestamp_format (epoch_s)",
+		},
+		{
 			name: "negative min_poll_interval",
 			config: &Config{
 				URL:      "https://api.example.com/data",

--- a/receiver/restapireceiver/pagination.go
+++ b/receiver/restapireceiver/pagination.go
@@ -71,16 +71,23 @@ func newPaginationState(cfg *Config) *paginationState {
 		// Set initial timestamp if provided, otherwise start from zero time.
 		// Config validation ensures the timestamp is parseable.
 		if cfg.Pagination.Timestamp.InitialTimestamp != "" {
-			// First try the user's configured format (they likely copied the timestamp from the API)
-			if cfg.Pagination.Timestamp.TimestampFormat != "" {
-				if t, err := time.Parse(cfg.Pagination.Timestamp.TimestampFormat, cfg.Pagination.Timestamp.InitialTimestamp); err == nil {
+			if isEpochFormat(cfg.Pagination.Timestamp.TimestampFormat) {
+				// Parse epoch numeric value
+				if t, err := parseEpochTimestamp(cfg.Pagination.Timestamp.InitialTimestamp, cfg.Pagination.Timestamp.TimestampFormat); err == nil {
 					state.CurrentTimestamp = t
 				}
-			}
-			// Fall back to RFC3339 (the default format)
-			if state.CurrentTimestamp.IsZero() {
-				if t, err := time.Parse(time.RFC3339, cfg.Pagination.Timestamp.InitialTimestamp); err == nil {
-					state.CurrentTimestamp = t
+			} else {
+				// First try the user's configured format (they likely copied the timestamp from the API)
+				if cfg.Pagination.Timestamp.TimestampFormat != "" {
+					if t, err := time.Parse(cfg.Pagination.Timestamp.TimestampFormat, cfg.Pagination.Timestamp.InitialTimestamp); err == nil {
+						state.CurrentTimestamp = t
+					}
+				}
+				// Fall back to RFC3339 (the default format)
+				if state.CurrentTimestamp.IsZero() {
+					if t, err := time.Parse(time.RFC3339, cfg.Pagination.Timestamp.InitialTimestamp); err == nil {
+						state.CurrentTimestamp = t
+					}
 				}
 			}
 		}
@@ -136,17 +143,33 @@ func buildPaginationParams(cfg *Config, state *paginationState) url.Values {
 				// 2. timestampFromData is true: The timestamp came from response data (not initial config),
 				//    meaning we've already fetched records up to this timestamp in a previous cycle
 				if state.PagesFetched > 0 || state.TimestampFromData {
-					// Increment by 1 microsecond to ensure we get items strictly after this timestamp.
-					// We use microsecond (not nanosecond) because most timestamp formats only preserve
-					// microsecond precision, so adding 1 nanosecond wouldn't change the formatted value.
-					timestampForRequest = timestampForRequest.Add(time.Microsecond)
+					// Increment by the minimum resolution of the configured format to avoid
+					// re-fetching the same record.
+					switch cfg.Pagination.Timestamp.TimestampFormat {
+					case epochSeconds:
+						timestampForRequest = timestampForRequest.Add(time.Second)
+					case epochMilliseconds:
+						timestampForRequest = timestampForRequest.Add(time.Millisecond)
+					case epochMicroseconds:
+						timestampForRequest = timestampForRequest.Add(time.Microsecond)
+					case epochNanoseconds:
+						timestampForRequest = timestampForRequest.Add(time.Nanosecond)
+					default:
+						// For string formats, increment by 1 microsecond since most formats
+						// preserve microsecond precision at best.
+						timestampForRequest = timestampForRequest.Add(time.Microsecond)
+					}
 				}
 				// Use configured format or default to RFC3339
 				format := cfg.Pagination.Timestamp.TimestampFormat
-				if format == "" {
-					format = time.RFC3339
+				if isEpochFormat(format) {
+					params.Set(cfg.Pagination.Timestamp.ParamName, formatTimestampEpoch(timestampForRequest, format))
+				} else {
+					if format == "" {
+						format = time.RFC3339
+					}
+					params.Set(cfg.Pagination.Timestamp.ParamName, timestampForRequest.Format(format))
 				}
-				params.Set(cfg.Pagination.Timestamp.ParamName, timestampForRequest.Format(format))
 			}
 		}
 

--- a/receiver/restapireceiver/pagination.go
+++ b/receiver/restapireceiver/pagination.go
@@ -154,6 +154,9 @@ func buildPaginationParams(cfg *Config, state *paginationState) url.Values {
 						timestampForRequest = timestampForRequest.Add(time.Microsecond)
 					case epochNanoseconds:
 						timestampForRequest = timestampForRequest.Add(time.Nanosecond)
+					case epochSecondsFractional:
+						// Fractional seconds — increment by 1 microsecond as a reasonable default.
+						timestampForRequest = timestampForRequest.Add(time.Microsecond)
 					default:
 						// For string formats, increment by 1 microsecond since most formats
 						// preserve microsecond precision at best.
@@ -372,10 +375,14 @@ func parseTimestampValue(timestampVal any) time.Time {
 		// Unix timestamp (seconds or milliseconds)
 		if timestampFloat > 1e10 {
 			// Likely milliseconds
-			parsedTime = time.Unix(0, int64(timestampFloat*1e6))
+			ms := int64(timestampFloat)
+			fracNs := int64((timestampFloat - float64(ms)) * 1e6)
+			parsedTime = time.Unix(0, ms*int64(time.Millisecond)+fracNs)
 		} else {
-			// Likely seconds
-			parsedTime = time.Unix(int64(timestampFloat), 0)
+			// Likely seconds (preserve fractional part as nanoseconds)
+			sec := int64(timestampFloat)
+			fracNs := int64((timestampFloat - float64(sec)) * 1e9)
+			parsedTime = time.Unix(sec, fracNs)
 		}
 	} else if timestampInt, ok := timestampVal.(int64); ok {
 		if timestampInt > 1e10 {

--- a/receiver/restapireceiver/pagination_test.go
+++ b/receiver/restapireceiver/pagination_test.go
@@ -17,6 +17,7 @@ package restapireceiver
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -552,6 +553,142 @@ func TestNewPaginationState_PageSize_ZeroBased(t *testing.T) {
 	require.Equal(t, 0, state.CurrentPage)
 	require.Equal(t, 20, state.PageSize) // default
 	require.Equal(t, 0, state.CurrentOffset)
+}
+
+func TestBuildPaginationParams_Timestamp_EpochSeconds(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_s",
+				PageSizeFieldName:  "limit",
+				PageSize:           100,
+			},
+		},
+	}
+
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	state := &paginationState{
+		CurrentTimestamp: ts,
+		PageSize:         100,
+	}
+
+	params := buildPaginationParams(cfg, state)
+	require.Equal(t, "1735689600", params.Get("since"))
+	require.Equal(t, "100", params.Get("limit"))
+}
+
+func TestBuildPaginationParams_Timestamp_EpochMilliseconds(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_ms",
+				PageSizeFieldName:  "limit",
+				PageSize:           50,
+			},
+		},
+	}
+
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	state := &paginationState{
+		CurrentTimestamp: ts,
+		PageSize:         50,
+	}
+
+	params := buildPaginationParams(cfg, state)
+	require.Equal(t, "1735689600000", params.Get("since"))
+	require.Equal(t, "50", params.Get("limit"))
+}
+
+func TestBuildPaginationParams_Timestamp_EpochSeconds_WithOffset(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_s",
+			},
+		},
+	}
+
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	state := &paginationState{
+		CurrentTimestamp:  ts,
+		TimestampFromData: true, // should trigger +1s offset
+	}
+
+	params := buildPaginationParams(cfg, state)
+	// Should be 1 second after the stored timestamp
+	require.Equal(t, "1735689601", params.Get("since"))
+}
+
+func TestBuildPaginationParams_Timestamp_EpochMilliseconds_WithOffset(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_ms",
+			},
+		},
+	}
+
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	state := &paginationState{
+		CurrentTimestamp:  ts,
+		TimestampFromData: true, // should trigger +1ms offset
+	}
+
+	params := buildPaginationParams(cfg, state)
+	// Should be 1 millisecond after the stored timestamp
+	require.Equal(t, "1735689600001", params.Get("since"))
+}
+
+func TestNewPaginationState_Timestamp_EpochSeconds(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_s",
+				InitialTimestamp:   "1735689600",
+				PageSize:           100,
+			},
+		},
+	}
+
+	state := newPaginationState(cfg)
+	expected := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.True(t, expected.Equal(state.CurrentTimestamp), "expected %v, got %v", expected, state.CurrentTimestamp)
+	require.Equal(t, 100, state.PageSize)
+}
+
+func TestNewPaginationState_Timestamp_EpochMilliseconds(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_ms",
+				InitialTimestamp:   "1735689600000",
+				PageSize:           50,
+			},
+		},
+	}
+
+	state := newPaginationState(cfg)
+	expected := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.True(t, expected.Equal(state.CurrentTimestamp), "expected %v, got %v", expected, state.CurrentTimestamp)
+	require.Equal(t, 50, state.PageSize)
 }
 
 func TestParsePaginationResponse_WithDataArray(t *testing.T) {

--- a/receiver/restapireceiver/pagination_test.go
+++ b/receiver/restapireceiver/pagination_test.go
@@ -605,6 +605,56 @@ func TestBuildPaginationParams_Timestamp_EpochMilliseconds(t *testing.T) {
 	require.Equal(t, "50", params.Get("limit"))
 }
 
+func TestBuildPaginationParams_Timestamp_EpochMicroseconds(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_us",
+				PageSizeFieldName:  "limit",
+				PageSize:           100,
+			},
+		},
+	}
+
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	state := &paginationState{
+		CurrentTimestamp: ts,
+		PageSize:         100,
+	}
+
+	params := buildPaginationParams(cfg, state)
+	require.Equal(t, "1735689600000000", params.Get("since"))
+	require.Equal(t, "100", params.Get("limit"))
+}
+
+func TestBuildPaginationParams_Timestamp_EpochNanoseconds(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_ns",
+				PageSizeFieldName:  "limit",
+				PageSize:           100,
+			},
+		},
+	}
+
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	state := &paginationState{
+		CurrentTimestamp: ts,
+		PageSize:         100,
+	}
+
+	params := buildPaginationParams(cfg, state)
+	require.Equal(t, "1735689600000000000", params.Get("since"))
+	require.Equal(t, "100", params.Get("limit"))
+}
+
 func TestBuildPaginationParams_Timestamp_EpochSeconds_WithOffset(t *testing.T) {
 	cfg := &Config{
 		Pagination: PaginationConfig{
@@ -651,6 +701,52 @@ func TestBuildPaginationParams_Timestamp_EpochMilliseconds_WithOffset(t *testing
 	require.Equal(t, "1735689600001", params.Get("since"))
 }
 
+func TestBuildPaginationParams_Timestamp_EpochMicroseconds_WithOffset(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_us",
+			},
+		},
+	}
+
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	state := &paginationState{
+		CurrentTimestamp:  ts,
+		TimestampFromData: true, // should trigger +1us offset
+	}
+
+	params := buildPaginationParams(cfg, state)
+	// Should be 1 microsecond after the stored timestamp
+	require.Equal(t, "1735689600000001", params.Get("since"))
+}
+
+func TestBuildPaginationParams_Timestamp_EpochNanoseconds_WithOffset(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_ns",
+			},
+		},
+	}
+
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	state := &paginationState{
+		CurrentTimestamp:  ts,
+		TimestampFromData: true, // should trigger +1ns offset
+	}
+
+	params := buildPaginationParams(cfg, state)
+	// Should be 1 nanosecond after the stored timestamp
+	require.Equal(t, "1735689600000000001", params.Get("since"))
+}
+
 func TestNewPaginationState_Timestamp_EpochSeconds(t *testing.T) {
 	cfg := &Config{
 		Pagination: PaginationConfig{
@@ -689,6 +785,214 @@ func TestNewPaginationState_Timestamp_EpochMilliseconds(t *testing.T) {
 	expected := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	require.True(t, expected.Equal(state.CurrentTimestamp), "expected %v, got %v", expected, state.CurrentTimestamp)
 	require.Equal(t, 50, state.PageSize)
+}
+
+func TestNewPaginationState_Timestamp_EpochMicroseconds(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_us",
+				InitialTimestamp:   "1735689600000000",
+				PageSize:           100,
+			},
+		},
+	}
+
+	state := newPaginationState(cfg)
+	expected := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.True(t, expected.Equal(state.CurrentTimestamp), "expected %v, got %v", expected, state.CurrentTimestamp)
+	require.Equal(t, 100, state.PageSize)
+}
+
+func TestNewPaginationState_Timestamp_EpochNanoseconds(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_ns",
+				InitialTimestamp:   "1735689600000000000",
+				PageSize:           100,
+			},
+		},
+	}
+
+	state := newPaginationState(cfg)
+	expected := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.True(t, expected.Equal(state.CurrentTimestamp), "expected %v, got %v", expected, state.CurrentTimestamp)
+	require.Equal(t, 100, state.PageSize)
+}
+
+func TestBuildPaginationParams_Timestamp_EpochSecondsFractional(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_s_frac",
+				PageSizeFieldName:  "limit",
+				PageSize:           100,
+			},
+		},
+	}
+
+	// Time with 123ms 456us — formatting should output fractional seconds
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 123456000, time.UTC)
+	state := &paginationState{
+		CurrentTimestamp: ts,
+		PageSize:         100,
+	}
+
+	params := buildPaginationParams(cfg, state)
+	require.Equal(t, "1735689600.123456", params.Get("since"))
+	require.Equal(t, "100", params.Get("limit"))
+}
+
+func TestBuildPaginationParams_Timestamp_EpochSecondsFractional_WholeSeconds(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_s_frac",
+			},
+		},
+	}
+
+	// Whole seconds — no fractional part in output
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	state := &paginationState{
+		CurrentTimestamp: ts,
+		PageSize:         100,
+	}
+
+	params := buildPaginationParams(cfg, state)
+	require.Equal(t, "1735689600", params.Get("since"))
+}
+
+func TestBuildPaginationParams_Timestamp_EpochSecondsFractional_WithOffset(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_s_frac",
+			},
+		},
+	}
+
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 123456000, time.UTC)
+	state := &paginationState{
+		CurrentTimestamp:  ts,
+		TimestampFromData: true, // should trigger +1us offset
+	}
+
+	params := buildPaginationParams(cfg, state)
+	// Should be 1 microsecond after the stored timestamp
+	require.Equal(t, "1735689600.123457", params.Get("since"))
+}
+
+func TestNewPaginationState_Timestamp_EpochSecondsFractional_Ms(t *testing.T) {
+	// "1735689600.123" — millisecond precision fractional seconds
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_s_frac",
+				InitialTimestamp:   "1735689600.123",
+				PageSize:           100,
+			},
+		},
+	}
+
+	state := newPaginationState(cfg)
+	expected := time.Date(2025, 1, 1, 0, 0, 0, 123000000, time.UTC)
+	require.True(t, expected.Equal(state.CurrentTimestamp), "expected %v, got %v", expected, state.CurrentTimestamp)
+	require.Equal(t, 100, state.PageSize)
+}
+
+func TestNewPaginationState_Timestamp_EpochSecondsFractional_Us(t *testing.T) {
+	// "1735689600.123456" — microsecond precision fractional seconds
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_s_frac",
+				InitialTimestamp:   "1735689600.123456",
+				PageSize:           50,
+			},
+		},
+	}
+
+	state := newPaginationState(cfg)
+	expected := time.Date(2025, 1, 1, 0, 0, 0, 123456000, time.UTC)
+	require.True(t, expected.Equal(state.CurrentTimestamp), "expected %v, got %v", expected, state.CurrentTimestamp)
+	require.Equal(t, 50, state.PageSize)
+}
+
+func TestNewPaginationState_Timestamp_EpochSecondsFractional_Ns(t *testing.T) {
+	// "1735689600.123456789" — nanosecond precision fractional seconds
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_s_frac",
+				InitialTimestamp:   "1735689600.123456789",
+				PageSize:           50,
+			},
+		},
+	}
+
+	state := newPaginationState(cfg)
+	expected := time.Date(2025, 1, 1, 0, 0, 0, 123456789, time.UTC)
+	require.True(t, expected.Equal(state.CurrentTimestamp), "expected %v, got %v", expected, state.CurrentTimestamp)
+	require.Equal(t, 50, state.PageSize)
+}
+
+func TestNewPaginationState_Timestamp_EpochSecondsFractional_WholeSeconds(t *testing.T) {
+	// "1735689600" — whole seconds with epoch_s_frac format
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeTimestamp,
+			Timestamp: TimestampPagination{
+				ParamName:          "since",
+				TimestampFieldName: "ts",
+				TimestampFormat:    "epoch_s_frac",
+				InitialTimestamp:   "1735689600",
+				PageSize:           100,
+			},
+		},
+	}
+
+	state := newPaginationState(cfg)
+	expected := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.True(t, expected.Equal(state.CurrentTimestamp), "expected %v, got %v", expected, state.CurrentTimestamp)
+	require.Equal(t, 100, state.PageSize)
+}
+
+func TestParseTimestampValue_FractionalFloat(t *testing.T) {
+	// Float64 seconds with fractional part
+	result := parseTimestampValue(1735689600.123)
+	expected := time.Date(2025, 1, 1, 0, 0, 0, 123000000, time.UTC)
+	require.InDelta(t, expected.UnixNano(), result.UnixNano(), 1000, "expected %v, got %v", expected, result)
+
+	// Float64 milliseconds with fractional part
+	result = parseTimestampValue(1735689600123.456)
+	expected = time.Date(2025, 1, 1, 0, 0, 0, 123456000, time.UTC)
+	require.InDelta(t, expected.UnixNano(), result.UnixNano(), 1000, "expected %v, got %v", expected, result)
 }
 
 func TestParsePaginationResponse_WithDataArray(t *testing.T) {


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Add support for epoch timestamp handling for the REST API receiver.
- Receiver now accepts timestamp formats in epoch format
- Timestamp pagination can now be done with epoch format

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed

Working on creating a mock api to test this out, stay tuned...