### PR TITLE
feat: Add option to Webhook exporter to send single log

### DIFF
--- a/exporter/webhookexporter/README.md
+++ b/exporter/webhookexporter/README.md
@@ -29,7 +29,8 @@ The webhook exporter sends data to a configured HTTP endpoint. Here's how it pro
    - Data is sent to the configured endpoint using the specified HTTP method (POST, PATCH, or PUT)
    - The configured Content-Type header is applied
    - Any additional headers specified in the configuration are included
-   - The request body contains the data in JSON format
+   - When `format` is `json_array` (default), the request body contains all logs as a JSON array
+   - When `format` is `single`, each log record is sent as an individual HTTP request with a single JSON object as the body
 
 4. **Error Handling**:
    - Failed requests are retried according to the sending queue configuration
@@ -45,6 +46,7 @@ The following configuration options are available:
 | endpoint         | string            |         | `true`   | The URL where the webhook requests will be sent. Must start with http:// or https://                                                                                                                                                                |
 | verb             | string            |         | `true`   | The HTTP method to use for the webhook requests. Must be one of: POST, PATCH, PUT                                                                                                                                                                   |
 | content_type     | string            |         | `true`   | The Content-Type header for the webhook requests                                                                                                                                                                                                    |
+| format           | string            | json_array | `true` | The payload format for log data. `json_array` sends all logs as a JSON array in a single request. `single` sends one HTTP request per log record.                                                                                                   |
 | headers          | map[string]string |         | `false`  | Additional HTTP headers to include in the webhook requests                                                                                                                                                                                          |
 | sending_queue    | map               |         | `false`  | Determines how telemetry data is buffered before exporting. See the documentation for the [exporter helper](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.128.0/exporter/exporterhelper/README.md) for more information.        |
 | retry_on_failure | map               |         | `false`  | Determines how the exporter will attempt to retry after a failure. See the documentation for the [exporter helper](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.128.0/exporter/exporterhelper/README.md) for more information. |
@@ -60,6 +62,18 @@ exporters:
     endpoint: https://api.example.com/webhook
     verb: POST
     content_type: application/json
+```
+
+#### Single Log Format
+
+```yaml
+exporters:
+  webhook:
+    logs:
+      endpoint: https://api.example.com/webhook
+      verb: POST
+      content_type: application/json
+      format: single
 ```
 
 #### Sending Queue Configuration

--- a/exporter/webhookexporter/config.go
+++ b/exporter/webhookexporter/config.go
@@ -25,6 +25,28 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
+// PayloadFormat represents the allowed payload formats for the webhook exporter
+type PayloadFormat string
+
+const (
+	// JSONArray sends all logs as a JSON array in a single request
+	JSONArray PayloadFormat = "json_array"
+	// SingleJSON sends one HTTP request per log record
+	SingleJSON PayloadFormat = "single"
+)
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface
+func (f *PayloadFormat) UnmarshalText(text []byte) error {
+	format := PayloadFormat(text)
+	switch format {
+	case JSONArray, SingleJSON:
+		*f = format
+		return nil
+	default:
+		return fmt.Errorf("invalid payload format: %s, must be one of: json_array, single", text)
+	}
+}
+
 // HTTPVerb represents the allowed HTTP methods for the webhook exporter
 type HTTPVerb string
 
@@ -71,6 +93,11 @@ type SignalConfig struct {
 	// ContentType specifies the Content-Type header for the webhook requests
 	// This field is required
 	ContentType string `mapstructure:"content_type"`
+
+	// Format specifies how logs are serialized in the request body.
+	// "json_array" (default) sends all logs as a JSON array in a single request.
+	// "single" sends one HTTP request per log record.
+	Format PayloadFormat `mapstructure:"format"`
 }
 
 // Validate checks if the configuration is valid
@@ -95,6 +122,13 @@ func (c *SignalConfig) Validate() error {
 
 	if err := c.Verb.UnmarshalText([]byte(c.Verb)); err != nil {
 		return fmt.Errorf("invalid verb: %w", err)
+	}
+
+	if c.Format == "" {
+		return fmt.Errorf("format is required")
+	}
+	if err := c.Format.UnmarshalText([]byte(c.Format)); err != nil {
+		return fmt.Errorf("invalid format: %w", err)
 	}
 
 	return nil

--- a/exporter/webhookexporter/config_test.go
+++ b/exporter/webhookexporter/config_test.go
@@ -21,6 +21,50 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 )
 
+func TestPayloadFormat_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    PayloadFormat
+		wantErr bool
+	}{
+		{
+			name:  "valid json_array",
+			input: []byte("json_array"),
+			want:  JSONArray,
+		},
+		{
+			name:  "valid single",
+			input: []byte("single"),
+			want:  SingleJSON,
+		},
+		{
+			name:    "invalid format",
+			input:   []byte("ndjson"),
+			wantErr: true,
+		},
+		{
+			name:    "empty format",
+			input:   []byte(""),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var f PayloadFormat
+			err := f.UnmarshalText(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Empty(t, f)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, f)
+			}
+		})
+	}
+}
+
 func TestHTTPVerb_UnmarshalText(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -90,12 +134,13 @@ func TestConfig_Validate(t *testing.T) {
 					},
 					Verb:        POST,
 					ContentType: "application/json",
+					Format:      JSONArray,
 				},
 			},
 			wantErr: false,
 		},
 		{
-			name: "valid config with all signals",
+			name: "valid config with single format",
 			config: Config{
 				LogsConfig: &SignalConfig{
 					ClientConfig: confighttp.ClientConfig{
@@ -103,6 +148,7 @@ func TestConfig_Validate(t *testing.T) {
 					},
 					Verb:        POST,
 					ContentType: "application/json",
+					Format:      SingleJSON,
 				},
 			},
 			wantErr: false,
@@ -118,6 +164,34 @@ func TestConfig_Validate(t *testing.T) {
 				LogsConfig: &SignalConfig{
 					ClientConfig: confighttp.ClientConfig{
 						Endpoint: "ftp://example.com",
+					},
+					Verb:        POST,
+					ContentType: "application/json",
+					Format:      JSONArray,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid format in logs config",
+			config: Config{
+				LogsConfig: &SignalConfig{
+					ClientConfig: confighttp.ClientConfig{
+						Endpoint: "https://example.com",
+					},
+					Verb:        POST,
+					ContentType: "application/json",
+					Format:      "invalid",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing format in logs config",
+			config: Config{
+				LogsConfig: &SignalConfig{
+					ClientConfig: confighttp.ClientConfig{
+						Endpoint: "https://example.com",
 					},
 					Verb:        POST,
 					ContentType: "application/json",

--- a/exporter/webhookexporter/exporter_logs.go
+++ b/exporter/webhookexporter/exporter_logs.go
@@ -83,8 +83,14 @@ func (le *logsExporter) shutdown(_ context.Context) error {
 func (le *logsExporter) logsDataPusher(ctx context.Context, ld plog.Logs) error {
 	le.logger.Debug("begin webhook logsDataPusher")
 
-	// Extract log bodies and send all logs in one request
-	return le.sendLogs(ctx, extractLogBodies(ld))
+	bodies := extractLogBodies(ld)
+
+	switch le.cfg.Format {
+	case SingleJSON:
+		return le.sendSingleLogs(ctx, bodies)
+	default:
+		return le.sendLogs(ctx, bodies)
+	}
 }
 
 func extractLogBodies(ld plog.Logs) []any {
@@ -122,8 +128,22 @@ func extractLogsFromLogRecords(logRecords plog.LogRecordSlice) []any {
 	return logs
 }
 
+func (le *logsExporter) sendSingleLogs(ctx context.Context, logs []any) error {
+	var errs []error
+	for _, log := range logs {
+		if err := le.sendPayload(ctx, log); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func (le *logsExporter) sendLogs(ctx context.Context, logs []any) error {
-	body, err := json.Marshal(logs)
+	return le.sendPayload(ctx, logs)
+}
+
+func (le *logsExporter) sendPayload(ctx context.Context, payload any) error {
+	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("failed to marshal logs: %w", err)
 	}

--- a/exporter/webhookexporter/exporter_logs_test.go
+++ b/exporter/webhookexporter/exporter_logs_test.go
@@ -58,6 +58,7 @@ func TestNewLogsExporter(t *testing.T) {
 				},
 				Verb:        POST,
 				ContentType: "application/json",
+				Format:      JSONArray,
 			},
 			expectError: false,
 		},
@@ -170,6 +171,7 @@ func TestLogsDataPusher(t *testing.T) {
 				},
 				Verb:        POST,
 				ContentType: "application/json",
+				Format:      JSONArray,
 			}
 
 			exp, err := newLogsExporter(context.Background(), cfg, exportertest.NewNopSettings(component.MustNewType("webhook")))
@@ -226,6 +228,7 @@ func TestSendLogsRetryableVsPermanentErrors(t *testing.T) {
 				ClientConfig: confighttp.ClientConfig{Endpoint: srv.URL()},
 				Verb:         POST,
 				ContentType:  "application/json",
+				Format:       JSONArray,
 			}
 
 			exp, err := newLogsExporter(context.Background(), cfg, exportertest.NewNopSettings(component.MustNewType("webhook")))
@@ -385,6 +388,7 @@ func TestLogsDataPusherIntegration(t *testing.T) {
 				},
 				Verb:        POST,
 				ContentType: "application/json",
+				Format:      JSONArray,
 			}
 
 			exp, err := newLogsExporter(context.Background(), cfg, exportertest.NewNopSettings(component.MustNewType("webhook")))
@@ -416,6 +420,102 @@ func TestLogsDataPusherIntegration(t *testing.T) {
 			require.Equal(t, "test log message 2", jsonArray[1])
 		})
 	}
+}
+
+func TestLogsDataPusherSingleFormat(t *testing.T) {
+	// Track all received request bodies
+	receivedBodies := make(chan []byte, 10)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		receivedBodies <- body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &SignalConfig{
+		ClientConfig: confighttp.ClientConfig{
+			Endpoint: server.URL,
+		},
+		Verb:        POST,
+		ContentType: "application/json",
+		Format:      SingleJSON,
+	}
+
+	exp, err := newLogsExporter(context.Background(), cfg, exportertest.NewNopSettings(component.MustNewType("webhook")))
+	require.NoError(t, err)
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	// Create test logs with 3 records
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	lr1 := scopeLogs.LogRecords().AppendEmpty()
+	lr1.Body().SetStr("first log")
+	lr2 := scopeLogs.LogRecords().AppendEmpty()
+	lr2.Body().SetStr(`{"message": "structured log"}`)
+	lr3 := scopeLogs.LogRecords().AppendEmpty()
+	lr3.Body().SetStr("third log")
+
+	err = exp.logsDataPusher(context.Background(), logs)
+	require.NoError(t, err)
+
+	// Should receive 3 separate requests
+	body1 := <-receivedBodies
+	body2 := <-receivedBodies
+	body3 := <-receivedBodies
+
+	// Each body should be a single JSON value, not an array
+	require.Equal(t, `"first log"`, string(body1))
+	require.Equal(t, `{"message":"structured log"}`, string(body2))
+	require.Equal(t, `"third log"`, string(body3))
+}
+
+func TestLogsDataPusherSingleFormatPartialFailure(t *testing.T) {
+	requestCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount++
+		// Fail the second request with a permanent error
+		if requestCount == 2 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &SignalConfig{
+		ClientConfig: confighttp.ClientConfig{
+			Endpoint: server.URL,
+		},
+		Verb:        POST,
+		ContentType: "application/json",
+		Format:      SingleJSON,
+	}
+
+	exp, err := newLogsExporter(context.Background(), cfg, exportertest.NewNopSettings(component.MustNewType("webhook")))
+	require.NoError(t, err)
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	lr1 := scopeLogs.LogRecords().AppendEmpty()
+	lr1.Body().SetStr("log 1")
+	lr2 := scopeLogs.LogRecords().AppendEmpty()
+	lr2.Body().SetStr("log 2")
+	lr3 := scopeLogs.LogRecords().AppendEmpty()
+	lr3.Body().SetStr("log 3")
+
+	err = exp.logsDataPusher(context.Background(), logs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "400 Bad Request")
+	// All 3 requests should still have been attempted
+	require.Equal(t, 3, requestCount)
 }
 
 func TestExtractLogBodies(t *testing.T) {
@@ -823,6 +923,7 @@ func TestQueueBatchSettings(t *testing.T) {
 				},
 				Verb:             POST,
 				ContentType:      "application/json",
+				Format:           JSONArray,
 				QueueBatchConfig: tc.queueSettings,
 			}
 
@@ -936,6 +1037,7 @@ func TestQueueBatchSettingsWithRetries(t *testing.T) {
 				},
 				Verb:             POST,
 				ContentType:      "application/json",
+				Format:           JSONArray,
 				QueueBatchConfig: tc.queueSettings,
 			}
 

--- a/exporter/webhookexporter/factory.go
+++ b/exporter/webhookexporter/factory.go
@@ -63,6 +63,7 @@ func createDefaultConfig() component.Config {
 			},
 			Verb:             POST,
 			ContentType:      "application/json",
+			Format:           JSONArray,
 			QueueBatchConfig: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
 			BackOffConfig:    configretry.NewDefaultBackOffConfig(),
 		},

--- a/exporter/webhookexporter/factory_test.go
+++ b/exporter/webhookexporter/factory_test.go
@@ -59,6 +59,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 		},
 		Verb:             POST,
 		ContentType:      "application/json",
+		Format:           JSONArray,
 		QueueBatchConfig: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
 		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
 	}, webhookCfg.LogsConfig)
@@ -79,6 +80,7 @@ func TestCreateLogsExporter(t *testing.T) {
 					},
 					Verb:        POST,
 					ContentType: "application/json",
+					Format:      JSONArray,
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
LogicMonitor is unable to handle the JSON array the webhook exporter was sending. This PR adds a new option to send a single log at a time, without the array wrapping it.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
