### PR TITLE
fix(chronicleexporter): correctly report logs dropped metric

### DIFF
--- a/exporter/chronicleexporter/grpc_exporter.go
+++ b/exporter/chronicleexporter/grpc_exporter.go
@@ -216,6 +216,11 @@ func (exp *grpcExporter) uploadToChronicle(ctx context.Context, request *api.Bat
 			exp.telemetry.ExporterRequestCount.Add(ctx, 1,
 				metric.WithAttributeSet(attribute.NewSet(attrErrorUnknown)))
 
+			if exp.metrics != nil {
+				totalLogs := int64(len(request.GetBatch().GetEntries()))
+				exp.metrics.recordDropped(totalLogs)
+			}
+
 			return consumererror.NewPermanent(fmt.Errorf("upload logs to chronicle: %w", err))
 		}
 	}

--- a/exporter/chronicleexporter/hostmetrics.go
+++ b/exporter/chronicleexporter/hostmetrics.go
@@ -219,3 +219,18 @@ func (hmr *hostMetricsReporter) recordSent(count int64) {
 	hmr.agentStats.ExporterStats[0].AcceptedSpans += count
 	hmr.agentStats.LastSuccessfulUploadTime = timestamppb.Now()
 }
+
+func (hmr *hostMetricsReporter) recordDropped(count int64) {
+	hmr.mutex.Lock()
+	defer hmr.mutex.Unlock()
+
+	if len(hmr.agentStats.ExporterStats) == 0 {
+		hmr.agentStats.ExporterStats = []*api.ExporterStats{
+			{
+				Name: hmr.exporterID,
+			},
+		}
+	}
+
+	hmr.agentStats.ExporterStats[0].RefusedSpans += count
+}

--- a/exporter/chronicleexporter/http_exporter.go
+++ b/exporter/chronicleexporter/http_exporter.go
@@ -401,6 +401,12 @@ func (exp *httpExporter) uploadToChronicleHTTP(ctx context.Context, logs *api.Im
 		if exp.cfg.LogErroredPayloads {
 			exp.set.Logger.Warn("Import request rejected", zap.String("logType", logType), zap.String("rejectedRequest", string(data)))
 		}
+		if exp.metrics != nil {
+			if inlineSource := logs.GetInlineSource(); inlineSource != nil {
+				totalLogs := int64(len(inlineSource.GetLogs()))
+				exp.metrics.recordDropped(totalLogs)
+			}
+		}
 		return consumererror.NewPermanent(statusErr)
 	}
 }


### PR DESCRIPTION
### Proposed Change
Currently the Refused Spans metric has always been reported as 0 when reporting metrics to the Chronicle APIs.

This PR:
- Accurately tracks and reports the Logs Dropped (Refused Spans) metric in the chronicle exporter when a permanent error occurs.

Note - This metric will only be imported into GCP when there is a permanent error hitting the chronicle import logs endpoint, but the exporter can still successfully hit the import metrics endpoint. So a completely invalid / incorrect project number, customerID, credentials won't result in this metric getting imported.

The easiest way I found to replicate this is to use credentials that have permission to importStatsEvent but not to importLogs. I have a service account `cole-dropped-logs-testing` configured like this that can be used for testing.

<img width="509" height="703" alt="image" src="https://github.com/user-attachments/assets/923fc182-6ab8-4e59-967d-207829e853b7" />