### PR TITLE
chore(chronicleexporter): change metrics interval to 1 minute

### DIFF
--- a/exporter/chronicleexporter/hostmetrics.go
+++ b/exporter/chronicleexporter/hostmetrics.go
@@ -30,6 +30,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+const metricsInterval = 1 * time.Minute
+
 type hostMetricsReporter struct {
 	set    component.TelemetrySettings
 	cancel context.CancelFunc
@@ -87,7 +89,7 @@ func (hmr *hostMetricsReporter) start() {
 	hmr.wg.Add(1)
 
 	go func() {
-		ticker := time.NewTicker(5 * time.Minute)
+		ticker := time.NewTicker(metricsInterval)
 
 		defer func() {
 			hmr.wg.Done()


### PR DESCRIPTION
### Proposed Change
The Chronicle Exporter metrics sending interval was previously set to send metrics every 5 minutes.

This PR changes the interval to 1 minute in order to prevent confusion when viewing metrics from the GCP Metrics Explorer with the default interval. Read more here: https://github.com/observIQ/bindplane-otel-contrib/pull/58#pullrequestreview-3975259668

Note - Customers who had previously configured a GCP dashboard with a min interval of 5 minutes to correctly view the Accepted Spans metric will need to update their dashboards to a min interval of 1 minute.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed