### PR TITLE
fix(extension/opampgateway): Failure to send messages downstream should not break upstream connections

### DIFF
--- a/extension/opampgateway/internal/gateway/gateway.go
+++ b/extension/opampgateway/internal/gateway/gateway.go
@@ -70,9 +70,21 @@ func New(logger *zap.Logger, settings Settings, t *metadata.TelemetryBuilder) *G
 		telemetry: t,
 	}
 	g.client = newClient(settings, g.telemetry, ConnectionCallbacks[*upstreamConnection]{
-		OnMessage: g.HandleUpstreamMessage,
-		OnError:   g.HandleUpstreamError,
-		OnClose:   g.HandleUpstreamClose,
+		OnMessage: func(ctx context.Context, conn *upstreamConnection, messageType int, msg *message) error {
+			// The upstream connection is shared by many agents. Per-message
+			// errors are logged and swallowed so that a single bad message
+			// cannot tear down the connection and disconnect every agent.
+			if err := g.HandleUpstreamMessage(ctx, conn, messageType, msg); err != nil {
+				g.logger.Warn("upstream message handling failed",
+					zap.Error(err),
+					zap.String("upstream_connection_id", conn.id),
+					zap.Int("message_number", msg.number),
+				)
+			}
+			return nil
+		},
+		OnError: g.HandleUpstreamError,
+		OnClose: g.HandleUpstreamClose,
 	}, logger)
 	g.server = newServer(settings.OpAMPServer, settings.AuthTimeout, g.telemetry, g.client, ConnectionCallbacks[*downstreamConnection]{
 		OnMessage: g.HandleDownstreamMessage,
@@ -151,13 +163,13 @@ func (g *Gateway) HandleDownstreamClose(_ context.Context, connection *downstrea
 // --------------------------------------------------------------------------------------
 // Upstream callbacks
 
-// HandleUpstreamMessage handles message sent from the upstream connection to a downstream connection.
+// HandleUpstreamMessage handles a message sent from the upstream connection to
+// a downstream connection. Errors are non-fatal — the caller is responsible
+// for logging and discarding them to protect the shared upstream connection.
 func (g *Gateway) HandleUpstreamMessage(_ context.Context, connection *upstreamConnection, messageType int, message *message) error {
 	g.logger.Debug("HandleUpstreamMessage", zap.String("upstream_connection_id", connection.id), zap.Int("message_number", message.number), zap.Int("message_type", messageType), zap.String("message_bytes", string(message.data)))
 	if messageType != websocket.BinaryMessage {
-		err := fmt.Errorf("unexpected message type: %v, must be binary message", messageType)
-		g.logger.Error("Cannot process a message from WebSocket", zap.Error(err), zap.Int("message_number", message.number), zap.Int("message_type", messageType), zap.String("message_bytes", string(message.data)))
-		return err
+		return fmt.Errorf("unexpected message type: %v, must be binary message", messageType)
 	}
 
 	m := protobufs.ServerToAgent{}
@@ -182,7 +194,8 @@ func (g *Gateway) HandleUpstreamMessage(_ context.Context, connection *upstreamC
 
 	agentID, err := parseAgentID(m.GetInstanceUid())
 	if err != nil {
-		return fmt.Errorf("parse agent id: %w, %s", err, m.String())
+		return fmt.Errorf("invalid instance_uid (length=%d, fields=%v): %w",
+			len(m.GetInstanceUid()), serverToAgentFields(&m), err)
 	}
 
 	// find the downstream connection from the server
@@ -213,12 +226,12 @@ func (g *Gateway) HandleUpstreamMessage(_ context.Context, connection *upstreamC
 	// forward the message to the downstream connection
 	msg := fmt.Sprintf("%s <= %s", conn.id, connection.id)
 	logDownstreamMessage(g.logger, msg, agentID, message.number, len(message.data), &m)
-	err = conn.send(message)
-	if err == nil {
-		g.telemetry.OpampgatewayMessages.Add(context.Background(), 1, directionDownstream)
-		g.telemetry.OpampgatewayMessagesBytes.Add(context.Background(), int64(len(message.data)), directionDownstream)
+	if err := conn.send(message); err != nil {
+		return fmt.Errorf("send to downstream agent %s (%s): %w", agentID, conn.id, err)
 	}
-	return err
+	g.telemetry.OpampgatewayMessages.Add(context.Background(), 1, directionDownstream)
+	g.telemetry.OpampgatewayMessagesBytes.Add(context.Background(), int64(len(message.data)), directionDownstream)
+	return nil
 }
 
 // HandleUpstreamError handles an error from an upstream connection.
@@ -257,6 +270,31 @@ func logUpstreamMessage(logger *zap.Logger, msg string, agentID string, messageN
 		zap.Uint64("sequenceNum", message.SequenceNum),
 		zap.Uint64("flags", message.Flags),
 	)
+}
+
+// serverToAgentFields returns the names of all top-level fields that are set
+// on the message. This is used for diagnostic logging so operators can identify
+// what the server sent without leaking message contents.
+func serverToAgentFields(m *protobufs.ServerToAgent) []string {
+	var fields []string
+	if len(m.GetInstanceUid()) > 0 {
+		fields = append(fields, "instance_uid")
+	}
+	fields = append(fields, includeComponent(nil, m.GetErrorResponse(), "error_response")...)
+	fields = append(fields, includeComponent(nil, m.GetRemoteConfig(), "remote_config")...)
+	fields = append(fields, includeComponent(nil, m.GetConnectionSettings(), "connection_settings")...)
+	fields = append(fields, includeComponent(nil, m.GetPackagesAvailable(), "packages_available")...)
+	fields = append(fields, includeComponent(nil, m.GetAgentIdentification(), "agent_identification")...)
+	fields = append(fields, includeComponent(nil, m.GetCommand(), "command")...)
+	fields = append(fields, includeComponent(nil, m.GetCustomCapabilities(), "custom_capabilities")...)
+	fields = append(fields, includeComponent(nil, m.GetCustomMessage(), "custom_message")...)
+	if m.GetFlags() != 0 {
+		fields = append(fields, "flags")
+	}
+	if m.GetCapabilities() != 0 {
+		fields = append(fields, "capabilities")
+	}
+	return fields
 }
 
 func downstreamMessageComponents(serverToAgent *protobufs.ServerToAgent) []string {

--- a/extension/opampgateway/internal/gateway/gateway_test.go
+++ b/extension/opampgateway/internal/gateway/gateway_test.go
@@ -964,6 +964,108 @@ func TestGatewayUpstreamReconnection(t *testing.T) {
 	require.Equal(t, uint64(99), resp.GetCapabilities())
 }
 
+func TestGatewayDownstreamSendFailureDoesNotKillUpstream(t *testing.T) {
+	t.Parallel()
+
+	h := newGatewayTestHarness(t, 1)
+
+	agent1 := h.NewAgent(t)
+	agent2 := h.NewAgent(t)
+
+	// Register both agents by sending an initial message each.
+	agent1.Send(&protobufs.AgentToServer{SequenceNum: 1})
+	agent2.Send(&protobufs.AgentToServer{SequenceNum: 2})
+	h.upstream.WaitForAgentMessage(t, agent1.ID(), 5*time.Second)
+	h.upstream.WaitForAgentMessage(t, agent2.ID(), 5*time.Second)
+
+	// Close agent1's downstream connection and wait for cleanup so that
+	// send() returns "downstream connection closed" immediately.
+	conn1, ok := h.gateway.server.getAgentConnection(agent1.ID())
+	require.True(t, ok, "agent1 downstream connection must be registered")
+	require.NoError(t, conn1.close())
+	require.Eventually(t, func() bool {
+		select {
+		case <-conn1.writerDone:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 10*time.Millisecond, "downstream writer did not stop")
+
+	// Re-register agent1 so the gateway still has a mapping for it,
+	// even though the connection's writer is dead and send() will fail.
+	h.gateway.server.setAgentConnection(agent1.ID(), conn1)
+
+	// Send a message addressed to the dead agent1. The gateway should
+	// log a warning but NOT tear down the upstream connection.
+	require.NoError(t, h.upstream.Send(&protobufs.ServerToAgent{
+		InstanceUid:  agent1.RawID(),
+		Capabilities: 11,
+	}))
+
+	// Verify the upstream is still alive by sending to agent2 successfully.
+	require.NoError(t, h.upstream.Send(&protobufs.ServerToAgent{
+		InstanceUid:  agent2.RawID(),
+		Capabilities: 22,
+	}))
+	resp := agent2.WaitForMessage(t, 5*time.Second)
+	require.Equal(t, uint64(22), resp.GetCapabilities())
+}
+
+func TestGatewayInvalidInstanceUidDoesNotKillUpstream(t *testing.T) {
+	t.Parallel()
+
+	h := newGatewayTestHarness(t, 1)
+
+	// Connect an agent and verify the round-trip works.
+	agent := h.NewAgent(t)
+	agent.Send(&protobufs.AgentToServer{SequenceNum: 1})
+	h.upstream.WaitForAgentMessage(t, agent.ID(), 5*time.Second)
+
+	// Send a ServerToAgent message with an empty InstanceUid (0 bytes).
+	// This simulates the server sending an AgentIdentification reassignment
+	// without a routable InstanceUid. Previously this killed the upstream
+	// connection; now the gateway should drop the message and keep going.
+	require.NoError(t, h.upstream.Send(&protobufs.ServerToAgent{
+		AgentIdentification: &protobufs.AgentIdentification{
+			NewInstanceUid: uuid.New().NodeID(),
+		},
+	}))
+
+	// After the bad message, the upstream connection should still be alive.
+	// Verify by sending a valid message and getting a response.
+	require.NoError(t, h.upstream.Send(&protobufs.ServerToAgent{
+		InstanceUid:  agent.RawID(),
+		Capabilities: 77,
+	}))
+	resp := agent.WaitForMessage(t, 5*time.Second)
+	require.Equal(t, uint64(77), resp.GetCapabilities())
+}
+
+func TestGatewayInvalidInstanceUidWrongLength(t *testing.T) {
+	t.Parallel()
+
+	h := newGatewayTestHarness(t, 1)
+
+	agent := h.NewAgent(t)
+	agent.Send(&protobufs.AgentToServer{SequenceNum: 1})
+	h.upstream.WaitForAgentMessage(t, agent.ID(), 5*time.Second)
+
+	// Send a ServerToAgent with an InstanceUid of invalid length (not 16 or 26 bytes).
+	require.NoError(t, h.upstream.Send(&protobufs.ServerToAgent{
+		InstanceUid:  []byte("short"),
+		Capabilities: 99,
+	}))
+
+	// The upstream connection should survive. Verify with a valid round-trip.
+	require.NoError(t, h.upstream.Send(&protobufs.ServerToAgent{
+		InstanceUid:  agent.RawID(),
+		Capabilities: 88,
+	}))
+	resp := agent.WaitForMessage(t, 5*time.Second)
+	require.Equal(t, uint64(88), resp.GetCapabilities())
+}
+
 func TestGatewayTLSConnection(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Proposed Change

Errors in the gateway HandleUpstreamMessage should not be propagated. Instead log using a WARN.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed