### PR TITLE
feat: Use configopaque for REST API auth values

### DIFF
--- a/receiver/restapireceiver/client.go
+++ b/receiver/restapireceiver/client.go
@@ -297,7 +297,7 @@ func (c *defaultRESTAPIClient) generateEdgeGridAuth(req *http.Request) (string, 
 	}, "\t")
 
 	// Create signing key from client secret and timestamp
-	signingKey := makeSigningKey(timestamp, c.cfg.AkamaiEdgeGridConfig.ClientSecret)
+	signingKey := makeSigningKey(timestamp, string(c.cfg.AkamaiEdgeGridConfig.ClientSecret))
 
 	// Create the signature
 	signature := makeSignature(signingData, signingKey)
@@ -305,8 +305,8 @@ func (c *defaultRESTAPIClient) generateEdgeGridAuth(req *http.Request) (string, 
 	// Construct the authorization header
 	authHeader := fmt.Sprintf(
 		"EG1-HMAC-SHA256 client_token=%s;access_token=%s;timestamp=%s;nonce=%s;signature=%s",
-		c.cfg.AkamaiEdgeGridConfig.ClientToken,
-		c.cfg.AkamaiEdgeGridConfig.AccessToken,
+		string(c.cfg.AkamaiEdgeGridConfig.ClientToken),
+		string(c.cfg.AkamaiEdgeGridConfig.AccessToken),
 		timestamp,
 		nonce,
 		signature,
@@ -343,7 +343,7 @@ func makeSignature(data, key string) string {
 func (c *defaultRESTAPIClient) createOAuth2TokenSource(ctx context.Context) (oauth2.TokenSource, error) {
 	oauthConfig := clientcredentials.Config{
 		ClientID:       c.cfg.OAuth2Config.ClientID,
-		ClientSecret:   c.cfg.OAuth2Config.ClientSecret,
+		ClientSecret:   string(c.cfg.OAuth2Config.ClientSecret),
 		TokenURL:       c.cfg.OAuth2Config.TokenURL,
 		Scopes:         c.cfg.OAuth2Config.Scopes,
 		EndpointParams: url.Values{},
@@ -370,26 +370,26 @@ func (c *defaultRESTAPIClient) applyAuth(req *http.Request) error {
 
 	case authModeAPIKey:
 		// API key authentication
-		if c.cfg.APIKeyConfig.HeaderName == "" || c.cfg.APIKeyConfig.Value == "" {
+		if c.cfg.APIKeyConfig.HeaderName == "" || string(c.cfg.APIKeyConfig.Value) == "" {
 			return fmt.Errorf("API key header name and value are required")
 		}
-		req.Header.Set(c.cfg.APIKeyConfig.HeaderName, c.cfg.APIKeyConfig.Value)
+		req.Header.Set(c.cfg.APIKeyConfig.HeaderName, string(c.cfg.APIKeyConfig.Value))
 		return nil
 
 	case authModeBearer:
 		// Bearer token authentication
-		if c.cfg.BearerConfig.Token == "" {
+		if string(c.cfg.BearerConfig.Token) == "" {
 			return fmt.Errorf("bearer token is required")
 		}
-		req.Header.Set("Authorization", "Bearer "+c.cfg.BearerConfig.Token)
+		req.Header.Set("Authorization", "Bearer "+string(c.cfg.BearerConfig.Token))
 		return nil
 
 	case authModeBasic:
 		// Basic authentication
-		if c.cfg.BasicConfig.Username == "" || c.cfg.BasicConfig.Password == "" {
+		if c.cfg.BasicConfig.Username == "" || string(c.cfg.BasicConfig.Password) == "" {
 			return fmt.Errorf("basic auth username and password are required")
 		}
-		req.SetBasicAuth(c.cfg.BasicConfig.Username, c.cfg.BasicConfig.Password)
+		req.SetBasicAuth(c.cfg.BasicConfig.Username, string(c.cfg.BasicConfig.Password))
 		return nil
 
 	case authModeOAuth2:
@@ -406,7 +406,7 @@ func (c *defaultRESTAPIClient) applyAuth(req *http.Request) error {
 
 	case authModeAkamaiEdgeGrid:
 		// Akamai EdgeGrid authentication
-		if c.cfg.AkamaiEdgeGridConfig.AccessToken == "" || c.cfg.AkamaiEdgeGridConfig.ClientToken == "" || c.cfg.AkamaiEdgeGridConfig.ClientSecret == "" {
+		if string(c.cfg.AkamaiEdgeGridConfig.AccessToken) == "" || string(c.cfg.AkamaiEdgeGridConfig.ClientToken) == "" || string(c.cfg.AkamaiEdgeGridConfig.ClientSecret) == "" {
 			return fmt.Errorf("akamai edgegrid access token, client token, and client secret are required")
 		}
 		authHeader, err := c.generateEdgeGridAuth(req)

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -160,8 +160,8 @@ type MetricsConfig struct {
 
 // APIKeyConfig defines API key authentication configuration.
 type APIKeyConfig struct {
-	HeaderName string                `mapstructure:"header_name"`
-	Value      configopaque.String   `mapstructure:"value"`
+	HeaderName string              `mapstructure:"header_name"`
+	Value      configopaque.String `mapstructure:"value"`
 }
 
 // BearerConfig defines bearer token authentication configuration.
@@ -171,7 +171,7 @@ type BearerConfig struct {
 
 // BasicConfig defines basic authentication configuration.
 type BasicConfig struct {
-	Username string             `mapstructure:"username"`
+	Username string              `mapstructure:"username"`
 	Password configopaque.String `mapstructure:"password"`
 }
 

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -22,6 +22,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
 const (
@@ -159,35 +160,35 @@ type MetricsConfig struct {
 
 // APIKeyConfig defines API key authentication configuration.
 type APIKeyConfig struct {
-	HeaderName string `mapstructure:"header_name"`
-	Value      string `mapstructure:"value"`
+	HeaderName string                `mapstructure:"header_name"`
+	Value      configopaque.String   `mapstructure:"value"`
 }
 
 // BearerConfig defines bearer token authentication configuration.
 type BearerConfig struct {
-	Token string `mapstructure:"token"`
+	Token configopaque.String `mapstructure:"token"`
 }
 
 // BasicConfig defines basic authentication configuration.
 type BasicConfig struct {
-	Username string `mapstructure:"username"`
-	Password string `mapstructure:"password"`
+	Username string             `mapstructure:"username"`
+	Password configopaque.String `mapstructure:"password"`
 }
 
 // OAuth2Config defines OAuth2 client credentials authentication configuration.
 type OAuth2Config struct {
-	ClientID       string            `mapstructure:"client_id"`
-	ClientSecret   string            `mapstructure:"client_secret"`
-	TokenURL       string            `mapstructure:"token_url"`
-	Scopes         []string          `mapstructure:"scopes"`
-	EndpointParams map[string]string `mapstructure:"endpoint_params"`
+	ClientID       string              `mapstructure:"client_id"`
+	ClientSecret   configopaque.String `mapstructure:"client_secret"`
+	TokenURL       string              `mapstructure:"token_url"`
+	Scopes         []string            `mapstructure:"scopes"`
+	EndpointParams map[string]string   `mapstructure:"endpoint_params"`
 }
 
 // AkamaiEdgeGridConfig defines Akamai EdgeGrid authentication configuration.
 type AkamaiEdgeGridConfig struct {
-	AccessToken  string `mapstructure:"access_token"`
-	ClientToken  string `mapstructure:"client_token"`
-	ClientSecret string `mapstructure:"client_secret"`
+	AccessToken  configopaque.String `mapstructure:"access_token"`
+	ClientToken  configopaque.String `mapstructure:"client_token"`
+	ClientSecret configopaque.String `mapstructure:"client_secret"`
 }
 
 // PaginationConfig defines pagination configuration.
@@ -304,38 +305,38 @@ func (c *Config) Validate() error {
 		if c.APIKeyConfig.HeaderName == "" {
 			return fmt.Errorf("header_name is required when auth_mode is apikey")
 		}
-		if c.APIKeyConfig.Value == "" {
+		if string(c.APIKeyConfig.Value) == "" {
 			return fmt.Errorf("value is required when auth_mode is apikey")
 		}
 	case authModeBearer:
-		if c.BearerConfig.Token == "" {
+		if string(c.BearerConfig.Token) == "" {
 			return fmt.Errorf("token is required when auth_mode is bearer")
 		}
 	case authModeBasic:
 		if c.BasicConfig.Username == "" {
 			return fmt.Errorf("username is required when auth_mode is basic")
 		}
-		if c.BasicConfig.Password == "" {
+		if string(c.BasicConfig.Password) == "" {
 			return fmt.Errorf("password is required when auth_mode is basic")
 		}
 	case authModeOAuth2:
 		if c.OAuth2Config.ClientID == "" {
 			return fmt.Errorf("client_id is required when auth_mode is oauth2")
 		}
-		if c.OAuth2Config.ClientSecret == "" {
+		if string(c.OAuth2Config.ClientSecret) == "" {
 			return fmt.Errorf("client_secret is required when auth_mode is oauth2")
 		}
 		if c.OAuth2Config.TokenURL == "" {
 			return fmt.Errorf("token_url is required when auth_mode is oauth2")
 		}
 	case authModeAkamaiEdgeGrid:
-		if c.AkamaiEdgeGridConfig.AccessToken == "" {
+		if string(c.AkamaiEdgeGridConfig.AccessToken) == "" {
 			return fmt.Errorf("access_token is required when auth_mode is akamai_edgegrid")
 		}
-		if c.AkamaiEdgeGridConfig.ClientToken == "" {
+		if string(c.AkamaiEdgeGridConfig.ClientToken) == "" {
 			return fmt.Errorf("client_token is required when auth_mode is akamai_edgegrid")
 		}
-		if c.AkamaiEdgeGridConfig.ClientSecret == "" {
+		if string(c.AkamaiEdgeGridConfig.ClientSecret) == "" {
 			return fmt.Errorf("client_secret is required when auth_mode is akamai_edgegrid")
 		}
 	}

--- a/receiver/restapireceiver/config_test.go
+++ b/receiver/restapireceiver/config_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 
@@ -851,6 +852,6 @@ func TestLoadConfigFromYAML(t *testing.T) {
 	require.Equal(t, 10*time.Second, restapiCfg.MinPollInterval)
 	require.Equal(t, 5*time.Minute, restapiCfg.MaxPollInterval)
 	require.Equal(t, authModeAPIKey, restapiCfg.AuthMode)
-	require.Equal(t, "test-key", restapiCfg.APIKeyConfig.Value)
+	require.Equal(t, configopaque.String("test-key"), restapiCfg.APIKeyConfig.Value)
 	require.Equal(t, "X-API-Key", restapiCfg.APIKeyConfig.HeaderName)
 }

--- a/receiver/restapireceiver/go.mod
+++ b/receiver/restapireceiver/go.mod
@@ -9,6 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v1.53.0
 	go.opentelemetry.io/collector/component/componenttest v0.147.0
 	go.opentelemetry.io/collector/config/confighttp v0.147.0
+	go.opentelemetry.io/collector/config/configopaque v1.53.0
 	go.opentelemetry.io/collector/confmap v1.53.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.147.0
 	go.opentelemetry.io/collector/consumer v1.53.0
@@ -62,7 +63,6 @@ require (
 	go.opentelemetry.io/collector/config/configcompression v1.53.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v1.53.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.53.0 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.53.0 // indirect
 	go.opentelemetry.io/collector/config/configoptional v1.53.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.53.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.147.0 // indirect


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Updates the rest api receiver auth values to be `configopaque.String` instead of strings.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed