### PR TITLE
fix: Add profiles to ocsf body and update test builder to contrib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ gha-creds-*.json
 
 # Don't ignore the mdatagen generated config files
 !**/internal/metadata/testdata/config.yaml
+
+# Oh my claude code
+.omc

--- a/processor/ocsfstandardizationprocessor/processor.go
+++ b/processor/ocsfstandardizationprocessor/processor.go
@@ -34,6 +34,7 @@ type compiledEventMapping struct {
 	filter        *expr.Expression
 	classID       int
 	profiles      []string
+	profilesAny   []any // for serialization to the log body
 	fieldMappings []compiledFieldMapping
 	categoryUID   int
 }
@@ -69,9 +70,19 @@ func newOCSFStandardizationProcessor(logger *zap.Logger, config *Config) (*ocsfS
 			fieldMappings = append(fieldMappings, cfm)
 		}
 
+		// We need the profiles as a []any for serialization to the log body
+		var profilesAny []any
+		if len(eventMapping.Profiles) > 0 {
+			profilesAny = make([]any, len(eventMapping.Profiles))
+			for i, p := range eventMapping.Profiles {
+				profilesAny[i] = p
+			}
+		}
+
 		compiledEventMap := compiledEventMapping{
 			classID:       eventMapping.ClassID,
 			profiles:      eventMapping.Profiles,
+			profilesAny:   profilesAny,
 			fieldMappings: fieldMappings,
 			categoryUID:   categoryUID,
 		}
@@ -151,12 +162,8 @@ func (osp *ocsfStandardizationProcessor) processLogRecord(log plog.LogRecord, re
 			"category_uid": eventMapping.categoryUID,
 		}
 
-		if len(eventMapping.profiles) > 0 {
-			profilesAny := make([]any, len(eventMapping.profiles))
-			for i, p := range eventMapping.profiles {
-				profilesAny[i] = p
-			}
-			newBody["metadata"].(map[string]any)["profiles"] = profilesAny
+		if len(eventMapping.profilesAny) > 0 {
+			newBody["metadata"].(map[string]any)["profiles"] = eventMapping.profilesAny
 		}
 
 		for _, fieldMapping := range eventMapping.fieldMappings {

--- a/processor/ocsfstandardizationprocessor/processor.go
+++ b/processor/ocsfstandardizationprocessor/processor.go
@@ -151,6 +151,14 @@ func (osp *ocsfStandardizationProcessor) processLogRecord(log plog.LogRecord, re
 			"category_uid": eventMapping.categoryUID,
 		}
 
+		if len(eventMapping.profiles) > 0 {
+			profilesAny := make([]any, len(eventMapping.profiles))
+			for i, p := range eventMapping.profiles {
+				profilesAny[i] = p
+			}
+			newBody["metadata"].(map[string]any)["profiles"] = profilesAny
+		}
+
 		for _, fieldMapping := range eventMapping.fieldMappings {
 			var value any
 			if fieldMapping.from != nil {

--- a/processor/ocsfstandardizationprocessor/processor_test.go
+++ b/processor/ocsfstandardizationprocessor/processor_test.go
@@ -421,6 +421,84 @@ func TestProcessLogs(t *testing.T) {
 			expectedCount: 1,
 		},
 		{
+			name: "profiles emitted in metadata",
+			config: &Config{
+				OCSFVersion: OCSFVersion1_0_0,
+				EventMappings: []EventMapping{
+					{
+						ClassID:       3001,
+						Profiles:      []string{"datetime"},
+						FieldMappings: accountChangeFieldMappings,
+					},
+				},
+			},
+			inputLogs: func() plog.Logs {
+				ld := plog.NewLogs()
+				record := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+				err := record.Body().SetEmptyMap().FromRaw(accountChangeInputBody())
+				require.NoError(t, err)
+				return ld
+			},
+			expectedBody: func() map[string]any {
+				expected := accountChangeExpectedBody("1.0.0")
+				expected["metadata"].(map[string]any)["profiles"] = []any{"datetime"}
+				return expected
+			}(),
+			expectedCount: 1,
+		},
+		{
+			name: "multiple profiles emitted in metadata",
+			config: &Config{
+				OCSFVersion: OCSFVersion1_0_0,
+				EventMappings: []EventMapping{
+					{
+						ClassID:  3001,
+						Profiles: []string{"cloud", "datetime"},
+						FieldMappings: append(accountChangeFieldMappings,
+							FieldMapping{From: "body.cloud", To: "cloud"},
+						),
+					},
+				},
+			},
+			inputLogs: func() plog.Logs {
+				ld := plog.NewLogs()
+				record := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+				body := accountChangeInputBody()
+				body["cloud"] = map[string]any{"provider": "GCP"}
+				err := record.Body().SetEmptyMap().FromRaw(body)
+				require.NoError(t, err)
+				return ld
+			},
+			expectedBody: func() map[string]any {
+				expected := accountChangeExpectedBody("1.0.0")
+				expected["metadata"].(map[string]any)["profiles"] = []any{"cloud", "datetime"}
+				expected["cloud"] = map[string]any{"provider": "GCP"}
+				return expected
+			}(),
+			expectedCount: 1,
+		},
+		{
+			name: "no profiles omits profiles key from metadata",
+			config: &Config{
+				OCSFVersion: OCSFVersion1_0_0,
+				EventMappings: []EventMapping{
+					{
+						ClassID:       3001,
+						FieldMappings: accountChangeFieldMappings,
+					},
+				},
+			},
+			inputLogs: func() plog.Logs {
+				ld := plog.NewLogs()
+				record := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+				err := record.Body().SetEmptyMap().FromRaw(accountChangeInputBody())
+				require.NoError(t, err)
+				return ld
+			},
+			expectedBody:  accountChangeExpectedBody("1.0.0"),
+			expectedCount: 1,
+		},
+		{
 			name: "no event mappings drops all logs",
 			config: &Config{
 				OCSFVersion:   OCSFVersion1_0_0,

--- a/processor/ocsfstandardizationprocessor/testing/builder.yaml
+++ b/processor/ocsfstandardizationprocessor/testing/builder.yaml
@@ -3,16 +3,16 @@ dist:
   output_path: ./dist
 
 receivers:
-  - gomod: github.com/observiq/bindplane-otel-collector/receiver/telemetrygeneratorreceiver v0.0.0
+  - gomod: github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver v0.0.0
     path: ../../../receiver/telemetrygeneratorreceiver
 
 processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.146.0
-  - gomod: github.com/observiq/bindplane-otel-collector/processor/ocsfstandardizationprocessor v0.0.0
+  - gomod: github.com/observiq/bindplane-otel-contrib/processor/ocsfstandardizationprocessor v0.0.0
     path: ../
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.146.1
 
 replaces:
-  - github.com/observiq/bindplane-otel-collector/expr => ../../../../expr
+  - github.com/observiq/bindplane-otel-contrib/pkg/expr => ../../../../pkg/expr


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
- OCSF profiles should be saved to the log body in `metadata.profiles`
- Test builder.yaml was not pointing to contrib
- Oh my claude code agent files added to `.gitignore`
<!-- Please provide a description of the change here. -->
<img width="1548" height="337" alt="Screenshot 2026-03-25 at 11 21 44 AM" src="https://github.com/user-attachments/assets/9bce6d93-d448-41a0-b293-3c2bccf02746" />

##### Checklist
- [x] Changes are tested
- [x] CI has passed