### PR TITLE
fix(`restapireceiver`): Improve response timestamp handling

### DIFF
--- a/receiver/restapireceiver/pagination.go
+++ b/receiver/restapireceiver/pagination.go
@@ -352,9 +352,10 @@ func parseTimestampResponse(cfg *Config, dataArray []map[string]any, state *pagi
 	timestampField := cfg.Pagination.Timestamp.TimestampFieldName
 
 	if timestampField != "" {
+		configuredFormat := cfg.Pagination.Timestamp.TimestampFormat
 		for i, item := range dataArray {
 			if timestampVal, exists := item[timestampField]; exists {
-				parsedTime := parseTimestampValue(timestampVal)
+				parsedTime := parseTimestampValue(timestampVal, configuredFormat)
 				if !parsedTime.IsZero() && parsedTime.After(maxTimestamp) {
 					maxTimestamp = parsedTime
 					logger.Debug("parseTimestampResponse: found newer timestamp",
@@ -406,11 +407,25 @@ func parseTimestampResponse(cfg *Config, dataArray []map[string]any, state *pagi
 }
 
 // parseTimestampValue parses a timestamp value from various formats.
-func parseTimestampValue(timestampVal any) time.Time {
+// If configuredFormat is non-empty, it is tried first (for string values) or used
+// to select the correct epoch interpretation (for numeric values).
+func parseTimestampValue(timestampVal any, configuredFormat string) time.Time {
 	var parsedTime time.Time
 
 	if timestampStr, ok := timestampVal.(string); ok {
-		// Try multiple timestamp formats
+		// If the user configured an epoch format, try parsing the string as a numeric epoch value first.
+		if isEpochFormat(configuredFormat) {
+			if t, err := parseEpochTimestamp(timestampStr, configuredFormat); err == nil {
+				return t
+			}
+		}
+		// Try the user's configured format first, then fall back to common formats.
+		if configuredFormat != "" && !isEpochFormat(configuredFormat) {
+			if t, err := time.Parse(configuredFormat, timestampStr); err == nil {
+				return t
+			}
+		}
+		// Try multiple common timestamp formats
 		for _, format := range timestampFormats {
 			if t, err := time.Parse(format, timestampStr); err == nil {
 				parsedTime = t

--- a/receiver/restapireceiver/pagination.go
+++ b/receiver/restapireceiver/pagination.go
@@ -17,6 +17,8 @@ package restapireceiver
 import (
 	"fmt"
 	"net/url"
+	"regexp"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -318,18 +320,16 @@ func parsePageSizeResponse(cfg *Config, response any, extractedData []map[string
 	return false, nil // Partial page, no more
 }
 
-// Common timestamp formats to try when parsing response timestamps
-var timestampFormats = []string{
-	time.RFC3339,
-	time.RFC3339Nano,
-	"2006-01-02T15:04:05.000000-07:00", // RFC3339 with microseconds
-	"2006-01-02T15:04:05.000000Z",      // RFC3339 with microseconds, UTC
-	"2006-01-02T15:04:05-07:00",        // RFC3339 without fractional seconds
-	"2006-01-02 15:04:05.000000-07:00", // Space separator with microseconds
-	"2006-01-02 15:04:05-07:00",        // Space separator without fractional
-	"2006-01-02 15:04:05",              // Simple datetime
-	"2006-01-02",                       // Date only
-}
+var (
+	// datetimeRegex matches ISO 8601 / RFC 3339 style timestamps and captures:
+	//   1: separator (T or space)
+	//   2: fractional seconds including dot (e.g. ".123456")
+	//   3: timezone (Z, ±HH:MM, ±HHMM, or ±HH)
+	datetimeRegex = regexp.MustCompile(
+		`^\d{4}-\d{2}-\d{2}([T ])\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}(?::?\d{2})?)?$`,
+	)
+	dateOnlyRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+)
 
 // parseTimestampResponse parses the response for timestamp-based pagination.
 // The dataArray parameter contains the already-extracted data from extractDataFromResponse.
@@ -425,12 +425,9 @@ func parseTimestampValue(timestampVal any, configuredFormat string) time.Time {
 				return t
 			}
 		}
-		// Try multiple common timestamp formats
-		for _, format := range timestampFormats {
-			if t, err := time.Parse(format, timestampStr); err == nil {
-				parsedTime = t
-				break
-			}
+		// Detect format via regex and parse
+		if t, ok := parseTimestampString(timestampStr); ok {
+			parsedTime = t
 		}
 	} else if timestampFloat, ok := timestampVal.(float64); ok {
 		// Unix timestamp (seconds or milliseconds)
@@ -456,6 +453,48 @@ func parseTimestampValue(timestampVal any, configuredFormat string) time.Time {
 	}
 
 	return parsedTime
+}
+
+// parseTimestampString attempts to parse a timestamp string by detecting its
+// format via regex rather than iterating a fixed list of formats. This handles
+// any combination of T/space separator, fractional-second precision (1-9 digits),
+// and timezone style (Z, ±HH:MM, ±HHMM, ±HH, or absent).
+func parseTimestampString(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+
+	if m := datetimeRegex.FindStringSubmatch(s); m != nil {
+		format := "2006-01-02" + m[1] + "15:04:05"
+
+		if m[2] != "" {
+			// Build fractional format matching the exact digit count.
+			format += "." + strings.Repeat("0", len(m[2])-1)
+		}
+
+		if tz := m[3]; tz != "" {
+			switch {
+			case tz == "Z":
+				format += "Z07:00" // accepts literal Z
+			case strings.Contains(tz, ":"):
+				format += "-07:00" // ±HH:MM
+			case len(tz) == 5:
+				format += "-0700" // ±HHMM
+			case len(tz) == 3:
+				format += "-07" // ±HH
+			}
+		}
+
+		if t, err := time.Parse(format, s); err == nil {
+			return t, true
+		}
+	}
+
+	if dateOnlyRegex.MatchString(s) {
+		if t, err := time.Parse("2006-01-02", s); err == nil {
+			return t, true
+		}
+	}
+
+	return time.Time{}, false
 }
 
 // updatePaginationState updates the pagination state to the next page/offset.

--- a/receiver/restapireceiver/pagination_test.go
+++ b/receiver/restapireceiver/pagination_test.go
@@ -1303,14 +1303,29 @@ func TestNewPaginationState_Timestamp_EpochSecondsFractional_WholeSeconds(t *tes
 
 func TestParseTimestampValue_FractionalFloat(t *testing.T) {
 	// Float64 seconds with fractional part
-	result := parseTimestampValue(1735689600.123)
+	result := parseTimestampValue(1735689600.123, "")
 	expected := time.Date(2025, 1, 1, 0, 0, 0, 123000000, time.UTC)
 	require.InDelta(t, expected.UnixNano(), result.UnixNano(), 1000, "expected %v, got %v", expected, result)
 
 	// Float64 milliseconds with fractional part
-	result = parseTimestampValue(1735689600123.456)
+	result = parseTimestampValue(1735689600123.456, "")
 	expected = time.Date(2025, 1, 1, 0, 0, 0, 123456000, time.UTC)
 	require.InDelta(t, expected.UnixNano(), result.UnixNano(), 1000, "expected %v, got %v", expected, result)
+}
+
+func TestParseTimestampValue_ConfiguredFormat(t *testing.T) {
+	// Timestamp with milliseconds and no-colon timezone offset.
+	// This format is not in the default timestampFormats list, so it
+	// only parses when the configured format is passed through.
+	const format = "2006-01-02T15:04:05.000-0700"
+
+	result := parseTimestampValue("2026-03-29T02:09:21.550+0000", format)
+	expected := time.Date(2026, 3, 29, 2, 9, 21, 550000000, time.UTC)
+	require.True(t, expected.Equal(result), "expected %v, got %v", expected, result)
+
+	// Verify the same string fails without the configured format
+	result = parseTimestampValue("2026-03-29T02:09:21.550+0000", "")
+	require.True(t, result.IsZero(), "expected zero time without configured format, got %v", result)
 }
 
 func TestParsePaginationResponse_WithDataArray(t *testing.T) {

--- a/receiver/restapireceiver/pagination_test.go
+++ b/receiver/restapireceiver/pagination_test.go
@@ -1315,17 +1315,156 @@ func TestParseTimestampValue_FractionalFloat(t *testing.T) {
 
 func TestParseTimestampValue_ConfiguredFormat(t *testing.T) {
 	// Timestamp with milliseconds and no-colon timezone offset.
-	// This format is not in the default timestampFormats list, so it
-	// only parses when the configured format is passed through.
 	const format = "2006-01-02T15:04:05.000-0700"
 
 	result := parseTimestampValue("2026-03-29T02:09:21.550+0000", format)
 	expected := time.Date(2026, 3, 29, 2, 9, 21, 550000000, time.UTC)
 	require.True(t, expected.Equal(result), "expected %v, got %v", expected, result)
 
-	// Verify the same string fails without the configured format
+	// Regex-based fallback handles ±HHMM timezone offsets
 	result = parseTimestampValue("2026-03-29T02:09:21.550+0000", "")
-	require.True(t, result.IsZero(), "expected zero time without configured format, got %v", result)
+	require.True(t, expected.Equal(result), "expected regex fallback to parse ±HHMM timezone, got %v", result)
+}
+
+func TestParseTimestampString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantOK   bool
+		wantTime time.Time
+	}{
+		// RFC3339 / ISO8601 with T separator
+		{
+			name:     "RFC3339 with Z",
+			input:    "2024-06-15T10:30:00Z",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "RFC3339 with positive offset",
+			input:    "2024-06-15T10:30:00+05:30",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 0, time.FixedZone("", 5*3600+30*60)),
+		},
+		{
+			name:     "RFC3339 with negative offset",
+			input:    "2024-06-15T10:30:00-04:00",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 0, time.FixedZone("", -4*3600)),
+		},
+		// Fractional seconds of varying precision
+		{
+			name:     "milliseconds with Z",
+			input:    "2024-06-15T10:30:00.123Z",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 123000000, time.UTC),
+		},
+		{
+			name:     "microseconds with Z",
+			input:    "2024-06-15T10:30:00.123456Z",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 123456000, time.UTC),
+		},
+		{
+			name:     "nanoseconds with Z",
+			input:    "2024-06-15T10:30:00.123456789Z",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 123456789, time.UTC),
+		},
+		{
+			name:     "single fractional digit",
+			input:    "2024-06-15T10:30:00.1Z",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 100000000, time.UTC),
+		},
+		// No-colon timezone offset (±HHMM)
+		{
+			name:     "no-colon tz offset with fractional",
+			input:    "2024-06-15T10:30:00.550+0000",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 550000000, time.UTC),
+		},
+		{
+			name:     "no-colon negative tz offset",
+			input:    "2024-06-15T10:30:00-0500",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 0, time.FixedZone("", -5*3600)),
+		},
+		// Short timezone (±HH)
+		{
+			name:     "short tz offset",
+			input:    "2024-06-15T10:30:00+05",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 0, time.FixedZone("", 5*3600)),
+		},
+		// Space separator instead of T
+		{
+			name:     "space separator with tz",
+			input:    "2024-06-15 10:30:00+00:00",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "space separator with microseconds",
+			input:    "2024-06-15 10:30:00.123456-07:00",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 123456000, time.FixedZone("", -7*3600)),
+		},
+		// No timezone
+		{
+			name:     "no timezone",
+			input:    "2024-06-15T10:30:00",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "space separator no timezone",
+			input:    "2024-06-15 10:30:00",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC),
+		},
+		// Date only
+		{
+			name:     "date only",
+			input:    "2024-06-15",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC),
+		},
+		// Whitespace trimming
+		{
+			name:     "leading/trailing whitespace",
+			input:    "  2024-06-15T10:30:00Z  ",
+			wantOK:   true,
+			wantTime: time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC),
+		},
+		// Non-matching inputs
+		{
+			name:   "empty string",
+			input:  "",
+			wantOK: false,
+		},
+		{
+			name:   "plain text",
+			input:  "not-a-timestamp",
+			wantOK: false,
+		},
+		{
+			name:   "epoch number as string",
+			input:  "1735689600",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseTimestampString(tt.input)
+			require.Equal(t, tt.wantOK, ok, "parseTimestampString(%q) ok", tt.input)
+			if tt.wantOK {
+				require.True(t, tt.wantTime.Equal(got),
+					"parseTimestampString(%q) = %v, want %v", tt.input, got, tt.wantTime)
+			}
+		})
+	}
 }
 
 func TestParsePaginationResponse_WithDataArray(t *testing.T) {


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Improves how the REST API receiver handles the timestamps from the response returned by the API. 
- If a user has a timestamp format configured, try to parse that format first
- If there's no configured format, or the configured format fails to parse (API returns a different format than it expects), fallback to a regex for common ISO8601 and RFC 3339 formats

##### Checklist
- [x] Changes are tested
- [ ] CI has passed