### PR TITLE
ci: Add Graphite CI optimization for stacked PRs

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -6,8 +6,24 @@ permissions:
   contents: read
 
 jobs:
+  # Graphite CI optimization: skip redundant CI runs for stacked PRs.
+  # See https://graphite.com/docs/stacking-and-ci
+  optimize_ci:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        uses: withgraphite/graphite-ci-action@26bc0dcdeaba101794931d67a464ecbb21a76a8b # v0.0.9 tag (no formal releases)
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+
   build-collector:
-    if: github.actor != 'dependabot[bot]'
+    if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]'
+    needs:
+      - optimize_ci
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04
     strategy:
       matrix:
@@ -41,7 +57,7 @@ jobs:
 
   build-summary:
     if: always()
-    needs: [build-collector]
+    needs: [optimize_ci, build-collector]
     runs-on: ubuntu-latest
     steps:
       - name: Check build results

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,8 +6,25 @@ permissions:
   contents: read
 
 jobs:
+  # Graphite CI optimization: skip redundant CI runs for stacked PRs.
+  # See https://graphite.com/docs/stacking-and-ci
+  optimize_ci:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        uses: withgraphite/graphite-ci-action@26bc0dcdeaba101794931d67a464ecbb21a76a8b # v0.0.9 tag (no formal releases)
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+
   # Detect which files changed to skip irrelevant jobs on PRs.
   detect-changes:
+    if: needs.optimize_ci.outputs.skip != 'true'
+    needs:
+      - optimize_ci
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04
     permissions:
       contents: read
@@ -47,7 +64,9 @@ jobs:
               - '.github/dependabot.yml'
 
   setup-tools:
-    if: github.actor != 'dependabot[bot]'
+    if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]'
+    needs:
+      - optimize_ci
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04
     steps:
       - name: Checkout Sources
@@ -70,9 +89,10 @@ jobs:
         run: make install-tools
 
   check-fmt:
-    if: github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true'
+    if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true'
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04
     needs:
+      - optimize_ci
       - setup-tools
       - detect-changes
     steps:
@@ -98,9 +118,10 @@ jobs:
         run: make check-fmt
 
   check-license:
-    if: github.actor != 'dependabot[bot]' && (needs.detect-changes.outputs.go == 'true' || needs.detect-changes.outputs.scripts == 'true')
+    if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && (needs.detect-changes.outputs.go == 'true' || needs.detect-changes.outputs.scripts == 'true')
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04
     needs:
+      - optimize_ci
       - setup-tools
       - detect-changes
     steps:
@@ -126,9 +147,10 @@ jobs:
         run: make check-license
 
   gosec:
-    if: github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true'
+    if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true'
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04
     needs:
+      - optimize_ci
       - setup-tools
       - detect-changes
     steps:
@@ -154,9 +176,10 @@ jobs:
         run: make gosec
 
   misspell:
-    if: github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.misspell == 'true'
+    if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.misspell == 'true'
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04
     needs:
+      - optimize_ci
       - setup-tools
       - detect-changes
     steps:
@@ -182,9 +205,10 @@ jobs:
         run: make misspell
 
   lint:
-    if: github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true'
+    if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true'
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04
     needs:
+      - optimize_ci
       - setup-tools
       - detect-changes
     steps:
@@ -211,9 +235,10 @@ jobs:
 
   # Below checks don't need to run `make install-tools`
   check-mod-paths:
-    if: github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.gomod == 'true'
+    if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.gomod == 'true'
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04
     needs:
+      - optimize_ci
       - detect-changes
     steps:
       - name: Checkout Sources
@@ -222,9 +247,10 @@ jobs:
         run: make check-mod-paths
 
   check-dependabot:
-    if: github.actor != 'dependabot[bot]' && (needs.detect-changes.outputs.dependabot == 'true' || needs.detect-changes.outputs.gomod == 'true')
+    if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && (needs.detect-changes.outputs.dependabot == 'true' || needs.detect-changes.outputs.gomod == 'true')
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04
     needs:
+      - optimize_ci
       - detect-changes
     steps:
       - name: Checkout Sources

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,25 @@ permissions:
   contents: read
 
 jobs:
+  # Graphite CI optimization: skip redundant CI runs for stacked PRs.
+  # See https://graphite.com/docs/stacking-and-ci
+  optimize_ci:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        uses: withgraphite/graphite-ci-action@26bc0dcdeaba101794931d67a464ecbb21a76a8b # v0.0.9 tag (no formal releases)
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+
   # Detect which files changed to skip irrelevant jobs on PRs.
   detect-changes:
+    if: needs.optimize_ci.outputs.skip != 'true'
+    needs:
+      - optimize_ci
     runs-on: namespace-profile-bindplane-default-ubuntu-24-04
     permissions:
       contents: read
@@ -34,8 +51,9 @@ jobs:
               - '**/go.sum'
 
   unit-tests:
-    if: github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true'
+    if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true'
     needs:
+      - optimize_ci
       - detect-changes
     strategy:
       fail-fast: false
@@ -145,7 +163,7 @@ jobs:
 
   test-summary:
     if: always()
-    needs: [unit-tests]
+    needs: [optimize_ci, unit-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check test results


### PR DESCRIPTION
### Proposed Change
Adds Graphite CI optimization to skip redundant CI runs for stacked PRs, matching the pattern already used in the bindplane repo.

Each workflow file (`checks.yml`, `tests.yml`, `build-check.yml`) gets an `optimize_ci` job that calls `withgraphite/graphite-ci-action` to detect stacked PRs. All substantive jobs depend on this and skip when the action flags the run as redundant. Summary/gate jobs (`test-summary`, `build-summary`) are left untouched so they always report status.

Requires the `GRAPHITE_CI_OPTIMIZER_TOKEN` secret to be configured in this repo's settings.

##### Checklist
- [x] Changes are tested
- [x] CI has passed