### PR TITLE
feat(restapireceiver): Support NDJSON return format

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "mcp__claude_ai_Linear__get_issue",
-      "mcp__claude_ai_Linear__list_comments"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__claude_ai_Linear__get_issue",
+      "mcp__claude_ai_Linear__list_comments"
+    ]
+  }
+}

--- a/receiver/restapireceiver/README.md
+++ b/receiver/restapireceiver/README.md
@@ -31,7 +31,8 @@ Alpha:
 | Field                | Type      | Default | Required | Description                                                                                                                                                                                    |
 | -------------------- | --------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `url`                | string    |         | `true`   | The base URL for the REST API endpoint                                                                                                                                                         |
-| `response_field`     | string    |         | `false`  | The name of the field in the response that contains the array of items. If empty, the response is assumed to be a top-level array. For nested fields, use dot notation (e.g., `response.data`) |
+| `response_format`    | string    | `json`  | `false`  | Response body format: `json` (standard JSON array/object) or `ndjson` (newline-delimited JSON). In NDJSON mode, each line is a separate JSON object; the last line is treated as metadata (e.g., containing pagination cursors) and is not emitted as data. |
+| `response_field`     | string    |         | `false`  | The name of the field in the response that contains the array of items. If empty, the response is assumed to be a top-level array. For nested fields, use dot notation (e.g., `response.data`). Not used when `response_format` is `ndjson`. |
 | `metrics`            | object    |         | `false`  | Metrics configuration (see below)                                                                                                                                                              |
 | `auth_mode`          | string    | `none`  | `false`  | Authentication mode: `none`, `apikey`, `bearer`, `basic`, `oauth2`, or `akamai_edgegrid`                                                                                                       |
 | `apikey`             | object    |         | `false`  | API Key configuration (see below)                                                                                                                                                              |
@@ -266,6 +267,29 @@ receivers:
       access_token: "your-access-token"
       client_token: "your-client-token"
       client_secret: "your-client-secret"
+```
+
+### Akamai SIEM API (NDJSON + Cursor Pagination)
+
+The Akamai SIEM API returns newline-delimited JSON (NDJSON), where each line is a security event and the last line is a metadata object containing the `offset` cursor for pagination. Use `response_format: ndjson` combined with `next_offset_field_name` to handle this.
+
+```yaml
+receivers:
+  restapi:
+    url: "https://{hostname}/siem/v1/configs/{configId}"
+    response_format: ndjson
+    max_poll_interval: 5m
+    auth_mode: akamai_edgegrid
+    akamai_edgegrid:
+      access_token: "your-access-token"
+      client_token: "your-client-token"
+      client_secret: "your-client-secret"
+    pagination:
+      mode: offset_limit
+      offset_limit:
+        offset_field_name: "offset"
+        limit_field_name: "limit"
+        next_offset_field_name: "offset"
 ```
 
 ### Token-Based (Cursor) Offset Pagination

--- a/receiver/restapireceiver/README.md
+++ b/receiver/restapireceiver/README.md
@@ -100,7 +100,8 @@ Use `auth_mode: none` for public APIs that don't require authentication. No addi
 | Field                                 | Type   | Default | Required | Description                                                          |
 | ------------------------------------- | ------ | ------- | -------- | -------------------------------------------------------------------- |
 | `pagination.mode`                     | string | `none`  | `false`  | Pagination mode: `none`, `offset_limit`, `page_size`, or `timestamp` |
-| `pagination.total_record_count_field` | string |         | `false`  | Field name in response containing total record count                 |
+| `pagination.response_source`          | string | `body`  | `false`  | Where to extract pagination response attributes from: `body` (response body or NDJSON metadata line) or `header` (HTTP response headers). Applies to `total_record_count_field`, `next_offset_field_name`, and `total_pages_field_name`. |
+| `pagination.total_record_count_field` | string |         | `false`  | Name of the field or header containing total record count            |
 | `pagination.page_limit`               | int    | `0`     | `false`  | Maximum number of pages to fetch (0 = no limit)                      |
 | `pagination.zero_based_index`         | bool   | `false` | `false`  | Indicates that the requested data starts at index 0                  |
 
@@ -111,8 +112,7 @@ Use `auth_mode: none` for public APIs that don't require authentication. No addi
 | `pagination.offset_limit.offset_field_name`      | string |         | `false`  | Query parameter name for offset                                                                                                                                                                                                |
 | `pagination.offset_limit.limit_field_name`       | string |         | `false`  | Query parameter name for limit                                                                                                                                                                                                 |
 | `pagination.offset_limit.starting_offset`        | int    | `0`     | `false`  | Starting offset value                                                                                                                                                                                                          |
-| `pagination.offset_limit.next_offset_field_name` | string |         | `false`  | Name of the field (in the response body) or header that contains the next offset token. When set, the receiver uses token-based (cursor) pagination instead of numeric offsets. For body sources, supports nested fields with dot notation (e.g., `pagination.next_cursor`). |
-| `pagination.offset_limit.next_offset_source`     | string | `body`  | `false`  | Where to extract the next offset token from: `body` (response body or NDJSON metadata line) or `header` (HTTP response header). |
+| `pagination.offset_limit.next_offset_field_name` | string |         | `false`  | Name of the field or header containing the next offset token. When set, the receiver uses token-based (cursor) pagination instead of numeric offsets. For body sources, supports nested fields with dot notation (e.g., `pagination.next_cursor`). |
 
 #### Page/Size Pagination
 
@@ -121,7 +121,7 @@ Use `auth_mode: none` for public APIs that don't require authentication. No addi
 | `pagination.page_size.page_num_field_name`    | string |         | `false`  | Query parameter name for page number               |
 | `pagination.page_size.page_size_field_name`   | string |         | `false`  | Query parameter name for page size                 |
 | `pagination.page_size.starting_page`          | int    | `1`     | `false`  | Starting page number                               |
-| `pagination.page_size.total_pages_field_name` | string |         | `false`  | Field name in response containing total page count |
+| `pagination.page_size.total_pages_field_name` | string |         | `false`  | Name of the field or header containing total page count |
 
 #### Timestamp-Based Pagination
 
@@ -331,7 +331,7 @@ When `next_cursor` is empty, null, or missing, the receiver treats it as the end
 
 ### Header-Based Cursor Pagination
 
-Some APIs return the pagination cursor in a response header instead of the body. Set `next_offset_source: header` and use `next_offset_field_name` as the header name.
+Some APIs return pagination attributes (cursors, total counts) in response headers instead of the body. Set `response_source: header` to extract all pagination fields from headers.
 
 ```yaml
 receivers:
@@ -343,11 +343,12 @@ receivers:
       token: "your-bearer-token-here"
     pagination:
       mode: offset_limit
+      response_source: header
+      total_record_count_field: "X-Total-Count"
       offset_limit:
         offset_field_name: "cursor"
         limit_field_name: "limit"
         next_offset_field_name: "X-Next-Cursor"
-        next_offset_source: header
     storage: file_storage
 ```
 

--- a/receiver/restapireceiver/README.md
+++ b/receiver/restapireceiver/README.md
@@ -111,7 +111,8 @@ Use `auth_mode: none` for public APIs that don't require authentication. No addi
 | `pagination.offset_limit.offset_field_name`      | string |         | `false`  | Query parameter name for offset                                                                                                                                                                                                |
 | `pagination.offset_limit.limit_field_name`       | string |         | `false`  | Query parameter name for limit                                                                                                                                                                                                 |
 | `pagination.offset_limit.starting_offset`        | int    | `0`     | `false`  | Starting offset value                                                                                                                                                                                                          |
-| `pagination.offset_limit.next_offset_field_name` | string |         | `false`  | Field name in the response containing the next offset token. When set, the receiver uses token-based (cursor) pagination instead of numeric offsets. Supports nested fields with dot notation (e.g., `pagination.next_cursor`) |
+| `pagination.offset_limit.next_offset_field_name` | string |         | `false`  | Name of the field (in the response body) or header that contains the next offset token. When set, the receiver uses token-based (cursor) pagination instead of numeric offsets. For body sources, supports nested fields with dot notation (e.g., `pagination.next_cursor`). |
+| `pagination.offset_limit.next_offset_source`     | string | `body`  | `false`  | Where to extract the next offset token from: `body` (response body or NDJSON metadata line) or `header` (HTTP response header). |
 
 #### Page/Size Pagination
 
@@ -327,6 +328,28 @@ This configuration would work with an API that returns responses like:
 ```
 
 When `next_cursor` is empty, null, or missing, the receiver treats it as the end of available data.
+
+### Header-Based Cursor Pagination
+
+Some APIs return the pagination cursor in a response header instead of the body. Set `next_offset_source: header` and use `next_offset_field_name` as the header name.
+
+```yaml
+receivers:
+  restapi:
+    url: "https://api.example.com/events"
+    max_poll_interval: 5m
+    auth_mode: bearer
+    bearer:
+      token: "your-bearer-token-here"
+    pagination:
+      mode: offset_limit
+      offset_limit:
+        offset_field_name: "cursor"
+        limit_field_name: "limit"
+        next_offset_field_name: "X-Next-Cursor"
+        next_offset_source: header
+    storage: file_storage
+```
 
 ### Timestamp Pagination
 

--- a/receiver/restapireceiver/client.go
+++ b/receiver/restapireceiver/client.go
@@ -43,12 +43,12 @@ type restAPIClient interface {
 	// Returns an array of map[string]any representing the JSON objects.
 	GetJSON(ctx context.Context, requestURL string, params url.Values) ([]map[string]any, error)
 	// GetFullResponse fetches the full JSON response from the specified URL.
-	// Returns the full response as map[string]any for pagination parsing.
-	GetFullResponse(ctx context.Context, requestURL string, params url.Values) (map[string]any, error)
+	// Returns the full response as map[string]any for pagination parsing, plus response headers.
+	GetFullResponse(ctx context.Context, requestURL string, params url.Values) (map[string]any, http.Header, error)
 	// GetNDJSON fetches an NDJSON response from the specified URL.
-	// Returns the data objects (all lines except the last) and the metadata object (last line).
-	// The metadata object typically contains pagination cursors (e.g., offset tokens).
-	GetNDJSON(ctx context.Context, requestURL string, params url.Values) (data []map[string]any, metadata map[string]any, err error)
+	// Returns the data objects (all lines except the last), the metadata object (last line),
+	// and the HTTP response headers.
+	GetNDJSON(ctx context.Context, requestURL string, params url.Values) (data []map[string]any, metadata map[string]any, headers http.Header, err error)
 	// Shutdown shuts down the REST API client.
 	Shutdown() error
 }
@@ -200,84 +200,7 @@ func (c *defaultRESTAPIClient) GetJSON(ctx context.Context, requestURL string, p
 }
 
 // GetFullResponse fetches the full JSON response from the specified URL.
-func (c *defaultRESTAPIClient) GetFullResponse(ctx context.Context, requestURL string, params url.Values) (map[string]any, error) {
-	// Build the request URL with query parameters
-	u, err := url.Parse(requestURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse URL: %w", err)
-	}
-
-	// Add query parameters
-	if len(params) > 0 {
-		existingParams := u.Query()
-		for key, values := range params {
-			for _, value := range values {
-				existingParams.Add(key, value)
-			}
-		}
-		u.RawQuery = existingParams.Encode()
-	}
-
-	// Create the HTTP request
-	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Apply authentication
-	if err := c.applyAuth(req); err != nil {
-		return nil, fmt.Errorf("failed to apply authentication: %w", err)
-	}
-
-	// Set default headers
-	req.Header.Set("Accept", "application/json")
-
-	// Apply custom headers (may override defaults)
-	c.applyHeaders(req)
-
-	// Make the request
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Check for HTTP errors
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("HTTP error %d: %s", resp.StatusCode, string(body))
-	}
-
-	// Read the response body
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	// Parse JSON
-	var jsonData any
-	if err := jsoniter.Unmarshal(body, &jsonData); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	// Return as map
-	responseMap, ok := jsonData.(map[string]any)
-	if !ok {
-		// If response is an array, wrap it in a map
-		if arr, ok := jsonData.([]any); ok {
-			return map[string]any{"data": arr}, nil
-		}
-		return nil, fmt.Errorf("response is not a JSON object or array")
-	}
-
-	return responseMap, nil
-}
-
-// GetNDJSON fetches an NDJSON response from the specified URL.
-// Each line of the response is a separate JSON object. The last line is treated
-// as metadata (e.g., containing pagination cursors like an offset token).
-// All other lines are returned as data objects.
-func (c *defaultRESTAPIClient) GetNDJSON(ctx context.Context, requestURL string, params url.Values) ([]map[string]any, map[string]any, error) {
+func (c *defaultRESTAPIClient) GetFullResponse(ctx context.Context, requestURL string, params url.Values) (map[string]any, http.Header, error) {
 	// Build the request URL with query parameters
 	u, err := url.Parse(requestURL)
 	if err != nil {
@@ -331,7 +254,88 @@ func (c *defaultRESTAPIClient) GetNDJSON(ctx context.Context, requestURL string,
 		return nil, nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	return parseNDJSON(body, c.logger)
+	// Parse JSON
+	var jsonData any
+	if err := jsoniter.Unmarshal(body, &jsonData); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	// Return as map
+	responseMap, ok := jsonData.(map[string]any)
+	if !ok {
+		// If response is an array, wrap it in a map
+		if arr, ok := jsonData.([]any); ok {
+			return map[string]any{"data": arr}, resp.Header, nil
+		}
+		return nil, nil, fmt.Errorf("response is not a JSON object or array")
+	}
+
+	return responseMap, resp.Header, nil
+}
+
+// GetNDJSON fetches an NDJSON response from the specified URL.
+// Each line of the response is a separate JSON object. The last line is treated
+// as metadata (e.g., containing pagination cursors like an offset token).
+// All other lines are returned as data objects.
+func (c *defaultRESTAPIClient) GetNDJSON(ctx context.Context, requestURL string, params url.Values) ([]map[string]any, map[string]any, http.Header, error) {
+	// Build the request URL with query parameters
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	// Add query parameters
+	if len(params) > 0 {
+		existingParams := u.Query()
+		for key, values := range params {
+			for _, value := range values {
+				existingParams.Add(key, value)
+			}
+		}
+		u.RawQuery = existingParams.Encode()
+	}
+
+	// Create the HTTP request
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Apply authentication
+	if err := c.applyAuth(req); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to apply authentication: %w", err)
+	}
+
+	// Set default headers
+	req.Header.Set("Accept", "application/json")
+
+	// Apply custom headers (may override defaults)
+	c.applyHeaders(req)
+
+	// Make the request
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to make request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for HTTP errors
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, nil, nil, fmt.Errorf("HTTP error %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	data, metadata, err := parseNDJSON(body, c.logger)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return data, metadata, resp.Header, nil
 }
 
 // parseNDJSON parses an NDJSON response body into data objects and a metadata object.

--- a/receiver/restapireceiver/client.go
+++ b/receiver/restapireceiver/client.go
@@ -46,9 +46,9 @@ type restAPIClient interface {
 	// Returns the full response as map[string]any for pagination parsing, plus response headers.
 	GetFullResponse(ctx context.Context, requestURL string, params url.Values) (map[string]any, http.Header, error)
 	// GetNDJSON fetches an NDJSON response from the specified URL.
-	// Returns the data objects (all lines except the last), the metadata object (last line),
-	// and the HTTP response headers.
-	GetNDJSON(ctx context.Context, requestURL string, params url.Values) (data []map[string]any, metadata map[string]any, headers http.Header, err error)
+	// When metadataInBody is true the last line is treated as pagination metadata;
+	// when false all lines are treated as data (metadata comes from headers instead).
+	GetNDJSON(ctx context.Context, requestURL string, params url.Values, metadataInBody bool) (data []map[string]any, metadata map[string]any, headers http.Header, err error)
 	// Shutdown shuts down the REST API client.
 	Shutdown() error
 }
@@ -277,7 +277,7 @@ func (c *defaultRESTAPIClient) GetFullResponse(ctx context.Context, requestURL s
 // Each line of the response is a separate JSON object. The last line is treated
 // as metadata (e.g., containing pagination cursors like an offset token).
 // All other lines are returned as data objects.
-func (c *defaultRESTAPIClient) GetNDJSON(ctx context.Context, requestURL string, params url.Values) ([]map[string]any, map[string]any, http.Header, error) {
+func (c *defaultRESTAPIClient) GetNDJSON(ctx context.Context, requestURL string, params url.Values, metadataInBody bool) ([]map[string]any, map[string]any, http.Header, error) {
 	// Build the request URL with query parameters
 	u, err := url.Parse(requestURL)
 	if err != nil {
@@ -331,7 +331,7 @@ func (c *defaultRESTAPIClient) GetNDJSON(ctx context.Context, requestURL string,
 		return nil, nil, nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	data, metadata, err := parseNDJSON(body, c.logger)
+	data, metadata, err := parseNDJSON(body, metadataInBody, c.logger)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -339,9 +339,12 @@ func (c *defaultRESTAPIClient) GetNDJSON(ctx context.Context, requestURL string,
 }
 
 // parseNDJSON parses an NDJSON response body into data objects and a metadata object.
-// The last non-empty line is treated as metadata; all preceding lines are data objects.
+// When metadataInBody is true, the last non-empty line is treated as metadata and all
+// preceding lines are data objects. When false, all lines are treated as data and
+// metadata is returned as nil (the caller is expected to source metadata elsewhere,
+// e.g. from response headers).
 // Empty lines are skipped.
-func parseNDJSON(body []byte, logger *zap.Logger) ([]map[string]any, map[string]any, error) {
+func parseNDJSON(body []byte, metadataInBody bool, logger *zap.Logger) ([]map[string]any, map[string]any, error) {
 	lines := strings.Split(strings.TrimSpace(string(body)), "\n")
 
 	// Filter out empty lines
@@ -357,14 +360,21 @@ func parseNDJSON(body []byte, logger *zap.Logger) ([]map[string]any, map[string]
 		return []map[string]any{}, map[string]any{}, nil
 	}
 
-	// Last line is metadata, everything else is data
-	metadataLine := nonEmptyLines[len(nonEmptyLines)-1]
-	dataLines := nonEmptyLines[:len(nonEmptyLines)-1]
+	var metadataLine string
+	dataLines := nonEmptyLines
+
+	if metadataInBody {
+		// Last line is metadata, everything else is data
+		metadataLine = nonEmptyLines[len(nonEmptyLines)-1]
+		dataLines = nonEmptyLines[:len(nonEmptyLines)-1]
+	}
 
 	// Parse metadata
 	var metadata map[string]any
-	if err := jsoniter.UnmarshalFromString(metadataLine, &metadata); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse NDJSON metadata line: %w", err)
+	if metadataLine != "" {
+		if err := jsoniter.UnmarshalFromString(metadataLine, &metadata); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse NDJSON metadata line: %w", err)
+		}
 	}
 
 	// Parse data lines

--- a/receiver/restapireceiver/client.go
+++ b/receiver/restapireceiver/client.go
@@ -45,6 +45,10 @@ type restAPIClient interface {
 	// GetFullResponse fetches the full JSON response from the specified URL.
 	// Returns the full response as map[string]any for pagination parsing.
 	GetFullResponse(ctx context.Context, requestURL string, params url.Values) (map[string]any, error)
+	// GetNDJSON fetches an NDJSON response from the specified URL.
+	// Returns the data objects (all lines except the last) and the metadata object (last line).
+	// The metadata object typically contains pagination cursors (e.g., offset tokens).
+	GetNDJSON(ctx context.Context, requestURL string, params url.Values) (data []map[string]any, metadata map[string]any, err error)
 	// Shutdown shuts down the REST API client.
 	Shutdown() error
 }
@@ -267,6 +271,112 @@ func (c *defaultRESTAPIClient) GetFullResponse(ctx context.Context, requestURL s
 	}
 
 	return responseMap, nil
+}
+
+// GetNDJSON fetches an NDJSON response from the specified URL.
+// Each line of the response is a separate JSON object. The last line is treated
+// as metadata (e.g., containing pagination cursors like an offset token).
+// All other lines are returned as data objects.
+func (c *defaultRESTAPIClient) GetNDJSON(ctx context.Context, requestURL string, params url.Values) ([]map[string]any, map[string]any, error) {
+	// Build the request URL with query parameters
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	// Add query parameters
+	if len(params) > 0 {
+		existingParams := u.Query()
+		for key, values := range params {
+			for _, value := range values {
+				existingParams.Add(key, value)
+			}
+		}
+		u.RawQuery = existingParams.Encode()
+	}
+
+	// Create the HTTP request
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Apply authentication
+	if err := c.applyAuth(req); err != nil {
+		return nil, nil, fmt.Errorf("failed to apply authentication: %w", err)
+	}
+
+	// Set default headers
+	req.Header.Set("Accept", "application/json")
+
+	// Apply custom headers (may override defaults)
+	c.applyHeaders(req)
+
+	// Make the request
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to make request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for HTTP errors
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, nil, fmt.Errorf("HTTP error %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return parseNDJSON(body, c.logger)
+}
+
+// parseNDJSON parses an NDJSON response body into data objects and a metadata object.
+// The last non-empty line is treated as metadata; all preceding lines are data objects.
+// Empty lines are skipped.
+func parseNDJSON(body []byte, logger *zap.Logger) ([]map[string]any, map[string]any, error) {
+	lines := strings.Split(strings.TrimSpace(string(body)), "\n")
+
+	// Filter out empty lines
+	var nonEmptyLines []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			nonEmptyLines = append(nonEmptyLines, trimmed)
+		}
+	}
+
+	if len(nonEmptyLines) == 0 {
+		return []map[string]any{}, map[string]any{}, nil
+	}
+
+	// Last line is metadata, everything else is data
+	metadataLine := nonEmptyLines[len(nonEmptyLines)-1]
+	dataLines := nonEmptyLines[:len(nonEmptyLines)-1]
+
+	// Parse metadata
+	var metadata map[string]any
+	if err := jsoniter.UnmarshalFromString(metadataLine, &metadata); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse NDJSON metadata line: %w", err)
+	}
+
+	// Parse data lines
+	data := make([]map[string]any, 0, len(dataLines))
+	for i, line := range dataLines {
+		var obj map[string]any
+		if err := jsoniter.UnmarshalFromString(line, &obj); err != nil {
+			logger.Warn("skipping invalid NDJSON line",
+				zap.Int("line_number", i+1),
+				zap.Error(err))
+			continue
+		}
+		data = append(data, obj)
+	}
+
+	return data, metadata, nil
 }
 
 // generateEdgeGridAuth generates the Akamai EdgeGrid authentication header.

--- a/receiver/restapireceiver/client_test.go
+++ b/receiver/restapireceiver/client_test.go
@@ -740,6 +740,202 @@ func TestRESTAPIClient_GetFullResponse_SensitiveHeaders(t *testing.T) {
 	require.NotNil(t, data)
 }
 
+func TestRESTAPIClient_GetNDJSON(t *testing.T) {
+	// Create a test server that returns NDJSON
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "test-key", r.Header.Get("X-API-Key"))
+
+		// NDJSON: data lines + metadata line (last)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.Write([]byte(`{"id":"1","message":"event1"}` + "\n"))
+		w.Write([]byte(`{"id":"2","message":"event2"}` + "\n"))
+		w.Write([]byte(`{"id":"3","message":"event3"}` + "\n"))
+		w.Write([]byte(`{"offset":"abc123","total":3}` + "\n"))
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:      server.URL,
+		AuthMode: authModeAPIKey,
+		APIKeyConfig: APIKeyConfig{
+			HeaderName: "X-API-Key",
+			Value:      "test-key",
+		},
+		ClientConfig: confighttp.ClientConfig{},
+	}
+
+	ctx := context.Background()
+	host := componenttest.NewNopHost()
+	settings := componenttest.NewNopTelemetrySettings()
+
+	client, err := newRESTAPIClient(ctx, settings, cfg, host)
+	require.NoError(t, err)
+
+	params := url.Values{}
+	data, metadata, err := client.GetNDJSON(ctx, server.URL, params)
+	require.NoError(t, err)
+	require.Len(t, data, 3)
+	require.Equal(t, "1", data[0]["id"])
+	require.Equal(t, "event1", data[0]["message"])
+	require.Equal(t, "2", data[1]["id"])
+	require.Equal(t, "3", data[2]["id"])
+	require.Equal(t, "abc123", metadata["offset"])
+	require.Equal(t, float64(3), metadata["total"])
+}
+
+func TestRESTAPIClient_GetNDJSON_EmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		// Empty response body
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:          server.URL,
+		AuthMode:     authModeNone,
+		ClientConfig: confighttp.ClientConfig{},
+	}
+
+	ctx := context.Background()
+	host := componenttest.NewNopHost()
+	settings := componenttest.NewNopTelemetrySettings()
+
+	client, err := newRESTAPIClient(ctx, settings, cfg, host)
+	require.NoError(t, err)
+
+	data, metadata, err := client.GetNDJSON(ctx, server.URL, url.Values{})
+	require.NoError(t, err)
+	require.Len(t, data, 0)
+	require.Empty(t, metadata)
+}
+
+func TestRESTAPIClient_GetNDJSON_MetadataOnly(t *testing.T) {
+	// Single line = metadata only, no data
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.Write([]byte(`{"offset":"xyz","total":0}` + "\n"))
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:          server.URL,
+		AuthMode:     authModeNone,
+		ClientConfig: confighttp.ClientConfig{},
+	}
+
+	ctx := context.Background()
+	host := componenttest.NewNopHost()
+	settings := componenttest.NewNopTelemetrySettings()
+
+	client, err := newRESTAPIClient(ctx, settings, cfg, host)
+	require.NoError(t, err)
+
+	data, metadata, err := client.GetNDJSON(ctx, server.URL, url.Values{})
+	require.NoError(t, err)
+	require.Len(t, data, 0)
+	require.Equal(t, "xyz", metadata["offset"])
+	require.Equal(t, float64(0), metadata["total"])
+}
+
+func TestRESTAPIClient_GetNDJSON_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("Forbidden"))
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:          server.URL,
+		AuthMode:     authModeNone,
+		ClientConfig: confighttp.ClientConfig{},
+	}
+
+	ctx := context.Background()
+	host := componenttest.NewNopHost()
+	settings := componenttest.NewNopTelemetrySettings()
+
+	client, err := newRESTAPIClient(ctx, settings, cfg, host)
+	require.NoError(t, err)
+
+	data, metadata, err := client.GetNDJSON(ctx, server.URL, url.Values{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "403")
+	require.Nil(t, data)
+	require.Nil(t, metadata)
+}
+
+func TestParseNDJSON(t *testing.T) {
+	logger := componenttest.NewNopTelemetrySettings().Logger
+
+	testCases := []struct {
+		name             string
+		body             string
+		expectedData     int
+		expectedMetadata map[string]any
+		expectErr        bool
+	}{
+		{
+			name:             "empty body",
+			body:             "",
+			expectedData:     0,
+			expectedMetadata: map[string]any{},
+		},
+		{
+			name:             "metadata only",
+			body:             `{"offset":"abc"}`,
+			expectedData:     0,
+			expectedMetadata: map[string]any{"offset": "abc"},
+		},
+		{
+			name:         "data and metadata",
+			body:         "{\"id\":\"1\"}\n{\"id\":\"2\"}\n{\"offset\":\"next\",\"total\":2}",
+			expectedData: 2,
+			expectedMetadata: map[string]any{
+				"offset": "next",
+				"total":  float64(2),
+			},
+		},
+		{
+			name:         "with blank lines",
+			body:         "{\"id\":\"1\"}\n\n{\"id\":\"2\"}\n\n{\"offset\":\"next\"}\n",
+			expectedData: 2,
+			expectedMetadata: map[string]any{
+				"offset": "next",
+			},
+		},
+		{
+			name:      "invalid metadata line",
+			body:      "{\"id\":\"1\"}\nnot-json",
+			expectErr: true,
+		},
+		{
+			name:         "invalid data line is skipped",
+			body:         "not-json\n{\"id\":\"1\"}\n{\"offset\":\"abc\"}",
+			expectedData: 1,
+			expectedMetadata: map[string]any{
+				"offset": "abc",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, metadata, err := parseNDJSON([]byte(tc.body), logger)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, data, tc.expectedData)
+			if tc.expectedMetadata != nil {
+				for k, v := range tc.expectedMetadata {
+					require.Equal(t, v, metadata[k])
+				}
+			}
+		})
+	}
+}
+
 func TestRESTAPIClient_GetJSON_EmptyArray(t *testing.T) {
 	// Create a test server that returns empty array
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/receiver/restapireceiver/client_test.go
+++ b/receiver/restapireceiver/client_test.go
@@ -657,7 +657,7 @@ func TestRESTAPIClient_GetFullResponse_CustomHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	params := url.Values{}
-	data, err := client.GetFullResponse(ctx, server.URL, params)
+	data, _, err := client.GetFullResponse(ctx, server.URL, params)
 	require.NoError(t, err)
 	require.NotNil(t, data)
 }
@@ -735,7 +735,7 @@ func TestRESTAPIClient_GetFullResponse_SensitiveHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	params := url.Values{}
-	data, err := client.GetFullResponse(ctx, server.URL, params)
+	data, _, err := client.GetFullResponse(ctx, server.URL, params)
 	require.NoError(t, err)
 	require.NotNil(t, data)
 }
@@ -772,7 +772,7 @@ func TestRESTAPIClient_GetNDJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	params := url.Values{}
-	data, metadata, err := client.GetNDJSON(ctx, server.URL, params)
+	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, params)
 	require.NoError(t, err)
 	require.Len(t, data, 3)
 	require.Equal(t, "1", data[0]["id"])
@@ -803,7 +803,7 @@ func TestRESTAPIClient_GetNDJSON_EmptyResponse(t *testing.T) {
 	client, err := newRESTAPIClient(ctx, settings, cfg, host)
 	require.NoError(t, err)
 
-	data, metadata, err := client.GetNDJSON(ctx, server.URL, url.Values{})
+	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, url.Values{})
 	require.NoError(t, err)
 	require.Len(t, data, 0)
 	require.Empty(t, metadata)
@@ -830,7 +830,7 @@ func TestRESTAPIClient_GetNDJSON_MetadataOnly(t *testing.T) {
 	client, err := newRESTAPIClient(ctx, settings, cfg, host)
 	require.NoError(t, err)
 
-	data, metadata, err := client.GetNDJSON(ctx, server.URL, url.Values{})
+	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, url.Values{})
 	require.NoError(t, err)
 	require.Len(t, data, 0)
 	require.Equal(t, "xyz", metadata["offset"])
@@ -857,7 +857,7 @@ func TestRESTAPIClient_GetNDJSON_HTTPError(t *testing.T) {
 	client, err := newRESTAPIClient(ctx, settings, cfg, host)
 	require.NoError(t, err)
 
-	data, metadata, err := client.GetNDJSON(ctx, server.URL, url.Values{})
+	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, url.Values{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "403")
 	require.Nil(t, data)
@@ -934,6 +934,67 @@ func TestParseNDJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRESTAPIClient_GetNDJSON_ReturnsHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Next-Offset", "cursor-abc123")
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.Write([]byte(`{"id":"1"}` + "\n"))
+		w.Write([]byte(`{"offset":"body-offset"}` + "\n"))
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:          server.URL,
+		AuthMode:     authModeNone,
+		ClientConfig: confighttp.ClientConfig{},
+	}
+
+	ctx := context.Background()
+	host := componenttest.NewNopHost()
+	settings := componenttest.NewNopTelemetrySettings()
+
+	client, err := newRESTAPIClient(ctx, settings, cfg, host)
+	require.NoError(t, err)
+
+	data, metadata, headers, err := client.GetNDJSON(ctx, server.URL, url.Values{})
+	require.NoError(t, err)
+	require.Len(t, data, 1)
+	require.Equal(t, "body-offset", metadata["offset"])
+	require.Equal(t, "cursor-abc123", headers.Get("X-Next-Offset"))
+}
+
+func TestRESTAPIClient_GetFullResponse_ReturnsHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Next-Cursor", "page2")
+		w.Header().Set("Content-Type", "application/json")
+		response := map[string]any{
+			"data": []map[string]any{
+				{"id": "1"},
+			},
+		}
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:          server.URL,
+		AuthMode:     authModeNone,
+		ClientConfig: confighttp.ClientConfig{},
+	}
+
+	ctx := context.Background()
+	host := componenttest.NewNopHost()
+	settings := componenttest.NewNopTelemetrySettings()
+
+	client, err := newRESTAPIClient(ctx, settings, cfg, host)
+	require.NoError(t, err)
+
+	data, headers, err := client.GetFullResponse(ctx, server.URL, url.Values{})
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Equal(t, "page2", headers.Get("X-Next-Cursor"))
 }
 
 func TestRESTAPIClient_GetJSON_EmptyArray(t *testing.T) {

--- a/receiver/restapireceiver/client_test.go
+++ b/receiver/restapireceiver/client_test.go
@@ -772,7 +772,7 @@ func TestRESTAPIClient_GetNDJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	params := url.Values{}
-	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, params)
+	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, params, true)
 	require.NoError(t, err)
 	require.Len(t, data, 3)
 	require.Equal(t, "1", data[0]["id"])
@@ -803,7 +803,7 @@ func TestRESTAPIClient_GetNDJSON_EmptyResponse(t *testing.T) {
 	client, err := newRESTAPIClient(ctx, settings, cfg, host)
 	require.NoError(t, err)
 
-	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, url.Values{})
+	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, url.Values{}, true)
 	require.NoError(t, err)
 	require.Len(t, data, 0)
 	require.Empty(t, metadata)
@@ -830,7 +830,7 @@ func TestRESTAPIClient_GetNDJSON_MetadataOnly(t *testing.T) {
 	client, err := newRESTAPIClient(ctx, settings, cfg, host)
 	require.NoError(t, err)
 
-	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, url.Values{})
+	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, url.Values{}, true)
 	require.NoError(t, err)
 	require.Len(t, data, 0)
 	require.Equal(t, "xyz", metadata["offset"])
@@ -857,7 +857,7 @@ func TestRESTAPIClient_GetNDJSON_HTTPError(t *testing.T) {
 	client, err := newRESTAPIClient(ctx, settings, cfg, host)
 	require.NoError(t, err)
 
-	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, url.Values{})
+	data, metadata, _, err := client.GetNDJSON(ctx, server.URL, url.Values{}, true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "403")
 	require.Nil(t, data)
@@ -870,6 +870,7 @@ func TestParseNDJSON(t *testing.T) {
 	testCases := []struct {
 		name             string
 		body             string
+		metadataInBody   bool
 		expectedData     int
 		expectedMetadata map[string]any
 		expectErr        bool
@@ -877,63 +878,129 @@ func TestParseNDJSON(t *testing.T) {
 		{
 			name:             "empty body",
 			body:             "",
+			metadataInBody:   true,
 			expectedData:     0,
 			expectedMetadata: map[string]any{},
 		},
 		{
 			name:             "metadata only",
 			body:             `{"offset":"abc"}`,
+			metadataInBody:   true,
 			expectedData:     0,
 			expectedMetadata: map[string]any{"offset": "abc"},
 		},
 		{
-			name:         "data and metadata",
-			body:         "{\"id\":\"1\"}\n{\"id\":\"2\"}\n{\"offset\":\"next\",\"total\":2}",
-			expectedData: 2,
+			name:           "data and metadata",
+			body:           "{\"id\":\"1\"}\n{\"id\":\"2\"}\n{\"offset\":\"next\",\"total\":2}",
+			metadataInBody: true,
+			expectedData:   2,
 			expectedMetadata: map[string]any{
 				"offset": "next",
 				"total":  float64(2),
 			},
 		},
 		{
-			name:         "with blank lines",
-			body:         "{\"id\":\"1\"}\n\n{\"id\":\"2\"}\n\n{\"offset\":\"next\"}\n",
-			expectedData: 2,
+			name:           "with blank lines",
+			body:           "{\"id\":\"1\"}\n\n{\"id\":\"2\"}\n\n{\"offset\":\"next\"}\n",
+			metadataInBody: true,
+			expectedData:   2,
 			expectedMetadata: map[string]any{
 				"offset": "next",
 			},
 		},
 		{
-			name:      "invalid metadata line",
-			body:      "{\"id\":\"1\"}\nnot-json",
-			expectErr: true,
+			name:           "invalid metadata line",
+			body:           "{\"id\":\"1\"}\nnot-json",
+			metadataInBody: true,
+			expectErr:      true,
 		},
 		{
-			name:         "invalid data line is skipped",
-			body:         "not-json\n{\"id\":\"1\"}\n{\"offset\":\"abc\"}",
-			expectedData: 1,
+			name:           "invalid data line is skipped",
+			body:           "not-json\n{\"id\":\"1\"}\n{\"offset\":\"abc\"}",
+			metadataInBody: true,
+			expectedData:   1,
 			expectedMetadata: map[string]any{
 				"offset": "abc",
 			},
+		},
+		{
+			name:           "metadata in header - all lines are data",
+			body:           "{\"id\":\"1\"}\n{\"id\":\"2\"}\n{\"id\":\"3\"}",
+			metadataInBody: false,
+			expectedData:   3,
+		},
+		{
+			name:           "metadata in header - single line is data not metadata",
+			body:           `{"offset":"abc","total":5}`,
+			metadataInBody: false,
+			expectedData:   1,
+		},
+		{
+			name:           "metadata in header - empty body",
+			body:           "",
+			metadataInBody: false,
+			expectedData:   0,
+		},
+		{
+			name:           "metadata in header - invalid line is skipped",
+			body:           "not-json\n{\"id\":\"1\"}\n{\"id\":\"2\"}",
+			metadataInBody: false,
+			expectedData:   2,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			data, metadata, err := parseNDJSON([]byte(tc.body), logger)
+			data, metadata, err := parseNDJSON([]byte(tc.body), tc.metadataInBody, logger)
 			if tc.expectErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 			require.Len(t, data, tc.expectedData)
-			if tc.expectedMetadata != nil {
+			if !tc.metadataInBody && tc.expectedData > 0 {
+				require.Nil(t, metadata)
+			} else if tc.expectedMetadata != nil {
 				for k, v := range tc.expectedMetadata {
 					require.Equal(t, v, metadata[k])
 				}
 			}
 		})
 	}
+}
+
+func TestRESTAPIClient_GetNDJSON_MetadataInHeader(t *testing.T) {
+	// When metadataInBody is false, all lines are data — none are stripped as metadata.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.Header().Set("X-Next-Offset", "abc123")
+		w.Write([]byte(`{"id":"1","message":"event1"}` + "\n"))
+		w.Write([]byte(`{"id":"2","message":"event2"}` + "\n"))
+		w.Write([]byte(`{"id":"3","message":"event3"}` + "\n"))
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:          server.URL,
+		AuthMode:     authModeNone,
+		ClientConfig: confighttp.ClientConfig{},
+	}
+
+	ctx := context.Background()
+	host := componenttest.NewNopHost()
+	settings := componenttest.NewNopTelemetrySettings()
+
+	client, err := newRESTAPIClient(ctx, settings, cfg, host)
+	require.NoError(t, err)
+
+	data, metadata, headers, err := client.GetNDJSON(ctx, server.URL, url.Values{}, false)
+	require.NoError(t, err)
+	require.Len(t, data, 3)
+	require.Equal(t, "1", data[0]["id"])
+	require.Equal(t, "2", data[1]["id"])
+	require.Equal(t, "3", data[2]["id"])
+	require.Nil(t, metadata)
+	require.Equal(t, "abc123", headers.Get("X-Next-Offset"))
 }
 
 func TestRESTAPIClient_GetNDJSON_ReturnsHeaders(t *testing.T) {
@@ -958,7 +1025,7 @@ func TestRESTAPIClient_GetNDJSON_ReturnsHeaders(t *testing.T) {
 	client, err := newRESTAPIClient(ctx, settings, cfg, host)
 	require.NoError(t, err)
 
-	data, metadata, headers, err := client.GetNDJSON(ctx, server.URL, url.Values{})
+	data, metadata, headers, err := client.GetNDJSON(ctx, server.URL, url.Values{}, true)
 	require.NoError(t, err)
 	require.Len(t, data, 1)
 	require.Equal(t, "body-offset", metadata["offset"])

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -60,6 +60,26 @@ func (m *AuthMode) UnmarshalText(text []byte) error {
 	}
 }
 
+// ResponseFormat defines the response format for the REST API receiver.
+type ResponseFormat string
+
+const (
+	responseFormatJSON   ResponseFormat = "json"
+	responseFormatNDJSON ResponseFormat = "ndjson"
+)
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface
+func (f *ResponseFormat) UnmarshalText(text []byte) error {
+	format := ResponseFormat(text)
+	switch format {
+	case responseFormatJSON, responseFormatNDJSON:
+		*f = format
+		return nil
+	default:
+		return fmt.Errorf("invalid response_format: %s, must be one of: json, ndjson", text)
+	}
+}
+
 // PaginationMode defines the pagination mode for the REST API receiver.
 type PaginationMode string
 
@@ -87,8 +107,16 @@ type Config struct {
 	// URL is the base URL for the REST API endpoint (required).
 	URL string `mapstructure:"url"`
 
+	// ResponseFormat defines the format of the API response body.
+	// "json" (default): standard JSON array or object with a data field.
+	// "ndjson": newline-delimited JSON where each line is a separate JSON object.
+	//   In NDJSON mode, the last line is treated as metadata (e.g., containing pagination cursors)
+	//   and is not included in the data output.
+	ResponseFormat ResponseFormat `mapstructure:"response_format"`
+
 	// ResponseField is the name of the field in the response that contains the array of items.
 	// If empty, the response is assumed to be a top-level array.
+	// Not used when response_format is "ndjson".
 	ResponseField string `mapstructure:"response_field"`
 
 	// Auth defines authentication configuration.
@@ -297,6 +325,19 @@ type TimestampPagination struct {
 func (c *Config) Validate() error {
 	if c.URL == "" {
 		return fmt.Errorf("url is required")
+	}
+
+	// Apply default response format
+	if c.ResponseFormat == "" {
+		c.ResponseFormat = responseFormatJSON
+	}
+
+	// Validate response format
+	switch c.ResponseFormat {
+	case responseFormatJSON, responseFormatNDJSON:
+		// Valid formats
+	default:
+		return fmt.Errorf("invalid response_format: %s, must be one of: json, ndjson", c.ResponseFormat)
 	}
 
 	// Validate auth

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -80,6 +80,26 @@ func (f *ResponseFormat) UnmarshalText(text []byte) error {
 	}
 }
 
+// OffsetSource defines where the next offset value is extracted from.
+type OffsetSource string
+
+const (
+	offsetSourceBody   OffsetSource = "body"
+	offsetSourceHeader OffsetSource = "header"
+)
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface
+func (s *OffsetSource) UnmarshalText(text []byte) error {
+	src := OffsetSource(text)
+	switch src {
+	case offsetSourceBody, offsetSourceHeader:
+		*s = src
+		return nil
+	default:
+		return fmt.Errorf("invalid next_offset_source: %s, must be one of: body, header", text)
+	}
+}
+
 // PaginationMode defines the pagination mode for the REST API receiver.
 type PaginationMode string
 
@@ -267,9 +287,15 @@ type OffsetLimitPagination struct {
 	// LimitFieldName is the name of the query parameter for limit.
 	LimitFieldName string `mapstructure:"limit_field_name"`
 
-	// NextOffsetFieldName is the name of the field in the response that contains the next offset token.
+	// NextOffsetFieldName is the name of the field or header that contains the next offset token.
 	// When set, the receiver uses token-based (cursor) pagination instead of numeric offsets.
+	// Where the value is extracted from depends on next_offset_source.
 	NextOffsetFieldName string `mapstructure:"next_offset_field_name"`
+
+	// NextOffsetSource controls where the next offset token is extracted from.
+	// "body" (default): extract from the response body (or NDJSON metadata line).
+	// "header": extract from an HTTP response header.
+	NextOffsetSource OffsetSource `mapstructure:"next_offset_source"`
 }
 
 // PageSizePagination defines page/size pagination configuration.
@@ -458,6 +484,21 @@ func (c *Config) Validate() error {
 		}
 		if c.Pagination.OffsetLimit.LimitFieldName == "" {
 			return fmt.Errorf("limit_field_name is required when pagination.mode is offset_limit")
+		}
+		// Default next_offset_source to body
+		if c.Pagination.OffsetLimit.NextOffsetSource == "" {
+			c.Pagination.OffsetLimit.NextOffsetSource = offsetSourceBody
+		}
+		// Validate next_offset_source
+		switch c.Pagination.OffsetLimit.NextOffsetSource {
+		case offsetSourceBody, offsetSourceHeader:
+			// Valid
+		default:
+			return fmt.Errorf("invalid next_offset_source: %s, must be one of: body, header", c.Pagination.OffsetLimit.NextOffsetSource)
+		}
+		// next_offset_field_name is required when next_offset_source is header
+		if c.Pagination.OffsetLimit.NextOffsetSource == offsetSourceHeader && c.Pagination.OffsetLimit.NextOffsetFieldName == "" {
+			return fmt.Errorf("next_offset_field_name is required when next_offset_source is header")
 		}
 	case paginationModePageSize:
 		if c.Pagination.PageSize.PageNumFieldName == "" {

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -80,23 +80,23 @@ func (f *ResponseFormat) UnmarshalText(text []byte) error {
 	}
 }
 
-// OffsetSource defines where the next offset value is extracted from.
-type OffsetSource string
+// ResponseSource defines where pagination response attributes are extracted from.
+type ResponseSource string
 
 const (
-	offsetSourceBody   OffsetSource = "body"
-	offsetSourceHeader OffsetSource = "header"
+	responseSourceBody   ResponseSource = "body"
+	responseSourceHeader ResponseSource = "header"
 )
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface
-func (s *OffsetSource) UnmarshalText(text []byte) error {
-	src := OffsetSource(text)
+func (s *ResponseSource) UnmarshalText(text []byte) error {
+	src := ResponseSource(text)
 	switch src {
-	case offsetSourceBody, offsetSourceHeader:
+	case responseSourceBody, responseSourceHeader:
 		*s = src
 		return nil
 	default:
-		return fmt.Errorf("invalid next_offset_source: %s, must be one of: body, header", text)
+		return fmt.Errorf("invalid response_source: %s, must be one of: body, header", text)
 	}
 }
 
@@ -257,6 +257,13 @@ type PaginationConfig struct {
 	// Mode is the pagination mode: "none", "offset_limit", or "page_size".
 	Mode PaginationMode `mapstructure:"mode"`
 
+	// ResponseSource controls where pagination response attributes are extracted from.
+	// "body" (default): extract from the response body (or NDJSON metadata line).
+	// "header": extract from HTTP response headers.
+	// Affects all response-based pagination fields: next_offset_field_name,
+	// total_record_count_field, and total_pages_field_name.
+	ResponseSource ResponseSource `mapstructure:"response_source"`
+
 	// OffsetLimit defines offset/limit pagination.
 	OffsetLimit OffsetLimitPagination `mapstructure:"offset_limit"`
 
@@ -266,7 +273,7 @@ type PaginationConfig struct {
 	// Timestamp defines timestamp-based pagination.
 	Timestamp TimestampPagination `mapstructure:"timestamp"`
 
-	// TotalRecordCountField is the name of the field in the response that contains the total record count.
+	// TotalRecordCountField is the name of the field or header that contains the total record count.
 	TotalRecordCountField string `mapstructure:"total_record_count_field"`
 
 	// PageLimit is the maximum number of pages to fetch (0 = no limit).
@@ -289,13 +296,8 @@ type OffsetLimitPagination struct {
 
 	// NextOffsetFieldName is the name of the field or header that contains the next offset token.
 	// When set, the receiver uses token-based (cursor) pagination instead of numeric offsets.
-	// Where the value is extracted from depends on next_offset_source.
+	// Where the value is extracted from depends on pagination.response_source.
 	NextOffsetFieldName string `mapstructure:"next_offset_field_name"`
-
-	// NextOffsetSource controls where the next offset token is extracted from.
-	// "body" (default): extract from the response body (or NDJSON metadata line).
-	// "header": extract from an HTTP response header.
-	NextOffsetSource OffsetSource `mapstructure:"next_offset_source"`
 }
 
 // PageSizePagination defines page/size pagination configuration.
@@ -476,6 +478,19 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid pagination mode: %s, must be one of: none, offset_limit, page_size, timestamp", c.Pagination.Mode)
 	}
 
+	// Default response_source to body
+	if c.Pagination.ResponseSource == "" {
+		c.Pagination.ResponseSource = responseSourceBody
+	}
+
+	// Validate response_source
+	switch c.Pagination.ResponseSource {
+	case responseSourceBody, responseSourceHeader:
+		// Valid
+	default:
+		return fmt.Errorf("invalid response_source: %s, must be one of: body, header", c.Pagination.ResponseSource)
+	}
+
 	// Validate pagination mode specific requirements
 	switch c.Pagination.Mode {
 	case paginationModeOffsetLimit:
@@ -485,20 +500,9 @@ func (c *Config) Validate() error {
 		if c.Pagination.OffsetLimit.LimitFieldName == "" {
 			return fmt.Errorf("limit_field_name is required when pagination.mode is offset_limit")
 		}
-		// Default next_offset_source to body
-		if c.Pagination.OffsetLimit.NextOffsetSource == "" {
-			c.Pagination.OffsetLimit.NextOffsetSource = offsetSourceBody
-		}
-		// Validate next_offset_source
-		switch c.Pagination.OffsetLimit.NextOffsetSource {
-		case offsetSourceBody, offsetSourceHeader:
-			// Valid
-		default:
-			return fmt.Errorf("invalid next_offset_source: %s, must be one of: body, header", c.Pagination.OffsetLimit.NextOffsetSource)
-		}
-		// next_offset_field_name is required when next_offset_source is header
-		if c.Pagination.OffsetLimit.NextOffsetSource == offsetSourceHeader && c.Pagination.OffsetLimit.NextOffsetFieldName == "" {
-			return fmt.Errorf("next_offset_field_name is required when next_offset_source is header")
+		// next_offset_field_name is required when response_source is header
+		if c.Pagination.ResponseSource == responseSourceHeader && c.Pagination.OffsetLimit.NextOffsetFieldName == "" {
+			return fmt.Errorf("next_offset_field_name is required when response_source is header")
 		}
 	case paginationModePageSize:
 		if c.Pagination.PageSize.PageNumFieldName == "" {

--- a/receiver/restapireceiver/config_test.go
+++ b/receiver/restapireceiver/config_test.go
@@ -464,37 +464,54 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
-			name: "valid offset_limit with header source",
+			name: "valid offset_limit with header response_source",
 			config: &Config{
 				URL:      "https://api.example.com/data",
 				AuthMode: authModeNone,
 				Pagination: PaginationConfig{
-					Mode: paginationModeOffsetLimit,
+					Mode:           paginationModeOffsetLimit,
+					ResponseSource: responseSourceHeader,
 					OffsetLimit: OffsetLimitPagination{
 						OffsetFieldName:     "offset",
 						LimitFieldName:      "limit",
 						NextOffsetFieldName: "X-Next-Offset",
-						NextOffsetSource:    offsetSourceHeader,
 					},
 				},
 			},
 			expectedErr: "",
 		},
 		{
-			name: "header source requires next_offset_field_name",
+			name: "header response_source requires next_offset_field_name for offset_limit",
 			config: &Config{
 				URL:      "https://api.example.com/data",
 				AuthMode: authModeNone,
 				Pagination: PaginationConfig{
-					Mode: paginationModeOffsetLimit,
+					Mode:           paginationModeOffsetLimit,
+					ResponseSource: responseSourceHeader,
 					OffsetLimit: OffsetLimitPagination{
-						OffsetFieldName:  "offset",
-						LimitFieldName:   "limit",
-						NextOffsetSource: offsetSourceHeader,
+						OffsetFieldName: "offset",
+						LimitFieldName:  "limit",
 					},
 				},
 			},
-			expectedErr: "next_offset_field_name is required when next_offset_source is header",
+			expectedErr: "next_offset_field_name is required when response_source is header",
+		},
+		{
+			name: "valid page_size with header response_source",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeNone,
+				Pagination: PaginationConfig{
+					Mode:           paginationModePageSize,
+					ResponseSource: responseSourceHeader,
+					PageSize: PageSizePagination{
+						PageNumFieldName:    "page",
+						PageSizeFieldName:   "per_page",
+						TotalPagesFieldName: "X-Total-Pages",
+					},
+				},
+			},
+			expectedErr: "",
 		},
 		{
 			name: "page_size pagination missing page num field name",

--- a/receiver/restapireceiver/config_test.go
+++ b/receiver/restapireceiver/config_test.go
@@ -464,6 +464,39 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			name: "valid offset_limit with header source",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeNone,
+				Pagination: PaginationConfig{
+					Mode: paginationModeOffsetLimit,
+					OffsetLimit: OffsetLimitPagination{
+						OffsetFieldName:     "offset",
+						LimitFieldName:      "limit",
+						NextOffsetFieldName: "X-Next-Offset",
+						NextOffsetSource:    offsetSourceHeader,
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "header source requires next_offset_field_name",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeNone,
+				Pagination: PaginationConfig{
+					Mode: paginationModeOffsetLimit,
+					OffsetLimit: OffsetLimitPagination{
+						OffsetFieldName:  "offset",
+						LimitFieldName:   "limit",
+						NextOffsetSource: offsetSourceHeader,
+					},
+				},
+			},
+			expectedErr: "next_offset_field_name is required when next_offset_source is header",
+		},
+		{
 			name: "page_size pagination missing page num field name",
 			config: &Config{
 				URL:      "https://api.example.com/data",

--- a/receiver/restapireceiver/config_test.go
+++ b/receiver/restapireceiver/config_test.go
@@ -367,6 +367,30 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			name: "valid ndjson response format",
+			config: &Config{
+				URL:            "https://api.example.com/data",
+				ResponseFormat: responseFormatNDJSON,
+				AuthMode:       authModeNone,
+				Pagination: PaginationConfig{
+					Mode: paginationModeNone,
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "invalid response format",
+			config: &Config{
+				URL:            "https://api.example.com/data",
+				ResponseFormat: ResponseFormat("xml"),
+				AuthMode:       authModeNone,
+				Pagination: PaginationConfig{
+					Mode: paginationModeNone,
+				},
+			},
+			expectedErr: "invalid response_format: xml, must be one of: json, ndjson",
+		},
+		{
 			name: "invalid pagination mode",
 			config: &Config{
 				URL:      "https://api.example.com/data",

--- a/receiver/restapireceiver/pagination.go
+++ b/receiver/restapireceiver/pagination.go
@@ -18,11 +18,28 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
 	"go.uber.org/zap"
 )
+
+// toInt coerces a value to int, handling float64, int, and string.
+// Returns (value, true) on success, (0, false) if the value cannot be converted.
+func toInt(v any) (int, bool) {
+	switch val := v.(type) {
+	case float64:
+		return int(val), true
+	case int:
+		return val, true
+	case string:
+		n, err := strconv.Atoi(val)
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}
 
 // paginationState tracks the current state of pagination.
 type paginationState struct {
@@ -260,9 +277,7 @@ func parseOffsetLimitResponse(cfg *Config, response any, extractedData []map[str
 	if cfg.Pagination.TotalRecordCountField != "" {
 		if responseMap, ok := response.(map[string]any); ok {
 			if totalVal, exists := responseMap[cfg.Pagination.TotalRecordCountField]; exists {
-				if total, ok := totalVal.(float64); ok {
-					state.TotalRecords = int(total)
-				} else if total, ok := totalVal.(int); ok {
+				if total, ok := toInt(totalVal); ok {
 					state.TotalRecords = total
 				}
 			}
@@ -294,9 +309,7 @@ func parsePageSizeResponse(cfg *Config, response any, extractedData []map[string
 	if cfg.Pagination.PageSize.TotalPagesFieldName != "" {
 		if responseMap, ok := response.(map[string]any); ok {
 			if totalPagesVal, exists := responseMap[cfg.Pagination.PageSize.TotalPagesFieldName]; exists {
-				if totalPages, ok := totalPagesVal.(float64); ok {
-					state.TotalPages = int(totalPages)
-				} else if totalPages, ok := totalPagesVal.(int); ok {
+				if totalPages, ok := toInt(totalPagesVal); ok {
 					state.TotalPages = totalPages
 				}
 			}

--- a/receiver/restapireceiver/receiver.go
+++ b/receiver/restapireceiver/receiver.go
@@ -189,8 +189,18 @@ func (b *baseReceiver) saveCheckpoint(ctx context.Context) error {
 }
 
 // fetchDataPage fetches a single page of data from the API.
-// Returns the full response, extracted data, and any error.
+// Returns the response metadata (for pagination), extracted data, and any error.
+// For NDJSON format, the metadata is the last line of the response.
+// For JSON format, the metadata is the full response object.
 func (b *baseReceiver) fetchDataPage(ctx context.Context, requestURL string, params url.Values) (map[string]any, []map[string]any, error) {
+	if b.cfg.ResponseFormat == responseFormatNDJSON {
+		data, metadata, err := b.client.GetNDJSON(ctx, requestURL, params)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get NDJSON response: %w", err)
+		}
+		return metadata, data, nil
+	}
+
 	fullResponse, err := b.client.GetFullResponse(ctx, requestURL, params)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get full response: %w", err)

--- a/receiver/restapireceiver/receiver.go
+++ b/receiver/restapireceiver/receiver.go
@@ -200,7 +200,8 @@ func (b *baseReceiver) fetchDataPage(ctx context.Context, requestURL string, par
 
 	if b.cfg.ResponseFormat == responseFormatNDJSON {
 		var err error
-		data, metadata, respHeaders, err = b.client.GetNDJSON(ctx, requestURL, params)
+		metadataInBody := b.cfg.Pagination.ResponseSource != responseSourceHeader
+		data, metadata, respHeaders, err = b.client.GetNDJSON(ctx, requestURL, params, metadataInBody)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get NDJSON response: %w", err)
 		}

--- a/receiver/restapireceiver/receiver.go
+++ b/receiver/restapireceiver/receiver.go
@@ -191,8 +191,8 @@ func (b *baseReceiver) saveCheckpoint(ctx context.Context) error {
 
 // fetchDataPage fetches a single page of data from the API.
 // Returns the response metadata (for pagination), extracted data, and any error.
-// When next_offset_source is "header", the offset value is extracted from the
-// response header and injected into the metadata map for the pagination logic.
+// When response_source is "header", pagination attributes are extracted from
+// response headers and injected into the metadata map for the pagination logic.
 func (b *baseReceiver) fetchDataPage(ctx context.Context, requestURL string, params url.Values) (map[string]any, []map[string]any, error) {
 	var metadata map[string]any
 	var data []map[string]any
@@ -213,22 +213,47 @@ func (b *baseReceiver) fetchDataPage(ctx context.Context, requestURL string, par
 		data = extractDataFromResponse(metadata, b.cfg.ResponseField, b.logger)
 	}
 
-	// When the next offset is sourced from a response header, extract the header
-	// value and inject it into the metadata map so the pagination logic can find it
-	// via the standard next_offset_field_name path.
-	if b.cfg.Pagination.Mode == paginationModeOffsetLimit &&
-		b.cfg.Pagination.OffsetLimit.NextOffsetSource == offsetSourceHeader &&
-		b.cfg.Pagination.OffsetLimit.NextOffsetFieldName != "" {
-		headerVal := respHeaders.Get(b.cfg.Pagination.OffsetLimit.NextOffsetFieldName)
+	// When response_source is "header", extract configured pagination fields from
+	// response headers and inject them into the metadata map. This lets the
+	// pagination logic find them through the same field-name lookup it uses for body
+	// attributes — no changes needed downstream.
+	if b.cfg.Pagination.ResponseSource == responseSourceHeader {
 		if metadata == nil {
 			metadata = make(map[string]any)
 		}
-		if headerVal != "" {
-			metadata[b.cfg.Pagination.OffsetLimit.NextOffsetFieldName] = headerVal
+		for _, fieldName := range b.paginationResponseFields() {
+			if headerVal := respHeaders.Get(fieldName); headerVal != "" {
+				metadata[fieldName] = headerVal
+			}
 		}
 	}
 
 	return metadata, data, nil
+}
+
+// paginationResponseFields returns the names of all configured pagination fields
+// that are read from the response (body or header). These are the fields that
+// need to be injected when response_source is "header".
+func (b *baseReceiver) paginationResponseFields() []string {
+	var fields []string
+
+	// Fields used across multiple pagination modes
+	if b.cfg.Pagination.TotalRecordCountField != "" {
+		fields = append(fields, b.cfg.Pagination.TotalRecordCountField)
+	}
+
+	switch b.cfg.Pagination.Mode {
+	case paginationModeOffsetLimit:
+		if b.cfg.Pagination.OffsetLimit.NextOffsetFieldName != "" {
+			fields = append(fields, b.cfg.Pagination.OffsetLimit.NextOffsetFieldName)
+		}
+	case paginationModePageSize:
+		if b.cfg.Pagination.PageSize.TotalPagesFieldName != "" {
+			fields = append(fields, b.cfg.Pagination.PageSize.TotalPagesFieldName)
+		}
+	}
+
+	return fields
 }
 
 // handlePagination checks if there are more pages and updates pagination state.

--- a/receiver/restapireceiver/receiver.go
+++ b/receiver/restapireceiver/receiver.go
@@ -17,6 +17,7 @@ package restapireceiver
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"sync"
@@ -190,24 +191,44 @@ func (b *baseReceiver) saveCheckpoint(ctx context.Context) error {
 
 // fetchDataPage fetches a single page of data from the API.
 // Returns the response metadata (for pagination), extracted data, and any error.
-// For NDJSON format, the metadata is the last line of the response.
-// For JSON format, the metadata is the full response object.
+// When next_offset_source is "header", the offset value is extracted from the
+// response header and injected into the metadata map for the pagination logic.
 func (b *baseReceiver) fetchDataPage(ctx context.Context, requestURL string, params url.Values) (map[string]any, []map[string]any, error) {
+	var metadata map[string]any
+	var data []map[string]any
+	var respHeaders http.Header
+
 	if b.cfg.ResponseFormat == responseFormatNDJSON {
-		data, metadata, err := b.client.GetNDJSON(ctx, requestURL, params)
+		var err error
+		data, metadata, respHeaders, err = b.client.GetNDJSON(ctx, requestURL, params)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get NDJSON response: %w", err)
 		}
-		return metadata, data, nil
+	} else {
+		var err error
+		metadata, respHeaders, err = b.client.GetFullResponse(ctx, requestURL, params)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get full response: %w", err)
+		}
+		data = extractDataFromResponse(metadata, b.cfg.ResponseField, b.logger)
 	}
 
-	fullResponse, err := b.client.GetFullResponse(ctx, requestURL, params)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get full response: %w", err)
+	// When the next offset is sourced from a response header, extract the header
+	// value and inject it into the metadata map so the pagination logic can find it
+	// via the standard next_offset_field_name path.
+	if b.cfg.Pagination.Mode == paginationModeOffsetLimit &&
+		b.cfg.Pagination.OffsetLimit.NextOffsetSource == offsetSourceHeader &&
+		b.cfg.Pagination.OffsetLimit.NextOffsetFieldName != "" {
+		headerVal := respHeaders.Get(b.cfg.Pagination.OffsetLimit.NextOffsetFieldName)
+		if metadata == nil {
+			metadata = make(map[string]any)
+		}
+		if headerVal != "" {
+			metadata[b.cfg.Pagination.OffsetLimit.NextOffsetFieldName] = headerVal
+		}
 	}
 
-	data := extractDataFromResponse(fullResponse, b.cfg.ResponseField, b.logger)
-	return fullResponse, data, nil
+	return metadata, data, nil
 }
 
 // handlePagination checks if there are more pages and updates pagination state.

--- a/receiver/restapireceiver/receiver_test.go
+++ b/receiver/restapireceiver/receiver_test.go
@@ -671,6 +671,154 @@ func TestRESTAPILogsReceiver_AdaptivePolling_PageLimitResetsInterval(t *testing.
 	require.Greater(t, int(requestCount.Load()), 4, "expected many polls when page limit is hit (interval should stay at min)")
 }
 
+func TestRESTAPILogsReceiver_NDJSONWithBodyOffset(t *testing.T) {
+	// Simulates an API like Akamai SIEM: NDJSON with offset in the last line (body).
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		offset := r.URL.Query().Get("offset")
+		w.Header().Set("Content-Type", "application/x-ndjson")
+
+		if offset == "" || offset == "0" {
+			// First page: 2 events + metadata with offset cursor
+			w.Write([]byte(`{"id":"1","message":"event1"}` + "\n"))
+			w.Write([]byte(`{"id":"2","message":"event2"}` + "\n"))
+			w.Write([]byte(`{"offset":"cursor-page2","total":2}` + "\n"))
+		} else {
+			// Second page: 0 events + metadata (no more data)
+			w.Write([]byte(`{"offset":"cursor-page2","total":0}` + "\n"))
+		}
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:            server.URL,
+		ResponseFormat: responseFormatNDJSON,
+		AuthMode:       authModeNone,
+		Pagination: PaginationConfig{
+			Mode: paginationModeOffsetLimit,
+			OffsetLimit: OffsetLimitPagination{
+				OffsetFieldName:     "offset",
+				LimitFieldName:      "limit",
+				NextOffsetFieldName: "offset",
+			},
+		},
+		MaxPollInterval: 100 * time.Millisecond,
+		ClientConfig:    confighttp.ClientConfig{},
+	}
+
+	sink := new(consumertest.LogsSink)
+	params := receivertest.NewNopSettings(metadata.Type)
+	receiver, err := newRESTAPILogsReceiver(params, cfg, sink)
+	require.NoError(t, err)
+
+	host := componenttest.NewNopHost()
+	ctx := context.Background()
+
+	err = receiver.Start(ctx, host)
+	require.NoError(t, err)
+
+	time.Sleep(300 * time.Millisecond)
+
+	err = receiver.Shutdown(ctx)
+	require.NoError(t, err)
+
+	allLogs := sink.AllLogs()
+	require.Greater(t, len(allLogs), 0)
+
+	totalRecords := 0
+	for _, logs := range allLogs {
+		totalRecords += logs.LogRecordCount()
+	}
+	require.GreaterOrEqual(t, totalRecords, 2)
+}
+
+func TestRESTAPILogsReceiver_HeaderBasedOffset(t *testing.T) {
+	// Tests offset extraction from a response header instead of the body.
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := requestCount.Add(1)
+		offset := r.URL.Query().Get("cursor")
+
+		if offset == "" || offset == "0" {
+			// First page: return data with offset in header
+			w.Header().Set("X-Next-Cursor", "page2-token")
+			response := []map[string]any{
+				{"id": "1"},
+				{"id": "2"},
+				{"id": "3"},
+				{"id": "4"},
+				{"id": "5"},
+				{"id": "6"},
+				{"id": "7"},
+				{"id": "8"},
+				{"id": "9"},
+				{"id": "10"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+		} else if offset == "page2-token" && page <= 3 {
+			// Second page: return partial page (fewer than limit), no next header
+			response := []map[string]any{
+				{"id": "11"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+		} else {
+			// Empty
+			response := []map[string]any{}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:      server.URL,
+		AuthMode: authModeNone,
+		Pagination: PaginationConfig{
+			Mode: paginationModeOffsetLimit,
+			OffsetLimit: OffsetLimitPagination{
+				OffsetFieldName:     "cursor",
+				LimitFieldName:      "limit",
+				NextOffsetFieldName: "X-Next-Cursor",
+				NextOffsetSource:    offsetSourceHeader,
+			},
+		},
+		MaxPollInterval: 100 * time.Millisecond,
+		ClientConfig:    confighttp.ClientConfig{},
+	}
+
+	sink := new(consumertest.LogsSink)
+	params := receivertest.NewNopSettings(metadata.Type)
+	receiver, err := newRESTAPILogsReceiver(params, cfg, sink)
+	require.NoError(t, err)
+
+	host := componenttest.NewNopHost()
+	ctx := context.Background()
+
+	err = receiver.Start(ctx, host)
+	require.NoError(t, err)
+
+	time.Sleep(300 * time.Millisecond)
+
+	err = receiver.Shutdown(ctx)
+	require.NoError(t, err)
+
+	allLogs := sink.AllLogs()
+	require.Greater(t, len(allLogs), 0)
+
+	totalRecords := 0
+	for _, logs := range allLogs {
+		totalRecords += logs.LogRecordCount()
+	}
+	// Should have received at least 11 records (10 from page1 + 1 from page2)
+	require.GreaterOrEqual(t, totalRecords, 11)
+
+	// Should have fetched at least 2 pages
+	require.GreaterOrEqual(t, int(requestCount.Load()), 2)
+}
+
 func TestGetNestedField(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/receiver/restapireceiver/receiver_test.go
+++ b/receiver/restapireceiver/receiver_test.go
@@ -824,7 +824,7 @@ func TestRESTAPILogsReceiver_HeaderBasedTotalCount(t *testing.T) {
 	// The server returns the total count in a header, and the receiver uses it
 	// to know when to stop paginating.
 	var requestCount atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		page := requestCount.Add(1)
 		w.Header().Set("X-Total-Count", "4")
 		w.Header().Set("Content-Type", "application/json")

--- a/receiver/restapireceiver/receiver_test.go
+++ b/receiver/restapireceiver/receiver_test.go
@@ -777,12 +777,12 @@ func TestRESTAPILogsReceiver_HeaderBasedOffset(t *testing.T) {
 		URL:      server.URL,
 		AuthMode: authModeNone,
 		Pagination: PaginationConfig{
-			Mode: paginationModeOffsetLimit,
+			Mode:           paginationModeOffsetLimit,
+			ResponseSource: responseSourceHeader,
 			OffsetLimit: OffsetLimitPagination{
 				OffsetFieldName:     "cursor",
 				LimitFieldName:      "limit",
 				NextOffsetFieldName: "X-Next-Cursor",
-				NextOffsetSource:    offsetSourceHeader,
 			},
 		},
 		MaxPollInterval: 100 * time.Millisecond,
@@ -817,6 +817,78 @@ func TestRESTAPILogsReceiver_HeaderBasedOffset(t *testing.T) {
 
 	// Should have fetched at least 2 pages
 	require.GreaterOrEqual(t, int(requestCount.Load()), 2)
+}
+
+func TestRESTAPILogsReceiver_HeaderBasedTotalCount(t *testing.T) {
+	// Tests that total_record_count_field works when sourced from a header.
+	// The server returns the total count in a header, and the receiver uses it
+	// to know when to stop paginating.
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := requestCount.Add(1)
+		w.Header().Set("X-Total-Count", "4")
+		w.Header().Set("Content-Type", "application/json")
+
+		if page == 1 {
+			response := []map[string]any{
+				{"id": "1"},
+				{"id": "2"},
+			}
+			json.NewEncoder(w).Encode(response)
+		} else if page == 2 {
+			response := []map[string]any{
+				{"id": "3"},
+				{"id": "4"},
+			}
+			json.NewEncoder(w).Encode(response)
+		} else {
+			json.NewEncoder(w).Encode([]map[string]any{})
+		}
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:      server.URL,
+		AuthMode: authModeNone,
+		Pagination: PaginationConfig{
+			Mode:                  paginationModeOffsetLimit,
+			ResponseSource:        responseSourceHeader,
+			TotalRecordCountField: "X-Total-Count",
+			OffsetLimit: OffsetLimitPagination{
+				OffsetFieldName: "offset",
+				LimitFieldName:  "limit",
+				// No next_offset_field_name — using numeric offset + total count from header
+			},
+		},
+		MaxPollInterval: 100 * time.Millisecond,
+		ClientConfig:    confighttp.ClientConfig{},
+	}
+
+	sink := new(consumertest.LogsSink)
+	params := receivertest.NewNopSettings(metadata.Type)
+	receiver, err := newRESTAPILogsReceiver(params, cfg, sink)
+	require.NoError(t, err)
+
+	host := componenttest.NewNopHost()
+	ctx := context.Background()
+
+	err = receiver.Start(ctx, host)
+	require.NoError(t, err)
+
+	time.Sleep(300 * time.Millisecond)
+
+	err = receiver.Shutdown(ctx)
+	require.NoError(t, err)
+
+	allLogs := sink.AllLogs()
+	require.Greater(t, len(allLogs), 0)
+
+	totalRecords := 0
+	for _, logs := range allLogs {
+		totalRecords += logs.LogRecordCount()
+	}
+	// Should have 4 records from 2 pages
+	require.GreaterOrEqual(t, totalRecords, 4)
 }
 
 func TestGetNestedField(t *testing.T) {


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Not every API returns a nice JSON object, some do newline delimited JSON. In those cases, pagination metadata will often be returned in a completely separate response, or in the response header.

This PR adds 2 new configuration options:
- specify the returned data format (json or ndjson)
- specify where to extract pagination metadata (body or header) 

Tested these changes against a mock api modeled after the Akamai SIEM API that returns ndjson, using token pagination, with the pagination metadata in a separate response (mock api source code and receiver config available upon request).

##### Checklist
- [x] Changes are tested
- [ ] CI has passed