### PR TITLE
feat: Expand OCSF `int` coercion

### DIFF
--- a/processor/ocsfstandardizationprocessor/type_coerce.go
+++ b/processor/ocsfstandardizationprocessor/type_coerce.go
@@ -50,8 +50,8 @@ func coerceToInt(value any) any {
 	case float64:
 		return int(v)
 	case string:
-		if i, err := strconv.Atoi(v); err == nil {
-			return i
+		if i, err := strconv.ParseInt(v, 0, 64); err == nil {
+			return int(i)
 		}
 		return value
 	case bool:
@@ -73,7 +73,7 @@ func coerceToInt64(value any) any {
 	case float64:
 		return int64(v)
 	case string:
-		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+		if i, err := strconv.ParseInt(v, 0, 64); err == nil {
 			return i
 		}
 		return value

--- a/processor/ocsfstandardizationprocessor/type_coerce.go
+++ b/processor/ocsfstandardizationprocessor/type_coerce.go
@@ -50,7 +50,7 @@ func coerceToInt(value any) any {
 	case float64:
 		return int(v)
 	case string:
-		if i, err := strconv.ParseInt(v, 0, 64); err == nil {
+		if i, err := strconv.ParseInt(v, 0, 0); err == nil {
 			return int(i)
 		}
 		return value

--- a/processor/ocsfstandardizationprocessor/type_coerce_test.go
+++ b/processor/ocsfstandardizationprocessor/type_coerce_test.go
@@ -33,6 +33,8 @@ func TestCoerceType(t *testing.T) {
 		{name: "integer from int64", value: int64(42), typeName: "integer", expected: int(42)},
 		{name: "integer from bool true", value: true, typeName: "integer", expected: 1},
 		{name: "integer from bool false", value: false, typeName: "integer", expected: 0},
+		{name: "integer from hex string", value: "0x280", typeName: "integer", expected: 640},
+		{name: "integer from hex string uppercase", value: "0xC000006D", typeName: "integer", expected: 3221225581},
 		{name: "integer from invalid string", value: "abc", typeName: "integer", expected: "abc"},
 
 		{name: "long from int64", value: int64(1000), typeName: "long", expected: int64(1000)},
@@ -40,6 +42,8 @@ func TestCoerceType(t *testing.T) {
 		{name: "long from float64", value: 1000.7, typeName: "long", expected: int64(1000)},
 		{name: "long from string", value: "1000", typeName: "long", expected: int64(1000)},
 		{name: "long from bool true", value: true, typeName: "long", expected: int64(1)},
+		{name: "long from hex string", value: "0x3e7", typeName: "long", expected: int64(999)},
+		{name: "long from hex string large", value: "0x3e7000000", typeName: "long", expected: int64(16760438784)},
 		{name: "long from invalid string", value: "abc", typeName: "long", expected: "abc"},
 
 		{name: "float from float64", value: 3.14, typeName: "float", expected: 3.14},


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Windows events contain a lot of hex strings for numbers. Previously, these would not be converted correctly. This change adds support for the type coercion to convert hex strings (see tests).

##### Checklist
- [x] Changes are tested
- [x] CI has passed