### PR TITLE
feat(chronicleexporter): configurable metrics interval

### DIFF
--- a/exporter/chronicleexporter/README.md
+++ b/exporter/chronicleexporter/README.md
@@ -35,6 +35,7 @@ The exporter can be configured using the following fields:
 | `compression`                   | string            | `none`                                 | `false`  | The compression type to use when sending logs. valid values are `none` and `gzip`           |
 | `ingestion_labels`              | map[string]string |                                        | `false`  | Key-value pairs of labels to be applied to the logs when sent to chronicle.                 |
 | `collect_agent_metrics`         | bool              | `true`                                 | `false`  | Enables collecting metrics about the agent's process and log ingestion metrics              |
+| `metrics_interval`              | duration          | `5m`                                   | `false`  | The interval at which agent metrics are collected and sent. Only applies when `collect_agent_metrics` is `true`. |
 | `batch_request_size_limit_grpc` | int               | `4000000`                              | `false`  | The maximum size, in bytes, allowed for a gRPC batch creation request.                      |
 | `batch_request_size_limit_http` | int               | `4000000`                              | `false`  | The maximum size, in bytes, allowed for a HTTP batch creation request.                      |
 | `api_version`                   | string            | `v1alpha`                              | `false`  | The API version to use. Valid values are `v1alpha` and `v1beta`. Only applies to HTTPS protocol.                           |

--- a/exporter/chronicleexporter/config.go
+++ b/exporter/chronicleexporter/config.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/observiq/bindplane-otel-contrib/pkg/expr"
 	"go.opentelemetry.io/collector/component"
@@ -78,6 +79,9 @@ type Config struct {
 
 	// CollectAgentMetrics is a flag that determines whether or not to collect agent metrics.
 	CollectAgentMetrics bool `mapstructure:"collect_agent_metrics"`
+
+	// MetricsInterval is the interval at which to collect and send agent metrics.
+	MetricsInterval time.Duration `mapstructure:"metrics_interval"`
 
 	// Protocol is the protocol that will be used to send logs to Chronicle.
 	// Either https or grpc.
@@ -141,6 +145,10 @@ func (cfg *Config) Validate() error {
 
 	if strings.HasPrefix(cfg.Endpoint, "http://") || strings.HasPrefix(cfg.Endpoint, "https://") {
 		return fmt.Errorf("endpoint should not contain a protocol: %s", cfg.Endpoint)
+	}
+
+	if cfg.CollectAgentMetrics && cfg.MetricsInterval <= 0 {
+		return errors.New("metrics_interval must be a positive duration")
 	}
 
 	if cfg.Protocol == protocolHTTPS {

--- a/exporter/chronicleexporter/config_test.go
+++ b/exporter/chronicleexporter/config_test.go
@@ -16,6 +16,7 @@ package chronicleexporter
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -192,6 +193,17 @@ func TestConfigValidate(t *testing.T) {
 				APIVersion:                "invalid",
 			},
 			expectedErr: "invalid API version: invalid",
+		},
+		{
+			desc: "Invalid metrics interval",
+			config: &Config{
+				Creds:               "creds_example",
+				LogType:             "log_type_example",
+				Compression:         noCompression,
+				CollectAgentMetrics: true,
+				MetricsInterval:     -1 * time.Second,
+			},
+			expectedErr: "metrics_interval must be a positive duration",
 		},
 	}
 

--- a/exporter/chronicleexporter/factory.go
+++ b/exporter/chronicleexporter/factory.go
@@ -17,6 +17,7 @@ package chronicleexporter
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/observiq/bindplane-otel-contrib/exporter/chronicleexporter/internal/metadata"
 	"go.opentelemetry.io/collector/component"
@@ -36,6 +37,7 @@ func NewFactory() exporter.Factory {
 
 const (
 	defaultEndpoint                  = "malachiteingestion-pa.googleapis.com"
+	defaultMetricsInterval           = 5 * time.Minute
 	defaultBatchRequestSizeLimitGRPC = 4000000
 	defaultBatchRequestSizeLimitHTTP = 4000000
 )
@@ -50,6 +52,7 @@ func createDefaultConfig() component.Config {
 		OverrideLogType:           true,
 		Compression:               noCompression,
 		CollectAgentMetrics:       true,
+		MetricsInterval:           defaultMetricsInterval,
 		Endpoint:                  defaultEndpoint,
 		BatchRequestSizeLimitGRPC: defaultBatchRequestSizeLimitGRPC,
 		BatchRequestSizeLimitHTTP: defaultBatchRequestSizeLimitHTTP,

--- a/exporter/chronicleexporter/factory_test.go
+++ b/exporter/chronicleexporter/factory_test.go
@@ -32,6 +32,7 @@ func Test_createDefaultConfig(t *testing.T) {
 		Endpoint:                  "malachiteingestion-pa.googleapis.com",
 		Compression:               "none",
 		CollectAgentMetrics:       true,
+		MetricsInterval:           defaultMetricsInterval,
 		Protocol:                  protocolGRPC,
 		BatchRequestSizeLimitGRPC: defaultBatchRequestSizeLimitGRPC,
 		BatchRequestSizeLimitHTTP: defaultBatchRequestSizeLimitHTTP,

--- a/exporter/chronicleexporter/hostmetrics.go
+++ b/exporter/chronicleexporter/hostmetrics.go
@@ -34,7 +34,9 @@ type hostMetricsReporter struct {
 	set    component.TelemetrySettings
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
-	send   sendMetricsFunc
+
+	send     sendMetricsFunc
+	interval time.Duration
 
 	mutex      sync.Mutex
 	agentID    []byte
@@ -67,6 +69,7 @@ func newHostMetricsReporter(cfg *Config, set component.TelemetrySettings, export
 	hmr := &hostMetricsReporter{
 		set:        set,
 		send:       send,
+		interval:   cfg.MetricsInterval,
 		agentID:    agentID[:],
 		exporterID: exporterID,
 		source: &api.EventSource{
@@ -87,7 +90,7 @@ func (hmr *hostMetricsReporter) start() {
 	hmr.wg.Add(1)
 
 	go func() {
-		ticker := time.NewTicker(5 * time.Minute)
+		ticker := time.NewTicker(hmr.interval)
 
 		defer func() {
 			hmr.wg.Done()


### PR DESCRIPTION
### Proposed Change
Adds a new `metrics_interval` config parameter to the chronicle exporter for configuring the interval at which agent metrics are scraped and sent to GCP.

Defaults to 5 minutes to maintain previous behavior.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed