### PR TITLE
fix(chronicleexporter): merge attribute & config ingestion labels in http exporter

### DIFF
--- a/exporter/chronicleexporter/README.md
+++ b/exporter/chronicleexporter/README.md
@@ -72,7 +72,7 @@ If the `attributes["chronicle_log_type"]` field is present in the log, its value
 
 If the `attributes["chronicle_namespace"]` field is present in the log, its value will be used in the payload instead of the `namespace` in the config.
 
-Ingested labels defined in `attributes["chronicle_ingestion_label"]` are merged with the `ingestion_labels` in the config. When the same label key is set in both places, the value from the log record attribute takes precedence.
+Any labels defined by key value pairs in a nested map at `attributes["chronicle_ingestion_label"]` are merged with the `ingestion_labels` in the config. When the same label key is set in both places, the value from the attribute takes precedence over that from the config.
 
 ## Credentials
 

--- a/exporter/chronicleexporter/README.md
+++ b/exporter/chronicleexporter/README.md
@@ -72,7 +72,7 @@ If the `attributes["chronicle_log_type"]` field is present in the log, its value
 
 If the `attributes["chronicle_namespace"]` field is present in the log, its value will be used in the payload instead of the `namespace` in the config.
 
-If there are nested fields in `attributes["chronicle_ingestion_label"]`, those values will be used in the payload instead of the `ingestion_labels` in the config.
+Ingested labels defined in `attributes["chronicle_ingestion_label"]` are merged with the `ingestion_labels` in the config. When the same label key is set in both places, the value from the log record attribute takes precedence.
 
 ## Credentials
 

--- a/exporter/chronicleexporter/marshal.go
+++ b/exporter/chronicleexporter/marshal.go
@@ -312,18 +312,15 @@ func (m *protoMarshaler) getHTTPIngestionLabels(logRecord plog.LogRecord) (map[s
 		return nil, fmt.Errorf("get chronicle ingestion labels: %w", err)
 	}
 
-	if len(ingestionLabels) != 0 {
-		return ingestionLabels, nil
-	}
-
-	// use labels defined in the config if needed
-	configLabels := make(map[string]*api.Log_LogLabel)
+	// merge in labels defined in config, using the labels defined in the log record if they exist
 	for key, value := range m.cfg.IngestionLabels {
-		configLabels[key] = &api.Log_LogLabel{
-			Value: value,
+		if _, exists := ingestionLabels[key]; !exists {
+			ingestionLabels[key] = &api.Log_LogLabel{
+				Value: value,
+			}
 		}
 	}
-	return configLabels, nil
+	return ingestionLabels, nil
 }
 
 // getRawField is a helper function to get the raw value of a field from a log record

--- a/exporter/chronicleexporter/marshal.go
+++ b/exporter/chronicleexporter/marshal.go
@@ -17,6 +17,7 @@ package chronicleexporter
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -172,10 +173,7 @@ func (m *protoMarshaler) processLogRecord(ctx context.Context, logRecord plog.Lo
 	if err != nil {
 		return "", "", "", nil, err
 	}
-	ingestionLabels, err := m.getIngestionLabels(logRecord)
-	if err != nil {
-		return "", "", "", nil, err
-	}
+	ingestionLabels := m.getGRPCIngestionLabels(logRecord)
 	return rawLog, logType, namespace, ingestionLabels, nil
 }
 
@@ -193,11 +191,7 @@ func (m *protoMarshaler) processHTTPLogRecord(ctx context.Context, logRecord plo
 	if err != nil {
 		return "", "", "", nil, err
 	}
-	ingestionLabels, err := m.getHTTPIngestionLabels(logRecord)
-	if err != nil {
-		return "", "", "", nil, err
-	}
-
+	ingestionLabels := m.getHTTPIngestionLabels(logRecord)
 	return rawLog, logType, namespace, ingestionLabels, nil
 }
 
@@ -279,48 +273,49 @@ func (m *protoMarshaler) getNamespace(ctx context.Context, logRecord plog.LogRec
 	return m.cfg.Namespace, nil
 }
 
-func (m *protoMarshaler) getIngestionLabels(logRecord plog.LogRecord) ([]*api.Label, error) {
-	// check for labels in attributes["chronicle_ingestion_labels"]
-	ingestionLabels, err := m.getRawNestedFields(chronicleIngestionLabelsPrefix, logRecord)
-	if err != nil {
-		return []*api.Label{}, fmt.Errorf("get chronicle ingestion labels: %w", err)
-	}
+// aggregateIngestionLabels returns the union of config-defined ingestion labels and those present in the log record's attributes.
+// In the case of key conflicts, the log record attribute labels take precedence over the config labels.
+func (m *protoMarshaler) aggregateIngestionLabels(logRecord plog.LogRecord) map[string]string {
+	mergedLabels := make(map[string]string, len(m.cfg.IngestionLabels))
+	maps.Copy(mergedLabels, m.cfg.IngestionLabels)
 
-	// merge in labels defined in config, using the labels defined in the log record if they exist
-	configLabels := make([]*api.Label, 0)
-	for key, value := range m.cfg.IngestionLabels {
-		if _, exists := ingestionLabels[key]; !exists {
-			configLabels = append(configLabels, &api.Label{
-				Key:   key,
-				Value: value,
-			})
+	logRecord.Attributes().Range(func(key string, value pcommon.Value) bool {
+		if !strings.HasPrefix(key, chronicleIngestionLabelsPrefix) {
+			return true
 		}
-	}
-	for key, value := range ingestionLabels {
-		configLabels = append(configLabels, &api.Label{
-			Key:   key,
-			Value: value,
-		})
-	}
-	return configLabels, nil
+		cleanKey := strings.Trim(key[len(chronicleIngestionLabelsPrefix):], `[]"`)
+		var jsonMap map[string]string
+		if err := json.Unmarshal([]byte(value.AsString()), &jsonMap); err == nil {
+			maps.Copy(mergedLabels, jsonMap)
+		} else {
+			mergedLabels[cleanKey] = value.AsString()
+		}
+		return true
+	})
+	return mergedLabels
 }
 
-func (m *protoMarshaler) getHTTPIngestionLabels(logRecord plog.LogRecord) (map[string]*api.Log_LogLabel, error) {
-	// Check for labels in attributes["chronicle_ingestion_labels"]
-	ingestionLabels, err := m.getHTTPRawNestedFields(chronicleIngestionLabelsPrefix, logRecord)
-	if err != nil {
-		return nil, fmt.Errorf("get chronicle ingestion labels: %w", err)
+func (m *protoMarshaler) getGRPCIngestionLabels(logRecord plog.LogRecord) []*api.Label {
+	mergedLabels := m.aggregateIngestionLabels(logRecord)
+	labels := make([]*api.Label, 0, len(mergedLabels))
+	for k, v := range mergedLabels {
+		labels = append(labels, &api.Label{
+			Key:   k,
+			Value: v,
+		})
 	}
+	return labels
+}
 
-	// merge in labels defined in config, using the labels defined in the log record if they exist
-	for key, value := range m.cfg.IngestionLabels {
-		if _, exists := ingestionLabels[key]; !exists {
-			ingestionLabels[key] = &api.Log_LogLabel{
-				Value: value,
-			}
+func (m *protoMarshaler) getHTTPIngestionLabels(logRecord plog.LogRecord) map[string]*api.Log_LogLabel {
+	mergedLabels := m.aggregateIngestionLabels(logRecord)
+	labels := make(map[string]*api.Log_LogLabel, len(mergedLabels))
+	for k, v := range mergedLabels {
+		labels[k] = &api.Log_LogLabel{
+			Value: v,
 		}
 	}
-	return ingestionLabels, nil
+	return labels
 }
 
 // getRawField is a helper function to get the raw value of a field from a log record
@@ -407,57 +402,6 @@ func (m *protoMarshaler) getRawField(ctx context.Context, field string, logRecor
 	default:
 		return "", fmt.Errorf("unsupported log record expression result type: %T", lrExprResult)
 	}
-}
-
-func (m *protoMarshaler) getRawNestedFields(field string, logRecord plog.LogRecord) (map[string]string, error) {
-	nestedFields := make(map[string]string)
-	logRecord.Attributes().Range(func(key string, value pcommon.Value) bool {
-		if !strings.HasPrefix(key, field) {
-			return true
-		}
-		// Extract the key name from the nested field
-		cleanKey := strings.Trim(key[len(field):], `[]"`)
-		var jsonMap map[string]string
-
-		// If needs to be parsed as JSON
-		if err := json.Unmarshal([]byte(value.AsString()), &jsonMap); err == nil {
-			for k, v := range jsonMap {
-				nestedFields[k] = v
-			}
-		} else {
-			nestedFields[cleanKey] = value.AsString()
-		}
-		return true
-	})
-	return nestedFields, nil
-}
-
-func (m *protoMarshaler) getHTTPRawNestedFields(field string, logRecord plog.LogRecord) (map[string]*api.Log_LogLabel, error) {
-	nestedFields := make(map[string]*api.Log_LogLabel) // Map with key as string and value as Log_LogLabel
-	logRecord.Attributes().Range(func(key string, value pcommon.Value) bool {
-		if !strings.HasPrefix(key, field) {
-			return true
-		}
-		// Extract the key name from the nested field
-		cleanKey := strings.Trim(key[len(field):], `[]"`)
-		var jsonMap map[string]string
-
-		// If needs to be parsed as JSON
-		if err := json.Unmarshal([]byte(value.AsString()), &jsonMap); err == nil {
-			for k, v := range jsonMap {
-				nestedFields[k] = &api.Log_LogLabel{
-					Value: v,
-				}
-			}
-		} else {
-			nestedFields[cleanKey] = &api.Log_LogLabel{
-				Value: value.AsString(),
-			}
-		}
-		return true
-	})
-
-	return nestedFields, nil
 }
 
 func (m *protoMarshaler) constructPayloads(logGrouper *logGrouper) []*api.BatchCreateLogsRequest {

--- a/exporter/chronicleexporter/marshal_test.go
+++ b/exporter/chronicleexporter/marshal_test.go
@@ -1492,6 +1492,44 @@ func TestProtoMarshaler_MarshalRawLogsForHTTP(t *testing.T) {
 				require.Equal(t, string(logs2[0].Data), "Second log message")
 			},
 		},
+		{
+			name: "Destination ingestion labels are merged with config ingestion labels",
+			cfg: Config{
+				CustomerID:      uuid.New().String(),
+				LogType:         "WINEVTLOG",
+				RawLogField:     "body",
+				OverrideLogType: false,
+				IngestionLabels: map[string]string{
+					"key1": "value3",
+					"key2": "value4",
+					"key3": "value5",
+				},
+				BatchRequestSizeLimitHTTP: 5242880,
+			},
+			logRecords: func() plog.Logs {
+				logs := plog.NewLogs()
+				record1 := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+				record1.Body().SetStr("First log message")
+				record1.Attributes().FromRaw(map[string]any{"chronicle_log_type": "WINEVTLOGS1", "chronicle_namespace": "test1", `chronicle_ingestion_label["key1"]`: "value1", `chronicle_ingestion_label["key2"]`: "value2"})
+				return logs
+			},
+			expectations: func(t *testing.T, requests map[string][]*api.ImportLogsRequest) {
+				require.Len(t, requests, 1, "Expected a single batch request")
+				logs := requests["WINEVTLOGS1"][0].GetInlineSource().Logs
+				require.Len(t, logs, 1, "Expected one log entry in the batch")
+				require.Equal(t, "First log message", string(logs[0].Data))
+				require.Equal(t, "test1", logs[0].EnvironmentNamespace)
+				expectedLabels := map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+					"key3": "value5",
+				}
+				require.Len(t, logs[0].Labels, len(expectedLabels))
+				for key, label := range logs[0].Labels {
+					require.Equal(t, expectedLabels[key], label.Value)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Proposed Change
Previously, the logic when aggregating ingestion labels in the chronicle exporter behaved differently for https protocol compared to grpc protocol. For gRPC, the ingestion labels present in the config parameters were merged with those present in a map at the special field `attributes['chronicle_ingestion_label']` on a log. However for HTTPS, if any labels were present in the special attribute field, only those were used when imports logs to the chronicle API, and the labels defined in the config were ignored.

This PR:
- Aligns ingestion label aggregation logic for HTTPS to be the same as gRPC: Merges the ingestion labels present in the special attribute field with those defined in the exporter config, with a precedence for those from the attribute.
- Updates the Readme to better describe this behavior.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed