### PR TITLE
fix(chronicleexporter): metricsreporter race condition

### DIFF
--- a/exporter/chronicleexporter/metrics.go
+++ b/exporter/chronicleexporter/metrics.go
@@ -102,31 +102,29 @@ func (hmr *metricsReporter) start() {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				err := hmr.collectHostMetrics()
-				if err != nil {
+				if err := hmr.collectHostMetrics(); err != nil {
 					hmr.set.Logger.Error("Failed to collect host metrics", zap.Error(err))
 				}
-				request := hmr.buildRequest()
-				err = hmr.send(ctx, request)
-				if err != nil {
+				request, sent := hmr.drainRequest(timestamppb.Now())
+				if err := hmr.send(ctx, request); err != nil {
 					hmr.set.Logger.Error("Failed to upload metrics", zap.Error(err))
-				} else {
-					hmr.resetWindow(timestamppb.Now())
+					hmr.restore(sent) // retry these counters in the next window
 				}
 			}
 		}
 	}()
 }
 
-// buildRequest builds the create events request object
-func (hmr *metricsReporter) buildRequest() *api.BatchCreateEventsRequest {
+// drainRequest snapshots the current window into a request and starts a fresh one atomically.
+func (hmr *metricsReporter) drainRequest(windowStartTime *timestamppb.Timestamp) (*api.BatchCreateEventsRequest, *api.AgentStatsEvent) {
 	hmr.mutex.Lock()
 	defer hmr.mutex.Unlock()
 
+	stats := hmr.agentStats
 	now := timestamppb.Now()
 	batchID := uuid.New()
 
-	return &api.BatchCreateEventsRequest{
+	request := &api.BatchCreateEventsRequest{
 		Batch: &api.EventBatch{
 			Id:        batchID[:],
 			Source:    hmr.source,
@@ -138,12 +136,28 @@ func (hmr *metricsReporter) buildRequest() *api.BatchCreateEventsRequest {
 					CollectionTime: now,
 					Source:         hmr.source,
 					Payload: &api.Event_AgentStats{
-						AgentStats: hmr.agentStats,
+						AgentStats: stats,
 					},
 				},
 			},
 		},
 	}
+
+	hmr.agentStats = newAgentStats(hmr.agentID, hmr.startTime, windowStartTime, hmr.exporterID)
+	return request, stats
+}
+
+// restore merges a failed upload's counters back so they retry next window.
+func (hmr *metricsReporter) restore(failed *api.AgentStatsEvent) {
+	hmr.mutex.Lock()
+	defer hmr.mutex.Unlock()
+
+	if len(hmr.agentStats.ExporterStats) == 0 || len(failed.ExporterStats) == 0 {
+		return
+	}
+	hmr.agentStats.ExporterStats[0].AcceptedSpans += failed.ExporterStats[0].AcceptedSpans
+	hmr.agentStats.ExporterStats[0].RefusedSpans += failed.ExporterStats[0].RefusedSpans
+	hmr.agentStats.WindowStartTime = failed.WindowStartTime
 }
 
 func (hmr *metricsReporter) shutdown() {
@@ -195,13 +209,18 @@ func (hmr *metricsReporter) resetWindow(windowStartTime *timestamppb.Timestamp) 
 	hmr.mutex.Lock()
 	defer hmr.mutex.Unlock()
 
-	hmr.agentStats = &api.AgentStatsEvent{
-		AgentId:         hmr.agentID,
-		StartTime:       hmr.startTime,
+	hmr.agentStats = newAgentStats(hmr.agentID, hmr.startTime, windowStartTime, hmr.exporterID)
+}
+
+// newAgentStats returns a fresh agent stats object for a new window.
+func newAgentStats(agentID []byte, startTime, windowStartTime *timestamppb.Timestamp, exporterID string) *api.AgentStatsEvent {
+	return &api.AgentStatsEvent{
+		AgentId:         agentID,
+		StartTime:       startTime,
 		WindowStartTime: windowStartTime,
 		ExporterStats: []*api.ExporterStats{
 			{
-				Name: hmr.exporterID,
+				Name: exporterID,
 			},
 		},
 	}

--- a/exporter/chronicleexporter/metrics.go
+++ b/exporter/chronicleexporter/metrics.go
@@ -66,7 +66,7 @@ func newMetricsReporter(cfg *Config, set component.TelemetrySettings, exporterID
 	}
 
 	now := timestamppb.Now()
-	hmr := &metricsReporter{
+	mr := &metricsReporter{
 		set:        set,
 		send:       send,
 		interval:   cfg.MetricsInterval,
@@ -77,23 +77,23 @@ func newMetricsReporter(cfg *Config, set component.TelemetrySettings, exporterID
 			CollectorId: getCollectorID(cfg.LicenseType),
 			Namespace:   cfg.Namespace,
 		},
-		startTime: now,
+		startTime:  now,
+		agentStats: newAgentStats(agentID[:], now, now, exporterID),
 	}
 
-	hmr.resetWindow(now)
-	return hmr, nil
+	return mr, nil
 }
 
-func (hmr *metricsReporter) start() {
+func (mr *metricsReporter) start() {
 	ctx, cancel := context.WithCancel(context.Background())
-	hmr.cancel = cancel
-	hmr.wg.Add(1)
+	mr.cancel = cancel
+	mr.wg.Add(1)
 
 	go func() {
-		ticker := time.NewTicker(hmr.interval)
+		ticker := time.NewTicker(mr.interval)
 
 		defer func() {
-			hmr.wg.Done()
+			mr.wg.Done()
 			ticker.Stop()
 		}()
 
@@ -102,13 +102,13 @@ func (hmr *metricsReporter) start() {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := hmr.collectHostMetrics(); err != nil {
-					hmr.set.Logger.Error("Failed to collect host metrics", zap.Error(err))
+				if err := mr.collectHostMetrics(); err != nil {
+					mr.set.Logger.Error("Failed to collect host metrics", zap.Error(err))
 				}
-				request, sent := hmr.drainRequest()
-				if err := hmr.send(ctx, request); err != nil {
-					hmr.set.Logger.Error("Failed to upload metrics", zap.Error(err))
-					hmr.restore(sent) // retry these counters in the next window
+				request, sent := mr.drainRequest()
+				if err := mr.send(ctx, request); err != nil {
+					mr.set.Logger.Error("Failed to upload metrics", zap.Error(err))
+					mr.restore(sent) // retry these counters in the next window
 				}
 			}
 		}
@@ -116,25 +116,25 @@ func (hmr *metricsReporter) start() {
 }
 
 // drainRequest snapshots the current window into a request and starts a fresh one atomically.
-func (hmr *metricsReporter) drainRequest() (*api.BatchCreateEventsRequest, *api.AgentStatsEvent) {
-	hmr.mutex.Lock()
-	defer hmr.mutex.Unlock()
+func (mr *metricsReporter) drainRequest() (*api.BatchCreateEventsRequest, *api.AgentStatsEvent) {
+	mr.mutex.Lock()
+	defer mr.mutex.Unlock()
 
-	stats := hmr.agentStats
+	stats := mr.agentStats
 	now := timestamppb.Now()
 	batchID := uuid.New()
 
 	request := &api.BatchCreateEventsRequest{
 		Batch: &api.EventBatch{
 			Id:        batchID[:],
-			Source:    hmr.source,
+			Source:    mr.source,
 			Type:      api.EventBatch_AGENT_STATS,
-			StartTime: hmr.startTime,
+			StartTime: mr.startTime,
 			Events: []*api.Event{
 				{
 					Timestamp:      now,
 					CollectionTime: now,
-					Source:         hmr.source,
+					Source:         mr.source,
 					Payload: &api.Event_AgentStats{
 						AgentStats: stats,
 					},
@@ -143,34 +143,34 @@ func (hmr *metricsReporter) drainRequest() (*api.BatchCreateEventsRequest, *api.
 		},
 	}
 
-	hmr.agentStats = newAgentStats(hmr.agentID, hmr.startTime, now, hmr.exporterID)
+	mr.agentStats = newAgentStats(mr.agentID, mr.startTime, now, mr.exporterID)
 	return request, stats
 }
 
 // restore merges a failed upload's counters back so they retry next window.
-func (hmr *metricsReporter) restore(failed *api.AgentStatsEvent) {
-	hmr.mutex.Lock()
-	defer hmr.mutex.Unlock()
+func (mr *metricsReporter) restore(failed *api.AgentStatsEvent) {
+	mr.mutex.Lock()
+	defer mr.mutex.Unlock()
 
-	if len(hmr.agentStats.ExporterStats) == 0 || len(failed.ExporterStats) == 0 {
+	if len(mr.agentStats.ExporterStats) == 0 || len(failed.ExporterStats) == 0 {
 		return
 	}
-	hmr.agentStats.ExporterStats[0].AcceptedSpans += failed.ExporterStats[0].AcceptedSpans
-	hmr.agentStats.ExporterStats[0].RefusedSpans += failed.ExporterStats[0].RefusedSpans
-	hmr.agentStats.WindowStartTime = failed.WindowStartTime
+	mr.agentStats.ExporterStats[0].AcceptedSpans += failed.ExporterStats[0].AcceptedSpans
+	mr.agentStats.ExporterStats[0].RefusedSpans += failed.ExporterStats[0].RefusedSpans
+	mr.agentStats.WindowStartTime = failed.WindowStartTime
 }
 
-func (hmr *metricsReporter) shutdown() {
-	if hmr.cancel != nil {
-		hmr.cancel()
-		hmr.wg.Wait()
+func (mr *metricsReporter) shutdown() {
+	if mr.cancel != nil {
+		mr.cancel()
+		mr.wg.Wait()
 	}
 }
 
 // collectHostMetrics collects the host metrics and updates the agent stats object
-func (hmr *metricsReporter) collectHostMetrics() error {
-	hmr.mutex.Lock()
-	defer hmr.mutex.Unlock()
+func (mr *metricsReporter) collectHostMetrics() error {
+	mr.mutex.Lock()
+	defer mr.mutex.Unlock()
 
 	// Get the current process using the current PID
 	proc, err := process.NewProcess(int32(os.Getpid()))
@@ -183,14 +183,14 @@ func (hmr *metricsReporter) collectHostMetrics() error {
 	if err != nil {
 		return fmt.Errorf("get cpu times: %w", err)
 	}
-	hmr.agentStats.ProcessCpuSeconds = int64(cpuTimes.User + cpuTimes.System)
+	mr.agentStats.ProcessCpuSeconds = int64(cpuTimes.User + cpuTimes.System)
 
 	// Collect memory usage (RSS)
 	memInfo, err := proc.MemoryInfo()
 	if err != nil {
 		return fmt.Errorf("get memory info: %w", err)
 	}
-	hmr.agentStats.ProcessMemoryRss = int64(memInfo.RSS / 1024) // Convert bytes to kilobytes
+	mr.agentStats.ProcessMemoryRss = int64(memInfo.RSS / 1024) // Convert bytes to kilobytes
 
 	// Calculate process uptime
 	startTimeMs, err := proc.CreateTime()
@@ -199,17 +199,9 @@ func (hmr *metricsReporter) collectHostMetrics() error {
 	}
 	startTimeSec := startTimeMs / 1000
 	currentTimeSec := time.Now().Unix()
-	hmr.agentStats.ProcessUptime = currentTimeSec - startTimeSec
+	mr.agentStats.ProcessUptime = currentTimeSec - startTimeSec
 
 	return nil
-}
-
-// resetWindow resets the agent stats object and sets the window start time
-func (hmr *metricsReporter) resetWindow(windowStartTime *timestamppb.Timestamp) {
-	hmr.mutex.Lock()
-	defer hmr.mutex.Unlock()
-
-	hmr.agentStats = newAgentStats(hmr.agentID, hmr.startTime, windowStartTime, hmr.exporterID)
 }
 
 // newAgentStats returns a fresh agent stats object for a new window.
@@ -226,33 +218,33 @@ func newAgentStats(agentID []byte, startTime, windowStartTime *timestamppb.Times
 	}
 }
 
-func (hmr *metricsReporter) recordSent(count int64) {
-	hmr.mutex.Lock()
-	defer hmr.mutex.Unlock()
+func (mr *metricsReporter) recordSent(count int64) {
+	mr.mutex.Lock()
+	defer mr.mutex.Unlock()
 
-	if len(hmr.agentStats.ExporterStats) == 0 {
-		hmr.agentStats.ExporterStats = []*api.ExporterStats{
+	if len(mr.agentStats.ExporterStats) == 0 {
+		mr.agentStats.ExporterStats = []*api.ExporterStats{
 			{
-				Name: hmr.exporterID,
+				Name: mr.exporterID,
 			},
 		}
 	}
 
-	hmr.agentStats.ExporterStats[0].AcceptedSpans += count
-	hmr.agentStats.LastSuccessfulUploadTime = timestamppb.Now()
+	mr.agentStats.ExporterStats[0].AcceptedSpans += count
+	mr.agentStats.LastSuccessfulUploadTime = timestamppb.Now()
 }
 
-func (hmr *metricsReporter) recordDropped(count int64) {
-	hmr.mutex.Lock()
-	defer hmr.mutex.Unlock()
+func (mr *metricsReporter) recordDropped(count int64) {
+	mr.mutex.Lock()
+	defer mr.mutex.Unlock()
 
-	if len(hmr.agentStats.ExporterStats) == 0 {
-		hmr.agentStats.ExporterStats = []*api.ExporterStats{
+	if len(mr.agentStats.ExporterStats) == 0 {
+		mr.agentStats.ExporterStats = []*api.ExporterStats{
 			{
-				Name: hmr.exporterID,
+				Name: mr.exporterID,
 			},
 		}
 	}
 
-	hmr.agentStats.ExporterStats[0].RefusedSpans += count
+	mr.agentStats.ExporterStats[0].RefusedSpans += count
 }

--- a/exporter/chronicleexporter/metrics.go
+++ b/exporter/chronicleexporter/metrics.go
@@ -105,7 +105,7 @@ func (hmr *metricsReporter) start() {
 				if err := hmr.collectHostMetrics(); err != nil {
 					hmr.set.Logger.Error("Failed to collect host metrics", zap.Error(err))
 				}
-				request, sent := hmr.drainRequest(timestamppb.Now())
+				request, sent := hmr.drainRequest()
 				if err := hmr.send(ctx, request); err != nil {
 					hmr.set.Logger.Error("Failed to upload metrics", zap.Error(err))
 					hmr.restore(sent) // retry these counters in the next window
@@ -116,7 +116,7 @@ func (hmr *metricsReporter) start() {
 }
 
 // drainRequest snapshots the current window into a request and starts a fresh one atomically.
-func (hmr *metricsReporter) drainRequest(windowStartTime *timestamppb.Timestamp) (*api.BatchCreateEventsRequest, *api.AgentStatsEvent) {
+func (hmr *metricsReporter) drainRequest() (*api.BatchCreateEventsRequest, *api.AgentStatsEvent) {
 	hmr.mutex.Lock()
 	defer hmr.mutex.Unlock()
 
@@ -143,7 +143,7 @@ func (hmr *metricsReporter) drainRequest(windowStartTime *timestamppb.Timestamp)
 		},
 	}
 
-	hmr.agentStats = newAgentStats(hmr.agentID, hmr.startTime, windowStartTime, hmr.exporterID)
+	hmr.agentStats = newAgentStats(hmr.agentID, hmr.startTime, now, hmr.exporterID)
 	return request, stats
 }
 

--- a/exporter/chronicleexporter/metrics_test.go
+++ b/exporter/chronicleexporter/metrics_test.go
@@ -220,7 +220,7 @@ func TestMetricsReporterBuildRequest(t *testing.T) {
 	mr.recordSent(10)
 	mr.recordDropped(2)
 
-	req, _ := mr.drainRequest(timestamppb.Now())
+	req, _ := mr.drainRequest()
 	require.NotNil(t, req)
 	require.NotNil(t, req.Batch)
 
@@ -246,8 +246,8 @@ func TestMetricsReporterBuildRequestUniqueBatchIDs(t *testing.T) {
 	mr, err := newMetricsReporter(newTestConfig(), componenttest.NewNopTelemetrySettings(), "test-exporter", noopSend)
 	require.NoError(t, err)
 
-	first, _ := mr.drainRequest(timestamppb.Now())
-	second, _ := mr.drainRequest(timestamppb.Now())
+	first, _ := mr.drainRequest()
+	second, _ := mr.drainRequest()
 	assert.NotEqual(t, first.Batch.Id, second.Batch.Id)
 }
 
@@ -384,7 +384,7 @@ func TestMetricsReporterDrainRequestMarshalRace(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for range iterations {
-			req, _ := mr.drainRequest(timestamppb.Now())
+			req, _ := mr.drainRequest()
 			_, err := proto.Marshal(req)
 			assert.NoError(t, err)
 			stats := req.Batch.Events[0].GetAgentStats().ExporterStats[0]
@@ -422,7 +422,7 @@ func TestMetricsReporterDrainNoCountsLost(t *testing.T) {
 	mr.recordSent(10)
 	mr.recordDropped(2)
 
-	req1, _ := mr.drainRequest(timestamppb.Now())
+	req1, _ := mr.drainRequest()
 	s1 := req1.Batch.Events[0].GetAgentStats().ExporterStats[0]
 	assert.Equal(t, int64(10), s1.AcceptedSpans)
 	assert.Equal(t, int64(2), s1.RefusedSpans)
@@ -431,7 +431,7 @@ func TestMetricsReporterDrainNoCountsLost(t *testing.T) {
 	mr.recordSent(3)
 	mr.recordDropped(1)
 
-	req2, _ := mr.drainRequest(timestamppb.Now())
+	req2, _ := mr.drainRequest()
 	s2 := req2.Batch.Events[0].GetAgentStats().ExporterStats[0]
 	assert.Equal(t, int64(3), s2.AcceptedSpans, "gap counts must carry into the next window")
 	assert.Equal(t, int64(1), s2.RefusedSpans)
@@ -448,7 +448,7 @@ func TestMetricsReporterRestoreOnFailure(t *testing.T) {
 	mr.recordSent(7)
 	mr.recordDropped(3)
 
-	req, sent := mr.drainRequest(timestamppb.Now())
+	req, sent := mr.drainRequest()
 	require.NotNil(t, req)
 	assert.Equal(t, int64(0), mr.agentStats.ExporterStats[0].AcceptedSpans, "drain starts a fresh window")
 

--- a/exporter/chronicleexporter/metrics_test.go
+++ b/exporter/chronicleexporter/metrics_test.go
@@ -31,6 +31,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -219,7 +220,7 @@ func TestMetricsReporterBuildRequest(t *testing.T) {
 	mr.recordSent(10)
 	mr.recordDropped(2)
 
-	req := mr.buildRequest()
+	req, _ := mr.drainRequest(timestamppb.Now())
 	require.NotNil(t, req)
 	require.NotNil(t, req.Batch)
 
@@ -245,9 +246,9 @@ func TestMetricsReporterBuildRequestUniqueBatchIDs(t *testing.T) {
 	mr, err := newMetricsReporter(newTestConfig(), componenttest.NewNopTelemetrySettings(), "test-exporter", noopSend)
 	require.NoError(t, err)
 
-	first := mr.buildRequest().Batch.Id
-	second := mr.buildRequest().Batch.Id
-	assert.NotEqual(t, first, second)
+	first, _ := mr.drainRequest(timestamppb.Now())
+	second, _ := mr.drainRequest(timestamppb.Now())
+	assert.NotEqual(t, first.Batch.Id, second.Batch.Id)
 }
 
 func TestMetricsReporterCollectHostMetrics(t *testing.T) {
@@ -353,7 +354,7 @@ func TestMetricsReporterConcurrency(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 10 {
-		wg.Add(3)
+		wg.Add(2)
 		go func() {
 			defer wg.Done()
 			mr.recordSent(1)
@@ -362,13 +363,100 @@ func TestMetricsReporterConcurrency(t *testing.T) {
 			defer wg.Done()
 			mr.recordDropped(1)
 		}()
-		go func() {
-			defer wg.Done()
-			_ = mr.buildRequest()
-		}()
 	}
 	wg.Wait()
 
 	assert.Equal(t, int64(10), mr.agentStats.ExporterStats[0].AcceptedSpans)
 	assert.Equal(t, int64(10), mr.agentStats.ExporterStats[0].RefusedSpans)
+}
+
+func TestMetricsReporterDrainRequestMarshalRace(t *testing.T) {
+	mr, err := newMetricsReporter(newTestConfig(), componenttest.NewNopTelemetrySettings(), "test-exporter", noopSend)
+	require.NoError(t, err)
+
+	const iterations = 1000
+	var drainedAccepted, drainedRefused int64
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	// Marshal each drained request without the lock, exactly as send() does.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			req, _ := mr.drainRequest(timestamppb.Now())
+			_, err := proto.Marshal(req)
+			assert.NoError(t, err)
+			stats := req.Batch.Events[0].GetAgentStats().ExporterStats[0]
+			drainedAccepted += stats.AcceptedSpans
+			drainedRefused += stats.RefusedSpans
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			mr.recordSent(1)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			mr.recordDropped(1)
+		}
+	}()
+
+	wg.Wait()
+
+	// Add counts still sitting in the open window.
+	drainedAccepted += mr.agentStats.ExporterStats[0].AcceptedSpans
+	drainedRefused += mr.agentStats.ExporterStats[0].RefusedSpans
+
+	assert.Equal(t, int64(iterations), drainedAccepted, "no accepted spans lost across concurrent drains")
+	assert.Equal(t, int64(iterations), drainedRefused, "no refused spans lost across concurrent drains")
+}
+
+func TestMetricsReporterDrainNoCountsLost(t *testing.T) {
+	mr, err := newMetricsReporter(newTestConfig(), componenttest.NewNopTelemetrySettings(), "test-exporter", noopSend)
+	require.NoError(t, err)
+
+	mr.recordSent(10)
+	mr.recordDropped(2)
+
+	req1, _ := mr.drainRequest(timestamppb.Now())
+	s1 := req1.Batch.Events[0].GetAgentStats().ExporterStats[0]
+	assert.Equal(t, int64(10), s1.AcceptedSpans)
+	assert.Equal(t, int64(2), s1.RefusedSpans)
+
+	// Recorded after the drain; must carry into the next window, not be dropped.
+	mr.recordSent(3)
+	mr.recordDropped(1)
+
+	req2, _ := mr.drainRequest(timestamppb.Now())
+	s2 := req2.Batch.Events[0].GetAgentStats().ExporterStats[0]
+	assert.Equal(t, int64(3), s2.AcceptedSpans, "gap counts must carry into the next window")
+	assert.Equal(t, int64(1), s2.RefusedSpans)
+
+	assert.Equal(t, int64(13), s1.AcceptedSpans+s2.AcceptedSpans, "no accepted spans lost")
+	assert.Equal(t, int64(3), s1.RefusedSpans+s2.RefusedSpans, "no refused spans lost")
+}
+
+func TestMetricsReporterRestoreOnFailure(t *testing.T) {
+	mr, err := newMetricsReporter(newTestConfig(), componenttest.NewNopTelemetrySettings(), "test-exporter", noopSend)
+	require.NoError(t, err)
+
+	initialWindow := mr.agentStats.WindowStartTime
+	mr.recordSent(7)
+	mr.recordDropped(3)
+
+	req, sent := mr.drainRequest(timestamppb.Now())
+	require.NotNil(t, req)
+	assert.Equal(t, int64(0), mr.agentStats.ExporterStats[0].AcceptedSpans, "drain starts a fresh window")
+
+	// Recorded after the drain, then the send fails and we restore.
+	mr.recordSent(2)
+	mr.restore(sent)
+
+	assert.Equal(t, int64(9), mr.agentStats.ExporterStats[0].AcceptedSpans, "restored 7 + gap 2")
+	assert.Equal(t, int64(3), mr.agentStats.ExporterStats[0].RefusedSpans)
+	assert.Equal(t, initialWindow, mr.agentStats.WindowStartTime, "restore rewinds the window start")
 }

--- a/exporter/chronicleexporter/metrics_test.go
+++ b/exporter/chronicleexporter/metrics_test.go
@@ -32,7 +32,6 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func newTestConfig(opts ...func(*Config)) *Config {
@@ -147,17 +146,11 @@ func TestNewMetricsReporter(t *testing.T) {
 	})
 }
 
-func TestMetricsReporterResetWindow(t *testing.T) {
+func TestMetricsReporterInitialWindow(t *testing.T) {
 	mr, err := newMetricsReporter(newTestConfig(), componenttest.NewNopTelemetrySettings(), "test-exporter", noopSend)
 	require.NoError(t, err)
 
-	mr.recordSent(10)
-	mr.recordDropped(5)
-
-	newWindow := timestamppb.Now()
-	mr.resetWindow(newWindow)
-
-	assert.Equal(t, newWindow, mr.agentStats.WindowStartTime)
+	assert.Equal(t, mr.startTime, mr.agentStats.WindowStartTime)
 	assert.Equal(t, mr.startTime, mr.agentStats.StartTime)
 	assert.Equal(t, mr.agentID, mr.agentStats.AgentId)
 	require.Len(t, mr.agentStats.ExporterStats, 1)


### PR DESCRIPTION
### Proposed Change
Fixes a race condition bug in the `chronicleexporter` in which agent metrics were not tracked if they were recorded in the time between building the agent stats request and resetting the metrics window (when the request returns successfully).

##### Checklist
- [x] Changes are tested
- [x] CI has passed