### PR TITLE
feat(telemetrygeneratorreceiver): add internal/blitzpdata LogAdapter for blitz embed integration (PIPE-1017)

### DIFF
--- a/receiver/telemetrygeneratorreceiver/go.mod
+++ b/receiver/telemetrygeneratorreceiver/go.mod
@@ -1,8 +1,9 @@
 module github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver
 
-go 1.25.9
+go 1.26.0
 
 require (
+	github.com/observiq/blitz v0.19.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.153.0
 	github.com/stretchr/testify v1.11.1

--- a/receiver/telemetrygeneratorreceiver/go.sum
+++ b/receiver/telemetrygeneratorreceiver/go.sum
@@ -1,3 +1,5 @@
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -46,6 +48,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/observiq/blitz v0.19.0 h1:Vi3imK0VhJgNqcIspjh+53XXjaZ8rODhmeYM6g9uEX4=
+github.com/observiq/blitz v0.19.0/go.mod h1:UCNFZvGrJiQ5FUq92JQU6gI2AGydIUPzseWzX4zttgc=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.153.0 h1:oNVsd/YwRjtl6tJO8/dY7wx2TGJGbEVwz7wcF2FGF8M=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.153.0/go.mod h1:2QNxJizbn7WpLRdVK/2/ADQfXlt8he4c5KJVH61EgEE=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.153.0 h1:VwVUNLFbACvJ2CHpHIZEy67DhpI5UZbOJQzBK8OH08o=

--- a/receiver/telemetrygeneratorreceiver/internal/blitzpdata/log_adapter.go
+++ b/receiver/telemetrygeneratorreceiver/internal/blitzpdata/log_adapter.go
@@ -1,0 +1,218 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package blitzpdata adapts blitz embed record batches to OpenTelemetry
+// pdata. The package is internal to the telemetrygeneratorreceiver
+// and exists so the receiver can satisfy blitz's embed.LogConsumer
+// interface without dragging pdata into blitz itself — per the embed
+// contract, format conversion lives on the consuming host.
+package blitzpdata // import "github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver/internal/blitzpdata"
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/observiq/blitz/embed"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+)
+
+// scopeName is set on every plog.ScopeLogs emitted by the adapter so
+// downstream pipelines can attribute the records to the blitz source.
+const scopeName = "github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver/blitz"
+
+// LogAdapter implements embed.LogConsumer. Each ConsumeLogs call builds
+// a fresh plog.Logs from the batch and pushes it to the receiver's
+// downstream consumer.
+//
+// The adapter is constructed once per receiver Start cycle. Resource
+// and per-record attribute maps are drawn from receiver config at
+// construction time and remain stable for the session; the v0.16.1
+// embed.LogRecord contract has no per-record attributes or resource
+// of its own (PIPE-1021 will lift this), so receiver config is the
+// sole source today.
+type LogAdapter struct {
+	consumer      consumer.Logs
+	resourceAttrs map[string]any
+	attrs         map[string]any
+	parseBody     bool
+	logger        *zap.Logger
+}
+
+// NewLogAdapter constructs an adapter that emits to the given consumer.
+//
+// resourceAttrs is written onto every outgoing plog.ResourceLogs.
+// attrs is written onto every outgoing log record. Either map may be
+// nil; nil means "no attributes of that kind on the output."
+//
+// parseBody controls whether the adapter calls LogRecord.ParseFunc
+// (when set) to build a structured map body. The default for the
+// receiver is false — emit the raw Message string as the body and let
+// downstream processors parse if needed. parseBody=true opts into the
+// structured-map path with raw-string fallback on parser error or
+// empty result.
+//
+// logger is used for in-band warnings (failed attribute conversion,
+// ParseFunc errors). A nil logger yields a no-op logger.
+func NewLogAdapter(c consumer.Logs, resourceAttrs, attrs map[string]any, parseBody bool, logger *zap.Logger) *LogAdapter {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &LogAdapter{
+		consumer:      c,
+		resourceAttrs: resourceAttrs,
+		attrs:         attrs,
+		parseBody:     parseBody,
+		logger:        logger,
+	}
+}
+
+// ConsumeLogs satisfies embed.LogConsumer. Each record in the batch
+// becomes one plog log record under a single shared resource + scope.
+//
+// An empty batch is a no-op (returns nil without invoking the
+// downstream consumer); blitz framework allows producers to coalesce,
+// and the receiver should not push empty payloads downstream.
+func (a *LogAdapter) ConsumeLogs(ctx context.Context, records []embed.LogRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	if err := rl.Resource().Attributes().FromRaw(a.resourceAttrs); err != nil {
+		a.logger.Warn("blitzpdata: failed to set resource attributes", zap.Error(err))
+	}
+	sl := rl.ScopeLogs().AppendEmpty()
+	sl.Scope().SetName(scopeName)
+	observedNow := pcommon.NewTimestampFromTime(time.Now())
+	for i := range records {
+		a.appendRecord(sl.LogRecords().AppendEmpty(), &records[i], observedNow)
+	}
+	return a.consumer.ConsumeLogs(ctx, logs)
+}
+
+// appendRecord populates a fresh plog.LogRecord from a single
+// embed.LogRecord. observedNow is the ObservedTimestamp shared across
+// the batch — captured once per ConsumeLogs call so every record in a
+// batch sees the same observation timestamp.
+func (a *LogAdapter) appendRecord(lr plog.LogRecord, rec *embed.LogRecord, observedNow pcommon.Timestamp) {
+	ts := rec.Metadata.Timestamp
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+	lr.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+	lr.SetObservedTimestamp(observedNow)
+
+	if rec.Metadata.Severity != "" {
+		lr.SetSeverityText(rec.Metadata.Severity)
+		lr.SetSeverityNumber(severityNumberFor(rec.Metadata.Severity))
+	}
+
+	a.setBody(lr, rec)
+
+	if err := lr.Attributes().FromRaw(a.attrs); err != nil {
+		a.logger.Warn("blitzpdata: failed to set record attributes", zap.Error(err))
+	}
+}
+
+// setBody chooses raw-string or parsed-map representation for the log
+// record body.
+//
+// Default (parseBody=false): emit the raw Message. This matches what a
+// real log-collection pipeline sees on the wire and lets downstream
+// processors decide whether and how to parse.
+//
+// Opt-in (parseBody=true): if ParseFunc is set and succeeds with a
+// non-empty map, the body becomes a structured pcommon.Map. The
+// ParseFunc is treated as untrusted closure code — recipes ship
+// arbitrary parsers and the embed contract does not require them to
+// be panic-free — so the call is wrapped in a recover() and any
+// panic is treated the same as a parser error. On parser error
+// (returned or recovered), empty result, or map-conversion failure,
+// fall back to the raw Message and log at debug. ParseFunc=nil with
+// parseBody=true also falls back to raw (no work for the adapter to do).
+func (a *LogAdapter) setBody(lr plog.LogRecord, rec *embed.LogRecord) {
+	if !a.parseBody || rec.ParseFunc == nil {
+		lr.Body().SetStr(rec.Message)
+		return
+	}
+	parsed, err := safeParseFunc(rec.ParseFunc, rec.Message)
+	if err != nil {
+		a.logger.Debug("blitzpdata: ParseFunc returned error; using raw message", zap.Error(err))
+		lr.Body().SetStr(rec.Message)
+		return
+	}
+	if len(parsed) == 0 {
+		lr.Body().SetStr(rec.Message)
+		return
+	}
+	if err := lr.Body().SetEmptyMap().FromRaw(parsed); err != nil {
+		a.logger.Debug("blitzpdata: parsed map not representable as pcommon.Map; using raw message", zap.Error(err))
+		lr.Body().SetStr(rec.Message)
+	}
+}
+
+// safeParseFunc invokes a blitz-supplied ParseFunc with panic
+// protection. ParseFuncs are closures shipped by recipes; the embed
+// contract does not require them to be panic-free, so any panic is
+// caught and converted to an error — the caller will then fall back
+// to the raw Message exactly as it would on any other parser error.
+func safeParseFunc(parse func(string) (map[string]any, error), msg string) (parsed map[string]any, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			parsed = nil
+			err = fmt.Errorf("ParseFunc panicked: %v", r)
+		}
+	}()
+	return parse(msg)
+}
+
+// severityNumberFor maps a free-form severity string to an OTel
+// SeverityNumber. The mapping is best-effort and case-insensitive,
+// covering OTel's native short names (TRACE / DEBUG / INFO / WARN /
+// ERROR / FATAL) plus common syslog-style synonyms (NOTICE, CRITICAL,
+// ALERT, EMERGENCY) per OTel logs semantic conventions. Unknown text
+// returns SeverityNumberUnspecified — the caller will still have
+// SeverityText set so downstream processors can recover the original
+// label.
+func severityNumberFor(text string) plog.SeverityNumber {
+	switch strings.ToUpper(strings.TrimSpace(text)) {
+	case "TRACE":
+		return plog.SeverityNumberTrace
+	case "DEBUG", "DBG":
+		return plog.SeverityNumberDebug
+	case "INFO", "INFORMATION", "INFORMATIONAL":
+		return plog.SeverityNumberInfo
+	case "NOTICE":
+		return plog.SeverityNumberInfo2
+	case "WARN", "WARNING":
+		return plog.SeverityNumberWarn
+	case "ERROR", "ERR":
+		return plog.SeverityNumberError
+	case "CRITICAL", "CRIT":
+		return plog.SeverityNumberFatal2
+	case "ALERT":
+		return plog.SeverityNumberFatal3
+	case "FATAL":
+		return plog.SeverityNumberFatal
+	case "EMERGENCY", "EMERG", "PANIC":
+		return plog.SeverityNumberFatal4
+	default:
+		return plog.SeverityNumberUnspecified
+	}
+}

--- a/receiver/telemetrygeneratorreceiver/internal/blitzpdata/log_adapter_test.go
+++ b/receiver/telemetrygeneratorreceiver/internal/blitzpdata/log_adapter_test.go
@@ -1,0 +1,274 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blitzpdata
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/observiq/blitz/embed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestLogAdapter_EmptyBatch_NoPush(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	a := NewLogAdapter(sink, nil, nil, false, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeLogs(context.Background(), nil))
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{}))
+	assert.Equal(t, 0, sink.LogRecordCount(), "empty batches must not produce a downstream consume call")
+}
+
+func TestLogAdapter_RawMessage(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	a := NewLogAdapter(sink, nil, nil, false, zaptest.NewLogger(t))
+	ts := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	err := a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message: "hello world",
+		Metadata: embed.LogRecordMetadata{
+			Timestamp: ts,
+			Severity:  "INFO",
+		},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, 1, sink.LogRecordCount())
+	lr := firstLogRecord(t, sink.AllLogs())
+	assert.Equal(t, "hello world", lr.Body().Str())
+	assert.Equal(t, pcommon.NewTimestampFromTime(ts), lr.Timestamp())
+	assert.Equal(t, "INFO", lr.SeverityText())
+	assert.Equal(t, plog.SeverityNumberInfo, lr.SeverityNumber())
+	assert.NotZero(t, lr.ObservedTimestamp(), "ObservedTimestamp should be set")
+}
+
+func TestLogAdapter_RawByDefault_IgnoresParseFunc(t *testing.T) {
+	// parseBody=false (the receiver default) means ParseFunc is NOT
+	// invoked even when blitz populates it on the LogRecord. The body
+	// is the raw Message string. This protects downstream pipelines
+	// from receiving structured maps when the operator intended raw
+	// log lines (the typical telemetrygenerator-receiver use case).
+	sink := &consumertest.LogsSink{}
+	a := NewLogAdapter(sink, nil, nil, false, zaptest.NewLogger(t))
+	parseCalled := false
+	parseFunc := func(_ string) (map[string]any, error) {
+		parseCalled = true
+		return map[string]any{"never": "applied"}, nil
+	}
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message:   "192.0.2.1 - - [27/May/2026:12:00:00 +0000] \"GET / HTTP/1.1\" 200 0",
+		ParseFunc: parseFunc,
+	}}))
+	lr := firstLogRecord(t, sink.AllLogs())
+	assert.Equal(t, pcommon.ValueTypeStr, lr.Body().Type(), "raw mode must emit a string body")
+	assert.Equal(t, "192.0.2.1 - - [27/May/2026:12:00:00 +0000] \"GET / HTTP/1.1\" 200 0", lr.Body().Str())
+	assert.False(t, parseCalled, "ParseFunc must not be called when parseBody is false")
+}
+
+func TestLogAdapter_ParseFunc_Success(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	a := NewLogAdapter(sink, nil, nil, true, zaptest.NewLogger(t))
+	parsed := map[string]any{"method": "GET", "status": int64(200), "path": "/healthz"}
+	parseFunc := func(msg string) (map[string]any, error) {
+		assert.Equal(t, "GET /healthz 200", msg)
+		return parsed, nil
+	}
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message:   "GET /healthz 200",
+		ParseFunc: parseFunc,
+		Metadata:  embed.LogRecordMetadata{Severity: "INFO"},
+	}}))
+	require.Equal(t, 1, sink.LogRecordCount())
+	lr := firstLogRecord(t, sink.AllLogs())
+	require.Equal(t, pcommon.ValueTypeMap, lr.Body().Type())
+	body := lr.Body().Map().AsRaw()
+	assert.Equal(t, "GET", body["method"])
+	assert.Equal(t, int64(200), body["status"])
+	assert.Equal(t, "/healthz", body["path"])
+}
+
+func TestLogAdapter_ParseFunc_Error_FallsBackToRaw(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	a := NewLogAdapter(sink, nil, nil, true, zaptest.NewLogger(t))
+	parseFunc := func(_ string) (map[string]any, error) {
+		return nil, errors.New("malformed input")
+	}
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message:   "bad payload",
+		ParseFunc: parseFunc,
+	}}))
+	lr := firstLogRecord(t, sink.AllLogs())
+	assert.Equal(t, pcommon.ValueTypeStr, lr.Body().Type())
+	assert.Equal(t, "bad payload", lr.Body().Str())
+}
+
+func TestLogAdapter_ParseFunc_EmptyMap_FallsBackToRaw(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	a := NewLogAdapter(sink, nil, nil, true, zaptest.NewLogger(t))
+	parseFunc := func(_ string) (map[string]any, error) {
+		return map[string]any{}, nil
+	}
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message:   "raw",
+		ParseFunc: parseFunc,
+	}}))
+	lr := firstLogRecord(t, sink.AllLogs())
+	assert.Equal(t, "raw", lr.Body().Str())
+}
+
+func TestLogAdapter_ParseFunc_Panic_FallsBackToRaw(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	a := NewLogAdapter(sink, nil, nil, true, zaptest.NewLogger(t))
+	parseFunc := func(_ string) (map[string]any, error) {
+		panic("recipe ParseFunc went sideways")
+	}
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message:   "untrusted payload",
+		ParseFunc: parseFunc,
+	}}))
+	lr := firstLogRecord(t, sink.AllLogs())
+	assert.Equal(t, pcommon.ValueTypeStr, lr.Body().Type(),
+		"a panicking ParseFunc must fall back to the raw Message body")
+	assert.Equal(t, "untrusted payload", lr.Body().Str())
+	assert.Equal(t, 1, sink.LogRecordCount(),
+		"the record must still flow through despite the panic")
+}
+
+func TestLogAdapter_ResourceAndRecordAttributes(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	resourceAttrs := map[string]any{
+		"service.name": "blitz-test",
+		"deployment":   "ci",
+	}
+	attrs := map[string]any{
+		"log.source": "apache",
+	}
+	a := NewLogAdapter(sink, resourceAttrs, attrs, false, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message: "first",
+	}, {
+		Message: "second",
+	}}))
+	logs := sink.AllLogs()
+	require.Len(t, logs, 1, "batch should produce a single plog.Logs")
+	rl := logs[0].ResourceLogs().At(0)
+	resMap := rl.Resource().Attributes().AsRaw()
+	assert.Equal(t, "blitz-test", resMap["service.name"])
+	assert.Equal(t, "ci", resMap["deployment"])
+	require.Equal(t, 1, rl.ScopeLogs().Len())
+	sl := rl.ScopeLogs().At(0)
+	assert.Equal(t, scopeName, sl.Scope().Name())
+	require.Equal(t, 2, sl.LogRecords().Len())
+	for i := 0; i < sl.LogRecords().Len(); i++ {
+		lr := sl.LogRecords().At(i)
+		got := lr.Attributes().AsRaw()
+		assert.Equal(t, "apache", got["log.source"], "record %d should carry per-record attrs", i)
+	}
+}
+
+func TestLogAdapter_ZeroTimestamp_FallsBackToNow(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	a := NewLogAdapter(sink, nil, nil, false, zaptest.NewLogger(t))
+	before := time.Now()
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message: "no ts",
+	}}))
+	after := time.Now()
+	lr := firstLogRecord(t, sink.AllLogs())
+	ts := lr.Timestamp().AsTime()
+	assert.False(t, ts.Before(before), "timestamp should not predate the ConsumeLogs call")
+	assert.False(t, ts.After(after), "timestamp should not postdate the ConsumeLogs call")
+}
+
+func TestLogAdapter_NoSeverity_LeavesSeverityNumberUnspecified(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	a := NewLogAdapter(sink, nil, nil, false, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message: "no severity",
+	}}))
+	lr := firstLogRecord(t, sink.AllLogs())
+	assert.Empty(t, lr.SeverityText())
+	assert.Equal(t, plog.SeverityNumberUnspecified, lr.SeverityNumber())
+}
+
+func TestLogAdapter_NilLogger_NoPanic(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	a := NewLogAdapter(sink, nil, nil, false, nil)
+	require.NotPanics(t, func() {
+		_ = a.ConsumeLogs(context.Background(), []embed.LogRecord{{Message: "x"}})
+	})
+}
+
+func TestSeverityNumberFor(t *testing.T) {
+	tests := []struct {
+		text string
+		want plog.SeverityNumber
+	}{
+		// Case insensitivity + whitespace tolerance.
+		{"INFO", plog.SeverityNumberInfo},
+		{"info", plog.SeverityNumberInfo},
+		{"  info  ", plog.SeverityNumberInfo},
+		{"Information", plog.SeverityNumberInfo},
+		{"informational", plog.SeverityNumberInfo},
+
+		// OTel native short names.
+		{"TRACE", plog.SeverityNumberTrace},
+		{"DEBUG", plog.SeverityNumberDebug},
+		{"WARN", plog.SeverityNumberWarn},
+		{"ERROR", plog.SeverityNumberError},
+		{"FATAL", plog.SeverityNumberFatal},
+
+		// Common synonyms.
+		{"dbg", plog.SeverityNumberDebug},
+		{"warning", plog.SeverityNumberWarn},
+		{"err", plog.SeverityNumberError},
+
+		// Syslog-style high-severity levels.
+		{"NOTICE", plog.SeverityNumberInfo2},
+		{"CRITICAL", plog.SeverityNumberFatal2},
+		{"crit", plog.SeverityNumberFatal2},
+		{"ALERT", plog.SeverityNumberFatal3},
+		{"EMERGENCY", plog.SeverityNumberFatal4},
+		{"emerg", plog.SeverityNumberFatal4},
+		{"panic", plog.SeverityNumberFatal4},
+
+		// Unknowns yield Unspecified.
+		{"", plog.SeverityNumberUnspecified},
+		{"hilarious", plog.SeverityNumberUnspecified},
+	}
+	for _, tc := range tests {
+		t.Run(tc.text, func(t *testing.T) {
+			assert.Equal(t, tc.want, severityNumberFor(tc.text))
+		})
+	}
+}
+
+// firstLogRecord pulls the single log record out of a sink that expects
+// exactly one batch with exactly one record. Fails the test if the
+// shape doesn't match.
+func firstLogRecord(t *testing.T, logs []plog.Logs) plog.LogRecord {
+	t.Helper()
+	require.Len(t, logs, 1, "expected exactly one plog.Logs batch")
+	require.Equal(t, 1, logs[0].ResourceLogs().Len())
+	rl := logs[0].ResourceLogs().At(0)
+	require.Equal(t, 1, rl.ScopeLogs().Len())
+	sl := rl.ScopeLogs().At(0)
+	require.Equal(t, 1, sl.LogRecords().Len())
+	return sl.LogRecords().At(0)
+}


### PR DESCRIPTION
### Proposed Change

Introduces `internal/blitzpdata`, a small adapter package that bridges blitz's
`embed.LogConsumer` contract to OTel's `consumer.Logs` / `plog.Logs`. It is the
foundation for the receiver-side blitz embed integration tracked in PIPE-1017;
this PR adds the adapter in isolation so it can be reviewed without the
generator dispatch or receiver wiring on top.

`LogAdapter`:
- Wraps a `consumer.Logs` and a per-receiver-entry pair of resource/attribute
  maps (so a receiver config can stamp identity onto records produced by any
  blitz module wired through this adapter).
- Builds one `plog.LogRecord` per `embed.LogRecord` and writes it through the
  wrapped consumer.
- Body handling is opt-in: when `parseBody` is false (default — "raw mode")
  the adapter sets the body to `rec.Message` verbatim; when true and the
  record carries a `ParseFunc`, it tries the parse and falls back to raw on
  error.

No receiver-side wiring is changed in this PR — the adapter is consumed by
follow-up PRs in this stack. The blitz module dep is pinned at v0.17.1; v1
release of the full integration is gated on blitz v0.18.0 (PIPE-1021, which
adds per-record `Metadata.Attributes` + `Metadata.Resource`).

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
