### PR TITLE
feat(telemetrygeneratorreceiver): wire blitz embed runner into receiver lifecycle + docs (PIPE-1017)

### DIFF
--- a/receiver/telemetrygeneratorreceiver/README.md
+++ b/receiver/telemetrygeneratorreceiver/README.md
@@ -166,3 +166,90 @@ telemetrygeneratorreceiver:
     generators:
         - type: windows_events          
 ```       
+
+### Blitz Generator (logs only)
+
+The `blitz` generator type pulls structured telemetry from the [blitz](https://github.com/observIQ/blitz) embed package and converts it to OTel `pdata`. v1 of this integration is **logs-only** and supports two complementary configuration shapes — curated recipes and pasted blitz YAML. See [PIPE-1017](https://linear.app/bindplane/issue/PIPE-1017) for context and [docs/embed.md](https://github.com/observIQ/blitz/blob/main/docs/embed.md) in the blitz repo for the underlying contract.
+
+#### Build requirement
+
+**Any binary that links this receiver MUST be built with `-tags embed_library`.** The tag bakes the blitz filegen data library into the binary so `package:<name>` references in `blitz_yaml` configs resolve without an on-disk install of `data_library/`. The receiver fails fast at Start time if the tag was omitted and any `Type: "blitz"` entries are configured.
+
+For BDOT goreleaser builds, add `-tags embed_library` to the build flags. For local development:
+
+```sh
+go build -tags embed_library ./...
+go test -tags embed_library ./...
+```
+
+#### Supported pipelines
+
+`Type: "blitz"` is only valid on a **logs** pipeline. The receiver factory rejects `blitz` entries on metrics or traces pipelines at startup with a clear error. Metric and trace support arrives in a follow-up after blitz v0.17.0 ships the migrations.
+
+#### Configuration shapes
+
+##### Recipe (named, parameterized)
+
+| Field                              | Type      | Default       | Required | Description |
+|------------------------------------|-----------|---------------|----------|-------------|
+| `additional_config.recipe`         | string    |               | `true` (one of `recipe`/`blitz_yaml`) | Recipe name. v1 ships `apache`, `apache-combined`, `apache-error`, `nginx`, `kubernetes-cluster`, `pii-stress`. |
+| `additional_config.recipe_params.workers` | int  | recipe default | `false` | Per-generator worker count for the recipe's modules. Recipes use `1` (or `2` for `pii-stress`) when omitted. |
+| `additional_config.recipe_params.rate` | string  | recipe default | `false` | Per-generator emission interval (Go duration string, e.g. `100ms`). Recipes use `1s` (or `100ms` for `pii-stress`) when omitted. |
+
+##### Custom blitz YAML
+
+| Field                          | Type     | Default | Required | Description |
+|--------------------------------|----------|---------|----------|-------------|
+| `additional_config.blitz_yaml` | string   |         | `true` (one of `recipe`/`blitz_yaml`) | A verbatim blitz YAML config string. Parsed by blitz's public `config.LoadModules` API; supports every blitz log-producing generator (apache common/combined/error, filegen, json, kubernetes, nginx, okta, palo-alto, postgres). Non-log generators (`hostmetrics`, `traces`, `winevt`) are rejected with a clear error at startup. |
+
+Users wanting env-driven values inside `blitz_yaml` use the OTel collector's native env-substitution syntax at collector-config time — the receiver does not forward process env into the blitz loader.
+
+#### v1 limitations
+
+- `embed.LogRecord` at blitz v0.16.1 has no per-record resource or attributes; receiver-config `resource_attributes` / `attributes` are the sole source of those values on the outgoing plog. [PIPE-1021](https://linear.app/bindplane/issue/PIPE-1021) tracks the blitz contract expansion that adds uniform per-record metadata across all signal types. A follow-up receiver enhancement consumes it.
+- Metrics, traces, and the new `wel` Windows generator are deferred to a v2 receiver follow-up once blitz v0.17.0 ships.
+
+#### Example — recipe
+
+```yaml
+telemetrygeneratorreceiver:
+    payloads_per_second: 1
+    generators:
+        - type: blitz
+          resource_attributes:
+              service.name: my-app
+              deployment.environment: staging
+          attributes:
+              log.source: apache
+          additional_config:
+              recipe: apache-combined
+              recipe_params:
+                  workers: 2
+                  rate: 100ms
+```
+
+#### Example — custom blitz YAML
+
+```yaml
+telemetrygeneratorreceiver:
+    payloads_per_second: 1
+    generators:
+        - type: blitz
+          resource_attributes:
+              service.name: my-cluster
+          additional_config:
+              blitz_yaml: |
+                  generators:
+                    - type: apache-common
+                      apache-common: {workers: 1, rate: 100ms}
+                    - type: json
+                      json: {workers: 1, rate: 100ms, type: default}
+                    - type: kubernetes
+                      kubernetes: {workers: 1, rate: 100ms}
+                  output:
+                    type: nop
+                  logging:
+                    type: stdout
+                  metrics:
+                    port: 19000
+```

--- a/receiver/telemetrygeneratorreceiver/blitz_generator.go
+++ b/receiver/telemetrygeneratorreceiver/blitz_generator.go
@@ -17,6 +17,7 @@ package telemetrygeneratorreceiver //import "github.com/observiq/bindplane-otel-
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"strings"
 	"time"
 
@@ -43,6 +44,21 @@ const (
 	// handle parsing.
 	blitzKeyParseBody = "parse_body"
 )
+
+// assertEmbeddedLibraryAvailable verifies the blitz filegen data
+// library snapshot was compiled into the binary. The binary MUST be
+// built with `-tags embed_library`; without the tag,
+// embeddedlibrary.FS() returns an empty stub that cannot be walked, and
+// any filegen reference in a blitz_yaml config that uses `package:`
+// names will fail at runtime with a confusing error. Catching the
+// missing tag at Start time turns that into a clear actionable message.
+func assertEmbeddedLibraryAvailable(lib fs.FS) error {
+	entries, err := fs.ReadDir(lib, ".")
+	if err != nil || len(entries) == 0 {
+		return errors.New("blitz embedded data library is empty — this receiver requires the binary be built with `-tags embed_library`; see the receiver README for details")
+	}
+	return nil
+}
 
 // validateBlitzGeneratorConfig checks the shape of a Type: "blitz"
 // generator entry without constructing any modules. The full module

--- a/receiver/telemetrygeneratorreceiver/blitz_generator_test.go
+++ b/receiver/telemetrygeneratorreceiver/blitz_generator_test.go
@@ -16,7 +16,9 @@ package telemetrygeneratorreceiver
 
 import (
 	"context"
+	"io/fs"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/observiq/blitz/embed"
@@ -294,6 +296,33 @@ metrics:
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "hostmetrics", "rejection error should mention the rejected module type")
 }
+
+func TestAssertEmbeddedLibraryAvailable(t *testing.T) {
+	t.Run("populated FS passes", func(t *testing.T) {
+		populated := fstest.MapFS{"syslog_generic/sample.log": &fstest.MapFile{Data: []byte("ok")}}
+		assert.NoError(t, assertEmbeddedLibraryAvailable(populated))
+	})
+	t.Run("empty fstest.MapFS passes (non-zero entries)", func(t *testing.T) {
+		// Sanity: fstest.MapFS with one entry yields a non-empty ReadDir.
+		assert.NoError(t, assertEmbeddedLibraryAvailable(fstest.MapFS{"a": &fstest.MapFile{}}))
+	})
+	t.Run("ReadDir-erroring FS fails with build-tag hint", func(t *testing.T) {
+		err := assertEmbeddedLibraryAvailable(erroringFS{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "-tags embed_library")
+	})
+	t.Run("truly empty FS fails", func(t *testing.T) {
+		err := assertEmbeddedLibraryAvailable(fstest.MapFS{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "-tags embed_library")
+	})
+}
+
+// erroringFS mimics the embeddedlibrary off-tag stub: every Open call
+// returns fs.ErrNotExist, which propagates through fs.ReadDir.
+type erroringFS struct{}
+
+func (erroringFS) Open(string) (fs.File, error) { return nil, fs.ErrNotExist }
 
 func TestBuildBlitzModules_MissingShape(t *testing.T) {
 	logger := zaptest.NewLogger(t)

--- a/receiver/telemetrygeneratorreceiver/blitz_integration_test.go
+++ b/receiver/telemetrygeneratorreceiver/blitz_integration_test.go
@@ -1,0 +1,246 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build embed_library
+
+// The integration tests in this file exercise the full receiver
+// lifecycle against blitz embed sources. They require the receiver be
+// built with `-tags embed_library` because:
+//
+//  1. The receiver asserts the embeddedlibrary FS is non-empty at
+//     Start time when any Type: "blitz" entry is configured.
+//  2. Filegen-based tests need the data_library snapshot baked into
+//     the binary.
+//
+// The build tag matches the deployment reality (every binary linking
+// this receiver MUST be built with the tag — see the receiver README).
+
+package telemetrygeneratorreceiver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+// blitzRecipeTestCfg builds a Config that runs a single recipe under
+// fast params suitable for integration tests.
+func blitzRecipeTestCfg(recipe string, resourceAttrs, attrs map[string]any) *Config {
+	return &Config{
+		PayloadsPerSecond: 1,
+		Generators: []GeneratorConfig{{
+			Type:               generatorTypeBlitz,
+			ResourceAttributes: resourceAttrs,
+			Attributes:         attrs,
+			AdditionalConfig: map[string]any{
+				"recipe": recipe,
+				"recipe_params": map[string]any{
+					"workers": 1,
+					"rate":    "50ms",
+				},
+			},
+		}},
+	}
+}
+
+// TestBlitz_EveryRecipe_DeliversRecordsEndToEnd boots the receiver via
+// its factory for each v1 recipe, runs briefly, and asserts records
+// flow into a consumertest.LogsSink. Acceptance criterion: "All six
+// curated recipes are shipped and exercised in a table-driven
+// integration test."
+func TestBlitz_EveryRecipe_DeliversRecordsEndToEnd(t *testing.T) {
+	recipes := []string{
+		"apache",
+		"apache-combined",
+		"apache-error",
+		"kubernetes-cluster",
+		"nginx",
+		"pii-stress",
+	}
+	for _, name := range recipes {
+		t.Run(name, func(t *testing.T) {
+			sink := &consumertest.LogsSink{}
+			cfg := blitzRecipeTestCfg(name, map[string]any{"service.name": "blitz-it"}, map[string]any{"log.source": name})
+			r := startReceiver(t, cfg, sink)
+			t.Cleanup(func() {
+				stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = r.Shutdown(stopCtx)
+			})
+
+			require.Eventually(t,
+				func() bool { return sink.LogRecordCount() >= 3 },
+				5*time.Second, 50*time.Millisecond,
+				"recipe %q produced %d records (want >=3)", name, sink.LogRecordCount(),
+			)
+			assertResourceAttr(t, sink.AllLogs(), "service.name", "blitz-it")
+		})
+	}
+}
+
+// TestBlitz_BlitzYAML_MultiModule exercises the paste-YAML path with a
+// non-trivial multi-module config (apache + json + kubernetes
+// concurrent) parsed via blitz's LoadModules. Acceptance criterion:
+// "Custom-YAML integration test exercises a multi-module log config
+// (apache + json + kubernetes concurrent) parsed via LoadModules."
+func TestBlitz_BlitzYAML_MultiModule(t *testing.T) {
+	yaml := `
+generators:
+  - type: apache-common
+    apache-common: {workers: 1, rate: 50ms}
+  - type: json
+    json: {workers: 1, rate: 50ms, type: default}
+  - type: kubernetes
+    kubernetes: {workers: 1, rate: 50ms}
+output:
+  type: nop
+logging:
+  type: stdout
+metrics:
+  port: 19000
+`
+	cfg := &Config{
+		PayloadsPerSecond: 1,
+		Generators: []GeneratorConfig{{
+			Type: generatorTypeBlitz,
+			AdditionalConfig: map[string]any{
+				"blitz_yaml": yaml,
+			},
+		}},
+	}
+	sink := &consumertest.LogsSink{}
+	r := startReceiver(t, cfg, sink)
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = r.Shutdown(stopCtx)
+	})
+	require.Eventually(t,
+		func() bool { return sink.LogRecordCount() >= 9 },
+		5*time.Second, 50*time.Millisecond,
+		"multi-module blitz_yaml produced %d records (want >=9 — 3 generators × 3 records each)", sink.LogRecordCount(),
+	)
+}
+
+// TestBlitz_BlitzYAML_Filegen_EmbeddedLibrary exercises a filegen
+// generator that references a data_library entry by name. With the
+// embed_library build tag set, embeddedlibrary.FS() is non-empty and
+// filegen's `package:` references resolve against the bundled snapshot
+// without any on-disk data_library/. Acceptance criterion: "Custom-YAML
+// integration test exercises a filegen-based config that references
+// the embedded data library; no on-disk data_library/ required for the
+// test to pass."
+func TestBlitz_BlitzYAML_Filegen_EmbeddedLibrary(t *testing.T) {
+	yaml := `
+generator:
+  type: filegen
+  filegen:
+    workers: 1
+    rate: 50ms
+    source: package:syslog_generic
+output:
+  type: nop
+logging:
+  type: stdout
+metrics:
+  port: 19000
+`
+	cfg := &Config{
+		PayloadsPerSecond: 1,
+		Generators: []GeneratorConfig{{
+			Type: generatorTypeBlitz,
+			AdditionalConfig: map[string]any{
+				"blitz_yaml": yaml,
+			},
+		}},
+	}
+	sink := &consumertest.LogsSink{}
+	r := startReceiver(t, cfg, sink)
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = r.Shutdown(stopCtx)
+	})
+	require.Eventually(t,
+		func() bool { return sink.LogRecordCount() >= 3 },
+		5*time.Second, 50*time.Millisecond,
+		"filegen-via-embedded-library produced %d records (want >=3)", sink.LogRecordCount(),
+	)
+}
+
+// TestBlitz_BlitzYAML_RejectsNonLogModule_AtFactoryCreation verifies
+// that a blitz_yaml referencing hostmetrics (metric-producing, not yet
+// embed-eligible) surfaces blitz's LoadModules rejection error when the
+// receiver is constructed. Acceptance criterion: "blitz_yaml configs
+// that name a non-log module surface blitz's LoadModules rejection
+// error to the receiver user."
+func TestBlitz_BlitzYAML_RejectsNonLogModule_AtFactoryCreation(t *testing.T) {
+	yaml := `
+generator:
+  type: hostmetrics
+  hostmetrics: {workers: 1, rate: 1s}
+output:
+  type: nop
+logging:
+  type: stdout
+metrics:
+  port: 19000
+`
+	cfg := &Config{
+		PayloadsPerSecond: 1,
+		Generators: []GeneratorConfig{{
+			Type:             generatorTypeBlitz,
+			AdditionalConfig: map[string]any{"blitz_yaml": yaml},
+		}},
+	}
+	factory := NewFactory()
+	_, err := factory.CreateLogs(context.Background(), receivertest.NewNopSettings(factory.Type()), cfg, consumertest.NewNop())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hostmetrics", "rejection error should name the offending module")
+}
+
+// startReceiver builds a logs receiver through the factory and Starts
+// it. The returned receiver is the caller's responsibility to Shutdown
+// via t.Cleanup.
+func startReceiver(t *testing.T, cfg *Config, sink *consumertest.LogsSink) receiver.Logs {
+	t.Helper()
+	factory := NewFactory()
+	r, err := factory.CreateLogs(context.Background(), receivertest.NewNopSettings(factory.Type()), cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
+	return r
+}
+
+// assertResourceAttr scans every ResourceLogs in logs for an attribute
+// matching key=want. Fails the test if no resource has it.
+func assertResourceAttr(t *testing.T, logs []plog.Logs, key, want string) {
+	t.Helper()
+	for _, batch := range logs {
+		for i := 0; i < batch.ResourceLogs().Len(); i++ {
+			rl := batch.ResourceLogs().At(i)
+			if got, ok := rl.Resource().Attributes().Get(key); ok && got.AsString() == want {
+				return
+			}
+		}
+	}
+	t.Fatalf("no ResourceLogs found with %s=%q", key, want)
+}

--- a/receiver/telemetrygeneratorreceiver/factory.go
+++ b/receiver/telemetrygeneratorreceiver/factory.go
@@ -17,6 +17,7 @@ package telemetrygeneratorreceiver //import "github.com/observiq/bindplane-otel-
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver/internal/metadata"
 	"go.opentelemetry.io/collector/component"
@@ -51,6 +52,9 @@ func createMetricsReceiver(ctx context.Context, params receiver.Settings, conf c
 	if !ok {
 		return nil, errImproperCfgType
 	}
+	if err := rejectBlitzOnNonLogsSignal(cfg, "metrics"); err != nil {
+		return nil, err
+	}
 
 	return newMetricsReceiver(ctx, params.Logger, cfg, nextConsumer)
 }
@@ -71,6 +75,23 @@ func createTracesReceiver(ctx context.Context, params receiver.Settings, conf co
 	if !ok {
 		return nil, errImproperCfgType
 	}
+	if err := rejectBlitzOnNonLogsSignal(cfg, "traces"); err != nil {
+		return nil, err
+	}
 
 	return newTracesReceiver(ctx, params.Logger, cfg, nextConsumer)
+}
+
+// rejectBlitzOnNonLogsSignal fails fast if a Type: "blitz" generator
+// entry is configured on a non-logs receiver instance. v1 of the blitz
+// embed integration is logs-only (PIPE-1017); metric and trace adapters
+// land in a follow-up once blitz v0.17.0 migrates hostmetrics and
+// traces to the embed contract.
+func rejectBlitzOnNonLogsSignal(cfg *Config, signal string) error {
+	for _, g := range cfg.Generators {
+		if g.Type == generatorTypeBlitz {
+			return fmt.Errorf("generator type %q is logs-only in v1 of the telemetrygeneratorreceiver blitz integration (PIPE-1017); remove it from the %s pipeline or use one of the receiver's existing generator types", generatorTypeBlitz, signal)
+		}
+	}
+	return nil
 }

--- a/receiver/telemetrygeneratorreceiver/factory_test.go
+++ b/receiver/telemetrygeneratorreceiver/factory_test.go
@@ -15,9 +15,13 @@
 package telemetrygeneratorreceiver //import "github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver"
 
 import (
+	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
 func Test_createDefaultConfig(t *testing.T) {
@@ -29,4 +33,52 @@ func Test_createDefaultConfig(t *testing.T) {
 	actualCfg, ok := componentCfg.(*Config)
 	require.True(t, ok)
 	require.Equal(t, expectedCfg, actualCfg)
+}
+
+func Test_createMetricsReceiver_RejectsBlitzEntries(t *testing.T) {
+	factory := NewFactory()
+	cfg := &Config{
+		PayloadsPerSecond: 1,
+		Generators: []GeneratorConfig{{
+			Type:             generatorTypeBlitz,
+			AdditionalConfig: map[string]any{"recipe": "apache"},
+		}},
+	}
+	_, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(factory.Type()), cfg, consumertest.NewNop())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "logs-only in v1")
+	assert.Contains(t, err.Error(), "metrics pipeline")
+}
+
+func Test_createTracesReceiver_RejectsBlitzEntries(t *testing.T) {
+	factory := NewFactory()
+	cfg := &Config{
+		PayloadsPerSecond: 1,
+		Generators: []GeneratorConfig{{
+			Type:             generatorTypeBlitz,
+			AdditionalConfig: map[string]any{"recipe": "apache"},
+		}},
+	}
+	_, err := factory.CreateTraces(context.Background(), receivertest.NewNopSettings(factory.Type()), cfg, consumertest.NewNop())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "logs-only in v1")
+	assert.Contains(t, err.Error(), "traces pipeline")
+}
+
+func Test_createMetricsReceiver_StillAcceptsNonBlitzEntries(t *testing.T) {
+	// Regression check: factory rejection logic must only trigger on
+	// Type: "blitz" — existing receiver types still work on metrics.
+	factory := NewFactory()
+	cfg := &Config{
+		PayloadsPerSecond: 1,
+		Generators: []GeneratorConfig{{
+			Type: generatorTypeHostMetrics,
+			AdditionalConfig: map[string]any{
+				"host_name": "test.example.com",
+			},
+		}},
+	}
+	r, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(factory.Type()), cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, r)
 }

--- a/receiver/telemetrygeneratorreceiver/logs_receiver.go
+++ b/receiver/telemetrygeneratorreceiver/logs_receiver.go
@@ -18,9 +18,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/observiq/blitz/embed"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
+
+	"github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver/internal/blitzpdata"
 )
 
 type logsGeneratorReceiver struct {
@@ -30,6 +33,12 @@ type logsGeneratorReceiver struct {
 }
 
 // newLogsReceiver creates a new logs specific receiver.
+//
+// The Start/Shutdown lifecycle (including blitz runner orchestration
+// and ticker short-circuit for blitz-only configs) lives on the
+// embedded telemetryGeneratorReceiver — the constructor's only job
+// is to populate the fields that lifecycle reads: hasTickerGenerators
+// and blitzRunner.
 func newLogsReceiver(ctx context.Context, logger *zap.Logger, cfg *Config, nextConsumer consumer.Logs) (*logsGeneratorReceiver, error) {
 	lr := &logsGeneratorReceiver{
 		nextConsumer: nextConsumer,
@@ -43,11 +52,50 @@ func newLogsReceiver(ctx context.Context, logger *zap.Logger, cfg *Config, nextC
 	if err != nil {
 		return nil, fmt.Errorf("new logs generators: %w", err)
 	}
+	lr.hasTickerGenerators = len(lr.generators) > 0
+
+	if err := lr.buildBlitzRunner(logger, cfg); err != nil {
+		return nil, err
+	}
 
 	return lr, nil
 }
 
-// generateTelemetry
+// buildBlitzRunner constructs the embed.Runner from all Type: "blitz"
+// entries in cfg, if any. Each entry gets its own LogAdapter
+// (preserving per-entry resource + attribute config) wired into the
+// modules built for that entry; the modules from every entry are
+// aggregated into a single Runner stored on the embedded base type
+// so the shared Start/Shutdown lifecycle owns it.
+func (r *logsGeneratorReceiver) buildBlitzRunner(logger *zap.Logger, cfg *Config) error {
+	var modules []embed.ProducerModule
+	for i, g := range cfg.Generators {
+		if g.Type != generatorTypeBlitz {
+			continue
+		}
+		// parse_body is validated in validateBlitzGeneratorConfig; the
+		// type assertion here is safe — a non-bool would have been
+		// rejected at validation time. Absent → false (raw mode).
+		parseBody, _ := g.AdditionalConfig[blitzKeyParseBody].(bool)
+		adapter := blitzpdata.NewLogAdapter(r.nextConsumer, g.ResourceAttributes, g.Attributes, parseBody, logger)
+		mods, err := buildBlitzModules(logger, g, adapter)
+		if err != nil {
+			return fmt.Errorf("blitz generator[%d]: %w", i, err)
+		}
+		modules = append(modules, mods...)
+	}
+	if len(modules) == 0 {
+		return nil
+	}
+	runner, err := embed.New(embed.Config{Modules: modules})
+	if err != nil {
+		return fmt.Errorf("construct blitz runner: %w", err)
+	}
+	r.blitzRunner = runner
+	return nil
+}
+
+// produce
 func (r *logsGeneratorReceiver) produce() error {
 	logs := plog.NewLogs()
 	for _, g := range r.generators {
@@ -56,6 +104,14 @@ func (r *logsGeneratorReceiver) produce() error {
 			src := l.ResourceLogs().At(i)
 			src.CopyTo(logs.ResourceLogs().AppendEmpty())
 		}
+	}
+	if logs.ResourceLogs().Len() == 0 {
+		// Pure-blitz configs have zero pull-style generators; skip the
+		// no-op consume call so downstream pipelines aren't woken every
+		// tick. (Belt-and-suspenders: the lifecycle short-circuits the
+		// ticker entirely when hasTickerGenerators is false, but this
+		// guard also covers the produce-as-called case in tests.)
+		return nil
 	}
 	return r.nextConsumer.ConsumeLogs(r.ctx, logs)
 }

--- a/receiver/telemetrygeneratorreceiver/metrics_receiver.go
+++ b/receiver/telemetrygeneratorreceiver/metrics_receiver.go
@@ -43,6 +43,7 @@ func newMetricsReceiver(ctx context.Context, logger *zap.Logger, cfg *Config, ne
 	if err != nil {
 		return nil, fmt.Errorf("new metrics generators: %w", err)
 	}
+	mr.hasTickerGenerators = len(mr.generators) > 0
 
 	return mr, nil
 }

--- a/receiver/telemetrygeneratorreceiver/receiver.go
+++ b/receiver/telemetrygeneratorreceiver/receiver.go
@@ -17,10 +17,12 @@ package telemetrygeneratorreceiver //import "github.com/observiq/bindplane-otel-
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
+	"github.com/observiq/blitz/embed"
+	"github.com/observiq/blitz/generator/filegen/embeddedlibrary"
 	"go.opentelemetry.io/collector/component"
-
 	"go.uber.org/zap"
 )
 
@@ -29,6 +31,7 @@ type telemetryProducer interface {
 	// produce should generate telemetry from each generator, update the timestamps to now, and send it to the next consumer
 	produce() error
 }
+
 type telemetryGeneratorReceiver struct {
 	logger     *zap.Logger
 	cfg        *Config
@@ -36,6 +39,23 @@ type telemetryGeneratorReceiver struct {
 	ctx        context.Context
 	cancelFunc context.CancelCauseFunc
 	producer   telemetryProducer
+
+	// blitzRunner is non-nil when the signal-type receiver has any
+	// Type: "blitz" generator entries; populated by the signal-type
+	// constructor (e.g. logsGeneratorReceiver.buildBlitzRunner). The
+	// field lives on the base type so Start/Shutdown orchestration is
+	// signal-agnostic and v0.18.0's metrics/traces blitz Producers
+	// can drop in without re-implementing lifecycle wiring on each
+	// signal-type receiver.
+	blitzRunner embed.Runner
+
+	// hasTickerGenerators is true when the signal-type receiver has
+	// non-blitz generators driven by the payloads_per_second ticker.
+	// For blitz-only configs (and any config with zero pull-style
+	// generators) the ticker is short-circuited — blitz modules emit
+	// on their own schedule and an unused ticker would just wake the
+	// downstream pipeline with empty payloads each interval.
+	hasTickerGenerators bool
 }
 
 // newTelemetryGeneratorReceiver creates a new telemetry generator receiver
@@ -48,35 +68,88 @@ func newTelemetryGeneratorReceiver(_ context.Context, logger *zap.Logger, cfg *C
 	}
 }
 
-// Shutdown shuts down the telemetry generator receiver
+// Shutdown stops the blitz runner (if any), then drains the ticker
+// goroutine via the receiver's cancellation context. Blitz is
+// stopped before the ticker drain begins so in-flight blitz module
+// emissions get a chance to flush downstream before the receiver's
+// context is cancelled and the ticker goroutine exits.
 func (r *telemetryGeneratorReceiver) Shutdown(ctx context.Context) error {
-	if r.cancelFunc == nil {
-		return nil
+	var blitzErr error
+	if r.blitzRunner != nil {
+		blitzErr = r.blitzRunner.Stop(ctx)
 	}
-
+	if r.cancelFunc == nil {
+		return blitzErr
+	}
 	r.cancelFunc(errors.New("shutdown"))
-	var err error
+	var drainErr error
 	select {
 	case <-ctx.Done():
-		err = ctx.Err()
+		drainErr = ctx.Err()
 	case <-r.doneChan:
 	}
-
-	return err
+	if blitzErr != nil {
+		return blitzErr
+	}
+	return drainErr
 }
 
-// Start starts the telemetryGeneratorReceiver receiver
+// Start orchestrates receiver startup across blitz (when configured)
+// and the ticker-driven generator loop (when any non-blitz generators
+// exist to drive it).
+//
+// Order of operations, fixed:
+//  1. Assert the embed library is built in when blitz is configured,
+//     so a missing -tags embed_library is reported with a clear
+//     pointer rather than as a downstream filegen error.
+//  2. Initialize the cancellation context shared by both subsystems
+//     so Shutdown can unwind them with one call.
+//  3. Start blitz first. If its Start fails, return the error before
+//     spawning any ticker goroutine — the OTel-contract failure path
+//     (Start error ⇒ Shutdown not called) then never leaves a
+//     dangling ticker.
+//  4. Spawn the ticker only when there are non-blitz generators to
+//     drive it. For blitz-only or zero-generator configs the ticker
+//     is short-circuited entirely.
 func (r *telemetryGeneratorReceiver) Start(_ context.Context, _ component.Host) error {
+	if r.blitzRunner != nil {
+		if err := assertEmbeddedLibraryAvailable(embeddedlibrary.FS()); err != nil {
+			return err
+		}
+	}
+
 	r.ctx, r.cancelFunc = context.WithCancelCause(context.Background())
 
+	if r.blitzRunner != nil {
+		if err := r.blitzRunner.Start(r.ctx, embed.Host{Logger: r.logger}); err != nil {
+			r.cancelFunc(errors.New("blitz runner Start failed"))
+			close(r.doneChan)
+			return fmt.Errorf("start blitz runner: %w", err)
+		}
+	}
+
+	if r.hasTickerGenerators {
+		r.startTicker()
+	} else {
+		// No ticker goroutine will close doneChan; close it eagerly
+		// so Shutdown's drain path passes through immediately.
+		close(r.doneChan)
+	}
+	return nil
+}
+
+// startTicker spawns the payloads_per_second producer loop. r.ctx
+// and r.cancelFunc must already be initialized — Start does this
+// before reaching here so blitz and the ticker share one
+// cancellation handle.
+func (r *telemetryGeneratorReceiver) startTicker() {
 	go func() {
 		defer close(r.doneChan)
 
 		ticker := time.NewTicker(time.Second / time.Duration(r.cfg.PayloadsPerSecond))
 		defer ticker.Stop()
 
-		err := r.producer.produce()
-		if err != nil {
+		if err := r.producer.produce(); err != nil {
 			r.logger.Error("Error generating telemetry", zap.Error(err))
 		}
 		for {
@@ -84,12 +157,10 @@ func (r *telemetryGeneratorReceiver) Start(_ context.Context, _ component.Host) 
 			case <-r.ctx.Done():
 				return
 			case <-ticker.C:
-				err = r.producer.produce()
-				if err != nil {
+				if err := r.producer.produce(); err != nil {
 					r.logger.Error("Error generating telemetry", zap.Error(err))
 				}
 			}
 		}
 	}()
-	return nil
 }

--- a/receiver/telemetrygeneratorreceiver/traces_receiver.go
+++ b/receiver/telemetrygeneratorreceiver/traces_receiver.go
@@ -44,6 +44,7 @@ func newTracesReceiver(ctx context.Context, logger *zap.Logger, cfg *Config, nex
 	if err != nil {
 		return nil, fmt.Errorf("new traces generators: %w", err)
 	}
+	tr.hasTickerGenerators = len(tr.generators) > 0
 
 	return tr, nil
 }


### PR DESCRIPTION
### Proposed Change

Final piece of the receiver-side blitz embed integration: wires the
validated `Type: "blitz"` entries from the prior PR into the logs receiver's
lifecycle and adds user-facing documentation.

In this PR:
- `logs_receiver.go` constructs one `LogAdapter` per blitz entry (so each
  entry's resource/attribute config is preserved) and aggregates their
  produced `embed.ProducerModule`s into a single `embed.Runner` owned by the
  receiver. Runner Start/Stop is sequenced with the existing ticker-driven
  generator path.
- The non-blitz ticker is short-circuited for blitz-only configs — blitz
  modules emit on their own schedule (per recipe / per `blitz_yaml`), so the
  receiver's `payloads_per_second` ticker would just be a no-op wakeup.
- A build-tag guard surfaces a clear error pointing at the README when the
  binary is built without `-tags embed_library`, instead of letting a
  downstream filegen error bubble up.
- `factory.go` is updated for the new wiring; `blitz_integration_test.go` is
  added under `//go:build embed_library` to exercise the full Start →
  produce → Shutdown path against a real blitz runner.
- `README.md` gains a Blitz Generator section covering config shape, the
  recipe set, the `blitz_yaml` escape hatch, the `parse_body` flag, the
  build-tag requirement, and current limitations.

The blitz module dep is pinned at v0.17.1. v1 release of this feature still
blocks on blitz v0.18.0 — PIPE-1021 adds per-record `Metadata.Attributes` +
`Metadata.Resource` which the adapter will consume (receiver-config base,
blitz overrides on top) and several other Producers (hostmetrics migration,
traces migration, FIX, winevt deprecation) land in the same release.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
