### PR TITLE
chore(ci): Pin go.opentelemetry.io/otel/metric/x for gowork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,13 @@ _build-setup:
 	for dir in $$(find "$$CONTRIB_ROOT" -name "go.mod" -not -path "*/vendor/*" -not -path "*/internal/tools/*" -exec dirname {} \;); do \
 		go work use "$$dir"; \
 	done && \
+	go work edit -replace "go.opentelemetry.io/otel/metric/x=go.opentelemetry.io/otel/metric/x@v0.0.0-20260514180605-442cdbdd9466" && \
 	mkdir -p $(OUTDIR)
+
+# TODO: remove the go.opentelemetry.io/otel/metric/x replace above once the collector
+# repo no longer pins a pre-release go.opentelemetry.io/otel/sdk/metric. That pre-release
+# commit's go.mod requires metric/x at a placeholder version (v0.0.0-00010101000000-...)
+# that only resolves inside the otel repo itself, which breaks workspace-mode resolution.
 
 .PHONY: _cleanup-build
 _cleanup-build:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The build job was failing in CI due to a failing dependency.

Why didn't this fail in bindplane-otel-collector? Collector's go.sum included these lines:
```
go.opentelemetry.io/otel/metric/x v0.0.0-20260514180605-442cdbdd9466 h1:pUtoUqFKIPSAf0dpAypqBduXSeqshWrjFGFA/+4/asM=
go.opentelemetry.io/otel/metric/x v0.0.0-20260514180605-442cdbdd9466/go.mod h1:HG0GCETcrdYgvFEfzSoImrRLsaiK59c4ukCkL6jID8M=
```

k8sattributesprocessor v0.153.0 imports go.opentelemetry.io/otel/semconv/v1.41.0. That package doesn't exist in the latest otel release (v1.43.0 only ships up to semconv/v1.40.0).

Upstream contrib therefore pinned go.opentelemetry.io/otel and its sibling modules to an unreleased commit. This includes a replace statement for go.opentelemetry.io/otel/metric/x, with v0.0.0-00010101000000-000000000000 as the actual pre-replaced placeholder.

Workspace mode (which we use to build the collector in this repo via go.work) basically loses the replace statement, meaning that it tries to resolve metric/x v0.0.0-00010101000000-000000000000, which does not exist.

The fix is therefore to pin the go.work to the above version of metric/x. This will be removed with the update to OTel v0.154.0.

##### Checklist
- [x] Changes are tested
- [x] CI has passed