### PR TITLE
feat(telemetrygeneratorreceiver): Z3 per-key attribute locking + PIPE-1021 per-record metadata in LogAdapter (PIPE-1017)

### DIFF
--- a/receiver/telemetrygeneratorreceiver/blitz_generator.go
+++ b/receiver/telemetrygeneratorreceiver/blitz_generator.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
 
+	"github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver/internal/blitzpdata"
 	"github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver/internal/recipes"
 )
 
@@ -70,10 +71,23 @@ func assertEmbeddedLibraryAvailable(lib fs.FS) error {
 // (collector startup still fails with a clear message) and avoids the
 // duplication.
 func validateBlitzGeneratorConfig(g *GeneratorConfig) error {
-	if err := pcommon.NewMap().FromRaw(g.Attributes); err != nil {
+	// Blitz entries interpret resource_attributes / attributes with Z3
+	// per-key locking semantics: each key is either a simple scalar
+	// (unlocked) or a structured `{value: ..., lock: bool}` map. Parse
+	// to validate the Z3 shape, then check the effective base values
+	// are pcommon-representable.
+	attrsZ3, err := blitzpdata.ParseZ3(g.Attributes, "attributes")
+	if err != nil {
+		return err
+	}
+	if err := pcommon.NewMap().FromRaw(attrsZ3.Base); err != nil {
 		return fmt.Errorf("error in attributes config: %s", err)
 	}
-	if err := pcommon.NewMap().FromRaw(g.ResourceAttributes); err != nil {
+	resourceZ3, err := blitzpdata.ParseZ3(g.ResourceAttributes, "resource_attributes")
+	if err != nil {
+		return err
+	}
+	if err := pcommon.NewMap().FromRaw(resourceZ3.Base); err != nil {
 		return fmt.Errorf("error in resource_attributes config: %s", err)
 	}
 

--- a/receiver/telemetrygeneratorreceiver/blitz_generator_test.go
+++ b/receiver/telemetrygeneratorreceiver/blitz_generator_test.go
@@ -210,10 +210,11 @@ func TestValidateBlitz_ParseBody(t *testing.T) {
 }
 
 func TestValidateBlitz_AttributesAndResourceAttributes(t *testing.T) {
-	// Receiver-config Attributes and ResourceAttributes go through
+	// Receiver-config Attributes and ResourceAttributes are parsed
+	// with Z3 semantics (simple scalars + structured `{value, lock}`
+	// forms), then the effective base values go through
 	// pcommon.NewMap().FromRaw() to validate they're representable as
-	// pcommon.Map. Invalid raw shapes (e.g., a map with a chan value)
-	// should be rejected; valid raw shapes pass through.
+	// pcommon.Map.
 	cfg := &GeneratorConfig{
 		Type:               generatorTypeBlitz,
 		ResourceAttributes: map[string]any{"service.name": "blitz-test"},
@@ -221,6 +222,77 @@ func TestValidateBlitz_AttributesAndResourceAttributes(t *testing.T) {
 		AdditionalConfig:   map[string]any{"recipe": "apache"},
 	}
 	assert.NoError(t, validateBlitzGeneratorConfig(cfg))
+}
+
+func TestValidateBlitz_Z3Shapes(t *testing.T) {
+	cases := []struct {
+		name      string
+		resource  map[string]any
+		attrs     map[string]any
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "structured locked resource attr",
+			resource: map[string]any{
+				"host.name": map[string]any{"value": "pinned", "lock": true},
+			},
+			wantErr: false,
+		},
+		{
+			name: "structured form mixed with simple form",
+			resource: map[string]any{
+				"host.name": map[string]any{"value": "pinned", "lock": true},
+				"os.type":   "linux",
+			},
+			attrs: map[string]any{
+				"service.team": map[string]any{"value": "ops", "lock": true},
+				"run.id":       "r1",
+			},
+			wantErr: false,
+		},
+		{
+			name: "map without value sub-key rejected",
+			resource: map[string]any{
+				"host.name": map[string]any{"locked": true},
+			},
+			wantErr:   true,
+			errSubstr: "resource_attributes.host.name",
+		},
+		{
+			name: "unknown sub-key rejected",
+			attrs: map[string]any{
+				"a": map[string]any{"value": "v", "sticky": true},
+			},
+			wantErr:   true,
+			errSubstr: `unknown sub-key "sticky"`,
+		},
+		{
+			name: "non-boolean lock rejected",
+			attrs: map[string]any{
+				"a": map[string]any{"value": "v", "lock": "yes"},
+			},
+			wantErr:   true,
+			errSubstr: "must be a boolean",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &GeneratorConfig{
+				Type:               generatorTypeBlitz,
+				ResourceAttributes: tc.resource,
+				Attributes:         tc.attrs,
+				AdditionalConfig:   map[string]any{"recipe": "apache"},
+			}
+			err := validateBlitzGeneratorConfig(cfg)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errSubstr)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func TestParseRecipeParams_AcceptsRecipeDefaults(t *testing.T) {

--- a/receiver/telemetrygeneratorreceiver/internal/blitzpdata/log_adapter.go
+++ b/receiver/telemetrygeneratorreceiver/internal/blitzpdata/log_adapter.go
@@ -40,68 +40,109 @@ const scopeName = "github.com/observiq/bindplane-otel-contrib/receiver/telemetry
 // a fresh plog.Logs from the batch and pushes it to the receiver's
 // downstream consumer.
 //
-// The adapter is constructed once per receiver Start cycle. Resource
-// and per-record attribute maps are drawn from receiver config at
-// construction time and remain stable for the session; the v0.16.1
-// embed.LogRecord contract has no per-record attributes or resource
-// of its own (PIPE-1021 will lift this), so receiver config is the
-// sole source today.
+// The adapter holds per-receiver-entry Z3Config maps for the resource
+// and per-record attributes. At ConsumeLogs time, blitz's per-record
+// `Metadata.Resource` and `Metadata.Attributes` (PIPE-1021, available
+// in blitz v0.18.0+) merge over the Z3 base maps with locked keys
+// preserved from the receiver-config side. Records whose merged
+// resource maps fingerprint differently are emitted under separate
+// `ResourceLogs` (Q1 resource grouping); records that share a
+// fingerprint share a single `ResourceLogs`.
 type LogAdapter struct {
-	consumer      consumer.Logs
-	resourceAttrs map[string]any
-	attrs         map[string]any
-	parseBody     bool
-	logger        *zap.Logger
+	consumer  consumer.Logs
+	resource  Z3Config
+	attrs     Z3Config
+	parseBody bool
+	logger    *zap.Logger
 }
 
 // NewLogAdapter constructs an adapter that emits to the given consumer.
 //
-// resourceAttrs is written onto every outgoing plog.ResourceLogs.
-// attrs is written onto every outgoing log record. Either map may be
-// nil; nil means "no attributes of that kind on the output."
+// resource and attrs are Z3-parsed config maps (see Z3Config). Either
+// may be a zero-value Z3Config; an empty config contributes no base
+// values and locks no keys — blitz's per-record metadata flows through
+// unmodified.
 //
 // parseBody controls whether the adapter calls LogRecord.ParseFunc
 // (when set) to build a structured map body. The default for the
 // receiver is false — emit the raw Message string as the body and let
 // downstream processors parse if needed. parseBody=true opts into the
-// structured-map path with raw-string fallback on parser error or
-// empty result.
+// structured-map path with raw-string fallback on parser error, panic,
+// or empty result.
 //
 // logger is used for in-band warnings (failed attribute conversion,
 // ParseFunc errors). A nil logger yields a no-op logger.
-func NewLogAdapter(c consumer.Logs, resourceAttrs, attrs map[string]any, parseBody bool, logger *zap.Logger) *LogAdapter {
+func NewLogAdapter(c consumer.Logs, resource, attrs Z3Config, parseBody bool, logger *zap.Logger) *LogAdapter {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 	return &LogAdapter{
-		consumer:      c,
-		resourceAttrs: resourceAttrs,
-		attrs:         attrs,
-		parseBody:     parseBody,
-		logger:        logger,
+		consumer:  c,
+		resource:  resource,
+		attrs:     attrs,
+		parseBody: parseBody,
+		logger:    logger,
 	}
 }
 
-// ConsumeLogs satisfies embed.LogConsumer. Each record in the batch
-// becomes one plog log record under a single shared resource + scope.
+// ConsumeLogs satisfies embed.LogConsumer.
 //
-// An empty batch is a no-op (returns nil without invoking the
-// downstream consumer); blitz framework allows producers to coalesce,
-// and the receiver should not push empty payloads downstream.
+// For each record in the batch:
+//  1. Compute the effective resource by merging blitz's per-record
+//     `Metadata.Resource` over the adapter's `resource` Z3 base
+//     (locked keys from the base are not overridden).
+//  2. Group records by the fingerprint of their effective resource —
+//     records sharing a fingerprint go under a single `ResourceLogs`
+//     with one `ScopeLogs`; records with distinct fingerprints get
+//     their own `ResourceLogs`.
+//  3. For each record, merge blitz's per-record `Metadata.Attributes`
+//     over the adapter's `attrs` Z3 base (same locking semantics) and
+//     write the result onto the outgoing `LogRecord.Attributes`.
+//
+// Empty batches are no-ops (return nil without invoking the downstream
+// consumer) — blitz allows producers to coalesce and the receiver
+// should not push empty payloads downstream.
 func (a *LogAdapter) ConsumeLogs(ctx context.Context, records []embed.LogRecord) error {
 	if len(records) == 0 {
 		return nil
 	}
-	logs := plog.NewLogs()
-	rl := logs.ResourceLogs().AppendEmpty()
-	if err := rl.Resource().Attributes().FromRaw(a.resourceAttrs); err != nil {
-		a.logger.Warn("blitzpdata: failed to set resource attributes", zap.Error(err))
+
+	// Group records by their merged-resource fingerprint. Each group
+	// becomes one ResourceLogs in the outgoing plog.Logs. The order
+	// slice preserves first-occurrence ordering so the output is
+	// deterministic for a given input batch — useful for downstream
+	// pipelines that batch on consume order and for test assertions.
+	type group struct {
+		merged  map[string]any
+		records []int
 	}
-	sl := rl.ScopeLogs().AppendEmpty()
-	sl.Scope().SetName(scopeName)
-	observedNow := pcommon.NewTimestampFromTime(time.Now())
+	groups := make(map[string]*group)
+	order := make([]string, 0)
 	for i := range records {
-		a.appendRecord(sl.LogRecords().AppendEmpty(), &records[i], observedNow)
+		merged := a.resource.MergeWithStringOverlay(records[i].Metadata.Resource)
+		fp := FingerprintMap(merged)
+		g, exists := groups[fp]
+		if !exists {
+			g = &group{merged: merged}
+			groups[fp] = g
+			order = append(order, fp)
+		}
+		g.records = append(g.records, i)
+	}
+
+	logs := plog.NewLogs()
+	observedNow := pcommon.NewTimestampFromTime(time.Now())
+	for _, fp := range order {
+		g := groups[fp]
+		rl := logs.ResourceLogs().AppendEmpty()
+		if err := rl.Resource().Attributes().FromRaw(g.merged); err != nil {
+			a.logger.Warn("blitzpdata: failed to set resource attributes", zap.Error(err))
+		}
+		sl := rl.ScopeLogs().AppendEmpty()
+		sl.Scope().SetName(scopeName)
+		for _, idx := range g.records {
+			a.appendRecord(sl.LogRecords().AppendEmpty(), &records[idx], observedNow)
+		}
 	}
 	return a.consumer.ConsumeLogs(ctx, logs)
 }
@@ -125,7 +166,8 @@ func (a *LogAdapter) appendRecord(lr plog.LogRecord, rec *embed.LogRecord, obser
 
 	a.setBody(lr, rec)
 
-	if err := lr.Attributes().FromRaw(a.attrs); err != nil {
+	mergedAttrs := a.attrs.MergeWithAnyOverlay(rec.Metadata.Attributes)
+	if err := lr.Attributes().FromRaw(mergedAttrs); err != nil {
 		a.logger.Warn("blitzpdata: failed to set record attributes", zap.Error(err))
 	}
 }

--- a/receiver/telemetrygeneratorreceiver/internal/blitzpdata/log_adapter_test.go
+++ b/receiver/telemetrygeneratorreceiver/internal/blitzpdata/log_adapter_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestLogAdapter_EmptyBatch_NoPush(t *testing.T) {
 	sink := &consumertest.LogsSink{}
-	a := NewLogAdapter(sink, nil, nil, false, zaptest.NewLogger(t))
+	a := NewLogAdapter(sink, Z3Config{}, Z3Config{}, false, zaptest.NewLogger(t))
 	require.NoError(t, a.ConsumeLogs(context.Background(), nil))
 	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{}))
 	assert.Equal(t, 0, sink.LogRecordCount(), "empty batches must not produce a downstream consume call")
@@ -39,7 +39,7 @@ func TestLogAdapter_EmptyBatch_NoPush(t *testing.T) {
 
 func TestLogAdapter_RawMessage(t *testing.T) {
 	sink := &consumertest.LogsSink{}
-	a := NewLogAdapter(sink, nil, nil, false, zaptest.NewLogger(t))
+	a := NewLogAdapter(sink, Z3Config{}, Z3Config{}, false, zaptest.NewLogger(t))
 	ts := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
 	err := a.ConsumeLogs(context.Background(), []embed.LogRecord{{
 		Message: "hello world",
@@ -65,7 +65,7 @@ func TestLogAdapter_RawByDefault_IgnoresParseFunc(t *testing.T) {
 	// from receiving structured maps when the operator intended raw
 	// log lines (the typical telemetrygenerator-receiver use case).
 	sink := &consumertest.LogsSink{}
-	a := NewLogAdapter(sink, nil, nil, false, zaptest.NewLogger(t))
+	a := NewLogAdapter(sink, Z3Config{}, Z3Config{}, false, zaptest.NewLogger(t))
 	parseCalled := false
 	parseFunc := func(_ string) (map[string]any, error) {
 		parseCalled = true
@@ -83,7 +83,7 @@ func TestLogAdapter_RawByDefault_IgnoresParseFunc(t *testing.T) {
 
 func TestLogAdapter_ParseFunc_Success(t *testing.T) {
 	sink := &consumertest.LogsSink{}
-	a := NewLogAdapter(sink, nil, nil, true, zaptest.NewLogger(t))
+	a := NewLogAdapter(sink, Z3Config{}, Z3Config{}, true, zaptest.NewLogger(t))
 	parsed := map[string]any{"method": "GET", "status": int64(200), "path": "/healthz"}
 	parseFunc := func(msg string) (map[string]any, error) {
 		assert.Equal(t, "GET /healthz 200", msg)
@@ -105,7 +105,7 @@ func TestLogAdapter_ParseFunc_Success(t *testing.T) {
 
 func TestLogAdapter_ParseFunc_Error_FallsBackToRaw(t *testing.T) {
 	sink := &consumertest.LogsSink{}
-	a := NewLogAdapter(sink, nil, nil, true, zaptest.NewLogger(t))
+	a := NewLogAdapter(sink, Z3Config{}, Z3Config{}, true, zaptest.NewLogger(t))
 	parseFunc := func(_ string) (map[string]any, error) {
 		return nil, errors.New("malformed input")
 	}
@@ -120,7 +120,7 @@ func TestLogAdapter_ParseFunc_Error_FallsBackToRaw(t *testing.T) {
 
 func TestLogAdapter_ParseFunc_EmptyMap_FallsBackToRaw(t *testing.T) {
 	sink := &consumertest.LogsSink{}
-	a := NewLogAdapter(sink, nil, nil, true, zaptest.NewLogger(t))
+	a := NewLogAdapter(sink, Z3Config{}, Z3Config{}, true, zaptest.NewLogger(t))
 	parseFunc := func(_ string) (map[string]any, error) {
 		return map[string]any{}, nil
 	}
@@ -134,7 +134,7 @@ func TestLogAdapter_ParseFunc_EmptyMap_FallsBackToRaw(t *testing.T) {
 
 func TestLogAdapter_ParseFunc_Panic_FallsBackToRaw(t *testing.T) {
 	sink := &consumertest.LogsSink{}
-	a := NewLogAdapter(sink, nil, nil, true, zaptest.NewLogger(t))
+	a := NewLogAdapter(sink, Z3Config{}, Z3Config{}, true, zaptest.NewLogger(t))
 	parseFunc := func(_ string) (map[string]any, error) {
 		panic("recipe ParseFunc went sideways")
 	}
@@ -152,14 +152,14 @@ func TestLogAdapter_ParseFunc_Panic_FallsBackToRaw(t *testing.T) {
 
 func TestLogAdapter_ResourceAndRecordAttributes(t *testing.T) {
 	sink := &consumertest.LogsSink{}
-	resourceAttrs := map[string]any{
+	resource := Z3Config{Base: map[string]any{
 		"service.name": "blitz-test",
 		"deployment":   "ci",
-	}
-	attrs := map[string]any{
+	}}
+	attrs := Z3Config{Base: map[string]any{
 		"log.source": "apache",
-	}
-	a := NewLogAdapter(sink, resourceAttrs, attrs, false, zaptest.NewLogger(t))
+	}}
+	a := NewLogAdapter(sink, resource, attrs, false, zaptest.NewLogger(t))
 	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
 		Message: "first",
 	}, {
@@ -184,7 +184,7 @@ func TestLogAdapter_ResourceAndRecordAttributes(t *testing.T) {
 
 func TestLogAdapter_ZeroTimestamp_FallsBackToNow(t *testing.T) {
 	sink := &consumertest.LogsSink{}
-	a := NewLogAdapter(sink, nil, nil, false, zaptest.NewLogger(t))
+	a := NewLogAdapter(sink, Z3Config{}, Z3Config{}, false, zaptest.NewLogger(t))
 	before := time.Now()
 	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
 		Message: "no ts",
@@ -198,7 +198,7 @@ func TestLogAdapter_ZeroTimestamp_FallsBackToNow(t *testing.T) {
 
 func TestLogAdapter_NoSeverity_LeavesSeverityNumberUnspecified(t *testing.T) {
 	sink := &consumertest.LogsSink{}
-	a := NewLogAdapter(sink, nil, nil, false, zaptest.NewLogger(t))
+	a := NewLogAdapter(sink, Z3Config{}, Z3Config{}, false, zaptest.NewLogger(t))
 	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
 		Message: "no severity",
 	}}))
@@ -209,7 +209,7 @@ func TestLogAdapter_NoSeverity_LeavesSeverityNumberUnspecified(t *testing.T) {
 
 func TestLogAdapter_NilLogger_NoPanic(t *testing.T) {
 	sink := &consumertest.LogsSink{}
-	a := NewLogAdapter(sink, nil, nil, false, nil)
+	a := NewLogAdapter(sink, Z3Config{}, Z3Config{}, false, nil)
 	require.NotPanics(t, func() {
 		_ = a.ConsumeLogs(context.Background(), []embed.LogRecord{{Message: "x"}})
 	})
@@ -257,6 +257,144 @@ func TestSeverityNumberFor(t *testing.T) {
 			assert.Equal(t, tc.want, severityNumberFor(tc.text))
 		})
 	}
+}
+
+// PIPE-1021 per-record metadata tests — blitz-supplied Metadata.Resource
+// and Metadata.Attributes merging over the receiver-config Z3 base.
+
+func TestLogAdapter_PerRecordResource_MergesOverBase(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	resource := Z3Config{Base: map[string]any{
+		"host.name":    "from-config",
+		"cluster.name": "gargantua",
+	}}
+	a := NewLogAdapter(sink, resource, Z3Config{}, false, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message: "x",
+		Metadata: embed.LogRecordMetadata{
+			Resource: map[string]string{
+				"host.name":        "from-blitz", // overrides unlocked base
+				"telemetry.source": "nginx",      // new key, lands as-is
+			},
+		},
+	}}))
+	logs := sink.AllLogs()
+	require.Len(t, logs, 1)
+	resMap := logs[0].ResourceLogs().At(0).Resource().Attributes().AsRaw()
+	assert.Equal(t, "from-blitz", resMap["host.name"], "unlocked: blitz wins")
+	assert.Equal(t, "gargantua", resMap["cluster.name"], "no blitz value: base stays")
+	assert.Equal(t, "nginx", resMap["telemetry.source"], "blitz-only key lands")
+}
+
+func TestLogAdapter_PerRecordResource_LockedKeyStays(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	resource := Z3Config{
+		Base:   map[string]any{"host.name": "pinned-host"},
+		Locked: map[string]struct{}{"host.name": {}},
+	}
+	a := NewLogAdapter(sink, resource, Z3Config{}, false, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message: "x",
+		Metadata: embed.LogRecordMetadata{
+			Resource: map[string]string{"host.name": "blitz-host"},
+		},
+	}}))
+	resMap := sink.AllLogs()[0].ResourceLogs().At(0).Resource().Attributes().AsRaw()
+	assert.Equal(t, "pinned-host", resMap["host.name"], "locked: receiver-config wins")
+}
+
+func TestLogAdapter_PerRecordAttributes_MergeAndLock(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	attrs := Z3Config{
+		Base: map[string]any{
+			"service.team": "midnight-pizza-ops",
+			"test.run.id":  "base-run",
+		},
+		Locked: map[string]struct{}{"service.team": {}},
+	}
+	a := NewLogAdapter(sink, Z3Config{}, attrs, false, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+		Message: "x",
+		Metadata: embed.LogRecordMetadata{
+			Attributes: map[string]any{
+				"service.team":    "blitz-team", // locked — dropped
+				"test.run.id":     "blitz-run",  // unlocked — wins
+				"blitz.generator": "apache",     // blitz-only — lands
+			},
+		},
+	}}))
+	lr := firstLogRecord(t, sink.AllLogs())
+	got := lr.Attributes().AsRaw()
+	assert.Equal(t, "midnight-pizza-ops", got["service.team"])
+	assert.Equal(t, "blitz-run", got["test.run.id"])
+	assert.Equal(t, "apache", got["blitz.generator"])
+}
+
+func TestLogAdapter_NilAndEmptyMetadata_Identical(t *testing.T) {
+	// Q3: nil and empty Metadata maps both mean "no override".
+	for _, meta := range []embed.LogRecordMetadata{
+		{}, // nil maps
+		{Resource: map[string]string{}, Attributes: map[string]any{}}, // empty maps
+	} {
+		sink := &consumertest.LogsSink{}
+		resource := Z3Config{Base: map[string]any{"host.name": "h"}}
+		attrs := Z3Config{Base: map[string]any{"a": "v"}}
+		a := NewLogAdapter(sink, resource, attrs, false, zaptest.NewLogger(t))
+		require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{{
+			Message:  "x",
+			Metadata: meta,
+		}}))
+		resMap := sink.AllLogs()[0].ResourceLogs().At(0).Resource().Attributes().AsRaw()
+		assert.Equal(t, "h", resMap["host.name"])
+		lr := firstLogRecord(t, sink.AllLogs())
+		assert.Equal(t, "v", lr.Attributes().AsRaw()["a"])
+	}
+}
+
+// Q1 resource grouping tests — records with distinct effective resources
+// split into separate ResourceLogs; identical resources share one.
+
+func TestLogAdapter_ResourceGrouping_DistinctResources_Split(t *testing.T) {
+	sink := &consumertest.LogsSink{}
+	a := NewLogAdapter(sink, Z3Config{}, Z3Config{}, false, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{
+		{Message: "a", Metadata: embed.LogRecordMetadata{Resource: map[string]string{"host.name": "h1"}}},
+		{Message: "b", Metadata: embed.LogRecordMetadata{Resource: map[string]string{"host.name": "h2"}}},
+		{Message: "c", Metadata: embed.LogRecordMetadata{Resource: map[string]string{"host.name": "h1"}}},
+	}))
+	logs := sink.AllLogs()
+	require.Len(t, logs, 1)
+	require.Equal(t, 2, logs[0].ResourceLogs().Len(), "two distinct resources → two ResourceLogs")
+	// First-occurrence ordering: h1 group first (records a + c), then h2.
+	rl0 := logs[0].ResourceLogs().At(0)
+	assert.Equal(t, "h1", rl0.Resource().Attributes().AsRaw()["host.name"])
+	require.Equal(t, 1, rl0.ScopeLogs().Len())
+	assert.Equal(t, 2, rl0.ScopeLogs().At(0).LogRecords().Len(), "h1 group carries records a and c")
+	rl1 := logs[0].ResourceLogs().At(1)
+	assert.Equal(t, "h2", rl1.Resource().Attributes().AsRaw()["host.name"])
+	assert.Equal(t, 1, rl1.ScopeLogs().At(0).LogRecords().Len())
+}
+
+func TestLogAdapter_ResourceGrouping_LockedKeyCollapsesGroups(t *testing.T) {
+	// Q1 × Z3 interaction: when the differing key is locked, all
+	// records share the same effective resource and group together.
+	sink := &consumertest.LogsSink{}
+	resource := Z3Config{
+		Base:   map[string]any{"host.name": "pinned"},
+		Locked: map[string]struct{}{"host.name": {}},
+	}
+	a := NewLogAdapter(sink, resource, Z3Config{}, false, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeLogs(context.Background(), []embed.LogRecord{
+		{Message: "a", Metadata: embed.LogRecordMetadata{Resource: map[string]string{"host.name": "h1"}}},
+		{Message: "b", Metadata: embed.LogRecordMetadata{Resource: map[string]string{"host.name": "h2"}}},
+	}))
+	logs := sink.AllLogs()
+	require.Len(t, logs, 1)
+	require.Equal(t, 1, logs[0].ResourceLogs().Len(),
+		"locked host.name collapses both records into one ResourceLogs")
+	rl := logs[0].ResourceLogs().At(0)
+	assert.Equal(t, "pinned", rl.Resource().Attributes().AsRaw()["host.name"])
+	assert.Equal(t, 2, rl.ScopeLogs().At(0).LogRecords().Len())
 }
 
 // firstLogRecord pulls the single log record out of a sink that expects

--- a/receiver/telemetrygeneratorreceiver/internal/blitzpdata/z3.go
+++ b/receiver/telemetrygeneratorreceiver/internal/blitzpdata/z3.go
@@ -1,0 +1,201 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blitzpdata // import "github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver/internal/blitzpdata"
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Z3Config holds a Z3-shaped attribute map after parsing:
+//
+//   - Base is every key's effective value — the scalar from the simple
+//     form `key: value`, or the `value` field of the structured form
+//     `key: { value: ..., lock: true|false }`. The lock state is not
+//     reflected in Base; both locked and unlocked keys contribute
+//     their value as the adapter-side base.
+//   - Locked is the set of keys with `lock: true`. Per-record blitz
+//     metadata values for these keys are dropped during merge — the
+//     receiver-config Base value stays put.
+//
+// A zero-value Z3Config (nil maps) is treated as "no base, no locks":
+// blitz's per-record metadata flows through unchanged to the outgoing
+// pdata.
+type Z3Config struct {
+	Base   map[string]any
+	Locked map[string]struct{}
+}
+
+// IsEmpty reports whether the config has neither base entries nor
+// locked keys. Used by adapter merge paths to short-circuit work for
+// the common "no receiver-config base, no locking" case.
+func (z Z3Config) IsEmpty() bool {
+	return len(z.Base) == 0 && len(z.Locked) == 0
+}
+
+// ParseZ3 parses a YAML/config map into a Z3Config. Each entry's value
+// may be either:
+//
+//   - A scalar (string, number, bool, slice, or any value that is NOT
+//     a Go map[string]any with a `value` sub-key) — simple form, the
+//     scalar is the attribute value and the key is unlocked.
+//   - A structured form: a map containing exactly `value` (required)
+//     and optionally `lock` (bool, default false). `lock: true` adds
+//     the key to the locked set.
+//
+// Validation errors are returned with the offending key's full config
+// path (e.g. "resource_attributes.deployment.environment") so the user
+// can locate the issue in their YAML without scanning the whole config.
+//
+// A nil or empty input map returns a zero-value Z3Config without
+// allocation.
+func ParseZ3(raw map[string]any, fieldPath string) (Z3Config, error) {
+	if len(raw) == 0 {
+		return Z3Config{}, nil
+	}
+	cfg := Z3Config{
+		Base:   make(map[string]any, len(raw)),
+		Locked: make(map[string]struct{}),
+	}
+	// Iterate in sorted key order so validation errors are
+	// deterministic across runs — the user gets the same first-failing
+	// key on every parse attempt.
+	keys := make([]string, 0, len(raw))
+	for k := range raw {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		keyPath := fieldPath + "." + key
+		val := raw[key]
+		sub, isMap := val.(map[string]any)
+		if !isMap {
+			cfg.Base[key] = val
+			continue
+		}
+		// Map at value position: must be Z3 structured form with a
+		// `value` sub-key. Without `value` the input is ambiguous
+		// (typo in a structured form, or a multi-value attribute the
+		// user meant as the value itself); reject explicitly.
+		valueField, hasValue := sub["value"]
+		if !hasValue {
+			return Z3Config{}, fmt.Errorf(
+				"%s: map at value position has no `value` sub-key; "+
+					"for a multi-value attribute use the simple form `%s: <map>`, "+
+					"for Z3 per-key locking use the structured form `%s: { value: <map>, lock: ... }`",
+				keyPath, key, key)
+		}
+		for sk := range sub {
+			if sk != "value" && sk != "lock" {
+				return Z3Config{}, fmt.Errorf(
+					"%s: unknown sub-key %q in structured form; only `value` and `lock` are allowed",
+					keyPath, sk)
+			}
+		}
+		var locked bool
+		if lockRaw, hasLock := sub["lock"]; hasLock {
+			lockBool, ok := lockRaw.(bool)
+			if !ok {
+				return Z3Config{}, fmt.Errorf(
+					"%s.lock: must be a boolean (true or false), got %T",
+					keyPath, lockRaw)
+			}
+			locked = lockBool
+		}
+		cfg.Base[key] = valueField
+		if locked {
+			cfg.Locked[key] = struct{}{}
+		}
+	}
+	return cfg, nil
+}
+
+// MergeWithStringOverlay returns a fresh map[string]any combining the
+// Z3 base map with a string-typed per-record overlay (used for
+// resource attributes, which are typed `map[string]string` across all
+// three signal types in blitz's record contract). Locked keys in the
+// base are NOT overridden by the overlay; unlocked keys are.
+//
+// For locks-only / overlay-only / both-empty cases, the result is
+// allocated to the combined max size to avoid a re-grow during merge.
+// Returning a fresh map (vs in-place mutation of base.Base) is
+// deliberate — the LogAdapter is constructed once per receiver entry
+// and may be invoked concurrently from blitz module goroutines.
+func (z Z3Config) MergeWithStringOverlay(overlay map[string]string) map[string]any {
+	merged := make(map[string]any, len(z.Base)+len(overlay))
+	for k, v := range z.Base {
+		merged[k] = v
+	}
+	for k, v := range overlay {
+		if _, locked := z.Locked[k]; locked {
+			continue
+		}
+		merged[k] = v
+	}
+	return merged
+}
+
+// MergeWithAnyOverlay is the `map[string]any`-overlay sibling of
+// MergeWithStringOverlay, used for per-record attribute overlays on
+// logs (`LogRecord.Metadata.Attributes`) and spans
+// (`Span.Metadata.Attributes`) where blitz emits values as `any`.
+// Semantics are otherwise identical: locked keys stay receiver-config;
+// unlocked keys take the overlay value.
+func (z Z3Config) MergeWithAnyOverlay(overlay map[string]any) map[string]any {
+	merged := make(map[string]any, len(z.Base)+len(overlay))
+	for k, v := range z.Base {
+		merged[k] = v
+	}
+	for k, v := range overlay {
+		if _, locked := z.Locked[k]; locked {
+			continue
+		}
+		merged[k] = v
+	}
+	return merged
+}
+
+// FingerprintMap returns a stable string representation of the
+// argument map suitable for grouping records by their effective
+// resource. Keys are sorted; values are stringified with `%v`.
+//
+// Used by adapters to bucket records in a single batch into one
+// `ResourceLogs` / `ResourceMetrics` / `ResourceSpans` per unique
+// merged-resource map (Q1 resource grouping). Two records whose
+// merged resources serialize to the same fingerprint share a
+// `ResourceX`; records whose fingerprints differ land in separate
+// resource sets.
+//
+// The unit-separator byte (0x1f) between entries prevents `key=val`
+// vs `keyval=` ambiguity (e.g. `{a: "b=c"}` vs `{a: "b", c: ""}`).
+func FingerprintMap(m map[string]any) string {
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var sb strings.Builder
+	for _, k := range keys {
+		sb.WriteString(k)
+		sb.WriteByte('=')
+		fmt.Fprintf(&sb, "%v", m[k])
+		sb.WriteByte('\x1f')
+	}
+	return sb.String()
+}

--- a/receiver/telemetrygeneratorreceiver/internal/blitzpdata/z3_test.go
+++ b/receiver/telemetrygeneratorreceiver/internal/blitzpdata/z3_test.go
@@ -1,0 +1,257 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blitzpdata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseZ3_NilInput_ReturnsEmpty(t *testing.T) {
+	cfg, err := ParseZ3(nil, "resource_attributes")
+	require.NoError(t, err)
+	assert.True(t, cfg.IsEmpty())
+	assert.Nil(t, cfg.Base)
+	assert.Nil(t, cfg.Locked)
+}
+
+func TestParseZ3_EmptyInput_ReturnsEmpty(t *testing.T) {
+	cfg, err := ParseZ3(map[string]any{}, "resource_attributes")
+	require.NoError(t, err)
+	assert.True(t, cfg.IsEmpty())
+}
+
+func TestParseZ3_SimpleForm_Scalars(t *testing.T) {
+	in := map[string]any{
+		"host.name":    "my-host",
+		"port":         8080,
+		"enabled":      true,
+		"sample.ratio": 0.25,
+	}
+	cfg, err := ParseZ3(in, "resource_attributes")
+	require.NoError(t, err)
+	assert.Equal(t, "my-host", cfg.Base["host.name"])
+	assert.Equal(t, 8080, cfg.Base["port"])
+	assert.Equal(t, true, cfg.Base["enabled"])
+	assert.Equal(t, 0.25, cfg.Base["sample.ratio"])
+	assert.Empty(t, cfg.Locked, "scalars are unlocked")
+}
+
+func TestParseZ3_StructuredForm_Locked(t *testing.T) {
+	in := map[string]any{
+		"deployment.environment": map[string]any{
+			"value": "staging",
+			"lock":  true,
+		},
+	}
+	cfg, err := ParseZ3(in, "resource_attributes")
+	require.NoError(t, err)
+	assert.Equal(t, "staging", cfg.Base["deployment.environment"])
+	_, locked := cfg.Locked["deployment.environment"]
+	assert.True(t, locked)
+}
+
+func TestParseZ3_StructuredForm_ExplicitUnlocked(t *testing.T) {
+	in := map[string]any{
+		"region": map[string]any{
+			"value": "us-east",
+			"lock":  false,
+		},
+	}
+	cfg, err := ParseZ3(in, "resource_attributes")
+	require.NoError(t, err)
+	assert.Equal(t, "us-east", cfg.Base["region"])
+	_, locked := cfg.Locked["region"]
+	assert.False(t, locked, "lock: false stays unlocked")
+}
+
+func TestParseZ3_StructuredForm_OmittedLockDefaultsFalse(t *testing.T) {
+	in := map[string]any{
+		"region": map[string]any{
+			"value": "us-east",
+		},
+	}
+	cfg, err := ParseZ3(in, "resource_attributes")
+	require.NoError(t, err)
+	assert.Equal(t, "us-east", cfg.Base["region"])
+	_, locked := cfg.Locked["region"]
+	assert.False(t, locked, "omitted lock defaults to false")
+}
+
+func TestParseZ3_MixedSimpleAndStructured(t *testing.T) {
+	in := map[string]any{
+		"host.name":              "my-host",
+		"cluster.name":           "gargantua",
+		"deployment.environment": map[string]any{"value": "staging", "lock": true},
+		"region": map[string]any{
+			"value": "us-east",
+			"lock":  false,
+		},
+	}
+	cfg, err := ParseZ3(in, "resource_attributes")
+	require.NoError(t, err)
+	assert.Equal(t, "my-host", cfg.Base["host.name"])
+	assert.Equal(t, "gargantua", cfg.Base["cluster.name"])
+	assert.Equal(t, "staging", cfg.Base["deployment.environment"])
+	assert.Equal(t, "us-east", cfg.Base["region"])
+	assert.Contains(t, cfg.Locked, "deployment.environment")
+	assert.NotContains(t, cfg.Locked, "region")
+	assert.NotContains(t, cfg.Locked, "host.name")
+}
+
+func TestParseZ3_StructuredForm_MapValueAsValueField(t *testing.T) {
+	// The `value` field can itself be any type — including a nested
+	// map. This is the simple-form-vs-structured-form disambiguation
+	// path: the structured form is identified by presence of the
+	// `value` sub-key, not by the value type.
+	in := map[string]any{
+		"nested.attr": map[string]any{
+			"value": map[string]any{"a": "b", "c": 1},
+			"lock":  true,
+		},
+	}
+	cfg, err := ParseZ3(in, "attributes")
+	require.NoError(t, err)
+	nested, ok := cfg.Base["nested.attr"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "b", nested["a"])
+	assert.Equal(t, 1, nested["c"])
+	assert.Contains(t, cfg.Locked, "nested.attr")
+}
+
+func TestParseZ3_MapWithoutValueKey_Rejected(t *testing.T) {
+	in := map[string]any{
+		"deployment.environment": map[string]any{
+			"locked": true, // typo for "lock", no value field
+		},
+	}
+	_, err := ParseZ3(in, "resource_attributes")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resource_attributes.deployment.environment")
+	assert.Contains(t, err.Error(), "no `value` sub-key")
+}
+
+func TestParseZ3_StructuredForm_UnknownSubKey_Rejected(t *testing.T) {
+	in := map[string]any{
+		"deployment.environment": map[string]any{
+			"value":  "staging",
+			"sticky": true, // unknown sub-key
+		},
+	}
+	_, err := ParseZ3(in, "resource_attributes")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resource_attributes.deployment.environment")
+	assert.Contains(t, err.Error(), `unknown sub-key "sticky"`)
+}
+
+func TestParseZ3_StructuredForm_NonBooleanLock_Rejected(t *testing.T) {
+	in := map[string]any{
+		"deployment.environment": map[string]any{
+			"value": "staging",
+			"lock":  "yes", // should be boolean
+		},
+	}
+	_, err := ParseZ3(in, "resource_attributes")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resource_attributes.deployment.environment.lock")
+	assert.Contains(t, err.Error(), "must be a boolean")
+}
+
+func TestParseZ3_DeterministicErrorKey(t *testing.T) {
+	// Two errors in one map — parser should fail on the
+	// alphabetically-first offending key so the user sees a stable
+	// error across runs.
+	in := map[string]any{
+		"zeta": map[string]any{"locked": true}, // no value
+		"alpha": map[string]any{
+			"value": "v",
+			"lock":  "yes", // non-bool
+		},
+	}
+	_, err := ParseZ3(in, "attributes")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "attributes.alpha", "alpha sorts before zeta")
+}
+
+func TestMergeWithStringOverlay_Empty(t *testing.T) {
+	cfg := Z3Config{}
+	merged := cfg.MergeWithStringOverlay(nil)
+	assert.Empty(t, merged)
+}
+
+func TestMergeWithStringOverlay_BaseOnly(t *testing.T) {
+	cfg := Z3Config{Base: map[string]any{"host.name": "h1", "os.type": "linux"}}
+	merged := cfg.MergeWithStringOverlay(nil)
+	assert.Equal(t, "h1", merged["host.name"])
+	assert.Equal(t, "linux", merged["os.type"])
+}
+
+func TestMergeWithStringOverlay_OverlayWins_Unlocked(t *testing.T) {
+	cfg := Z3Config{Base: map[string]any{"host.name": "from-config"}}
+	merged := cfg.MergeWithStringOverlay(map[string]string{"host.name": "from-blitz"})
+	assert.Equal(t, "from-blitz", merged["host.name"], "unlocked: blitz overlay wins")
+}
+
+func TestMergeWithStringOverlay_LockedStays(t *testing.T) {
+	cfg := Z3Config{
+		Base:   map[string]any{"host.name": "from-config"},
+		Locked: map[string]struct{}{"host.name": {}},
+	}
+	merged := cfg.MergeWithStringOverlay(map[string]string{"host.name": "from-blitz"})
+	assert.Equal(t, "from-config", merged["host.name"], "locked: receiver-config wins")
+}
+
+func TestMergeWithStringOverlay_OverlayKeyNotInBase_Added(t *testing.T) {
+	cfg := Z3Config{Base: map[string]any{"host.name": "h"}}
+	merged := cfg.MergeWithStringOverlay(map[string]string{"telemetry.source": "nginx"})
+	assert.Equal(t, "h", merged["host.name"])
+	assert.Equal(t, "nginx", merged["telemetry.source"])
+}
+
+func TestMergeWithAnyOverlay_LockedStays_AnyValueType(t *testing.T) {
+	cfg := Z3Config{
+		Base:   map[string]any{"svc.weight": 100},
+		Locked: map[string]struct{}{"svc.weight": {}},
+	}
+	merged := cfg.MergeWithAnyOverlay(map[string]any{"svc.weight": 0})
+	assert.Equal(t, 100, merged["svc.weight"])
+}
+
+func TestFingerprintMap_Empty(t *testing.T) {
+	assert.Equal(t, "", FingerprintMap(nil))
+	assert.Equal(t, "", FingerprintMap(map[string]any{}))
+}
+
+func TestFingerprintMap_StableUnderKeyOrder(t *testing.T) {
+	a := FingerprintMap(map[string]any{"b": 1, "a": 2})
+	b := FingerprintMap(map[string]any{"a": 2, "b": 1})
+	assert.Equal(t, a, b, "fingerprint should be insertion-order-independent")
+}
+
+func TestFingerprintMap_DifferentValuesYieldDifferentFingerprints(t *testing.T) {
+	a := FingerprintMap(map[string]any{"host.name": "h1"})
+	b := FingerprintMap(map[string]any{"host.name": "h2"})
+	assert.NotEqual(t, a, b)
+}
+
+func TestFingerprintMap_SeparatorAvoidsCollision(t *testing.T) {
+	// Without a separator, both these maps could produce the same
+	// flat string "abc". The unit-separator byte prevents that.
+	a := FingerprintMap(map[string]any{"a": "bc"})
+	b := FingerprintMap(map[string]any{"ab": "c"})
+	assert.NotEqual(t, a, b)
+}

--- a/receiver/telemetrygeneratorreceiver/logs_receiver.go
+++ b/receiver/telemetrygeneratorreceiver/logs_receiver.go
@@ -77,7 +77,19 @@ func (r *logsGeneratorReceiver) buildBlitzRunner(logger *zap.Logger, cfg *Config
 		// type assertion here is safe — a non-bool would have been
 		// rejected at validation time. Absent → false (raw mode).
 		parseBody, _ := g.AdditionalConfig[blitzKeyParseBody].(bool)
-		adapter := blitzpdata.NewLogAdapter(r.nextConsumer, g.ResourceAttributes, g.Attributes, parseBody, logger)
+		// Z3 shapes were validated at config-validate time; re-parse
+		// here to build the adapter's base + locked-key structures.
+		// Errors are still checked (belt-and-suspenders) in case the
+		// entry bypassed validation in a test harness.
+		resourceZ3, err := blitzpdata.ParseZ3(g.ResourceAttributes, "resource_attributes")
+		if err != nil {
+			return fmt.Errorf("blitz generator[%d]: %w", i, err)
+		}
+		attrsZ3, err := blitzpdata.ParseZ3(g.Attributes, "attributes")
+		if err != nil {
+			return fmt.Errorf("blitz generator[%d]: %w", i, err)
+		}
+		adapter := blitzpdata.NewLogAdapter(r.nextConsumer, resourceZ3, attrsZ3, parseBody, logger)
 		mods, err := buildBlitzModules(logger, g, adapter)
 		if err != nil {
 			return fmt.Errorf("blitz generator[%d]: %w", i, err)


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed