### PR TITLE
feat(telemetrygeneratorreceiver): MetricAdapter + metrics receiver blitz wiring (PIPE-1017)

### DIFF
--- a/receiver/telemetrygeneratorreceiver/blitz_generator.go
+++ b/receiver/telemetrygeneratorreceiver/blitz_generator.go
@@ -168,18 +168,40 @@ func parseRecipeParams(raw any) (recipes.Params, error) {
 	return out, nil
 }
 
+// blitzConsumers bundles the signal-typed consumers a receiver
+// instance wires into blitz module construction. Each signal-type
+// receiver populates only its own slot (the logs receiver sets logs,
+// the metrics receiver sets metrics, etc.); the other slots stay nil.
+// blitz's LoadModules rejects any generator in a blitz_yaml whose
+// matching consumer is nil with a clear signal-type error — that
+// rejection IS the receiver's wrong-signal validation (e.g. a log
+// generator configured on a metrics receiver instance).
+type blitzConsumers struct {
+	logs    embed.LogConsumer
+	metrics embed.MetricConsumer
+	traces  embed.TraceConsumer
+}
+
 // buildBlitzModules resolves one blitz generator entry into a slice of
-// embed.ProducerModule instances wired to the supplied consumer.
+// embed.ProducerModule instances wired to the supplied consumers.
 //
-// Called by the logs receiver at Start time after the LogAdapter for
-// the entry has been constructed. Returns an error if the entry's
-// configured recipe or blitz_yaml fails to construct modules — in the
-// blitz_yaml case, this is where non-log generator-type rejections
-// (hostmetrics, traces, winevt) from blitz's LoadModules first reach
-// the receiver. The receiver surfaces the error verbatim so the
-// operator sees blitz's pointer to the v0.17.0 follow-up.
-func buildBlitzModules(logger *zap.Logger, g GeneratorConfig, consumer embed.LogConsumer) ([]embed.ProducerModule, error) {
+// Called by each signal-type receiver at Start time after the
+// signal-appropriate adapter for the entry has been constructed.
+// Returns an error if the entry's configured recipe or blitz_yaml
+// fails to construct modules — in the blitz_yaml case this is where
+// signal-type mismatches (a generator whose consumer slot is nil) and
+// non-embed-eligible generator rejections (winevt, nop) from blitz's
+// LoadModules reach the receiver. The receiver surfaces those errors
+// verbatim.
+func buildBlitzModules(logger *zap.Logger, g GeneratorConfig, consumers blitzConsumers) ([]embed.ProducerModule, error) {
 	if name, ok := g.AdditionalConfig[blitzKeyRecipe].(string); ok && name != "" {
+		// All curated recipes are log recipes; metric/trace generators
+		// are reachable via blitz_yaml only (recipes are an optional
+		// usability layer — curating metric/trace recipes waits on
+		// usage patterns against the v0.19.0 Producer set).
+		if consumers.logs == nil {
+			return nil, fmt.Errorf("recipe %q: curated recipes are log-only; use blitz_yaml for metric and trace generators", name)
+		}
 		fn, found := recipes.Get(name)
 		if !found {
 			return nil, fmt.Errorf("unknown recipe %q", name)
@@ -188,7 +210,7 @@ func buildBlitzModules(logger *zap.Logger, g GeneratorConfig, consumer embed.Log
 		if err != nil {
 			return nil, err
 		}
-		return fn(logger, consumer, params)
+		return fn(logger, consumers.logs, params)
 	}
 
 	raw, ok := g.AdditionalConfig[blitzKeyBlitzYAML].(string)
@@ -197,7 +219,9 @@ func buildBlitzModules(logger *zap.Logger, g GeneratorConfig, consumer embed.Log
 	}
 	return config.LoadModules([]byte(raw), config.EmbedOpts{
 		Logger:         logger,
-		LogConsumer:    consumer,
+		LogConsumer:    consumers.logs,
+		MetricConsumer: consumers.metrics,
+		TraceConsumer:  consumers.traces,
 		FileGenLibrary: embeddedlibrary.FS(),
 		// EnvOverrides intentionally nil: the receiver does not forward
 		// process env. Users who want env-driven values inside their

--- a/receiver/telemetrygeneratorreceiver/blitz_generator_test.go
+++ b/receiver/telemetrygeneratorreceiver/blitz_generator_test.go
@@ -313,7 +313,7 @@ func TestBuildBlitzModules_RecipePath(t *testing.T) {
 			"recipe_params": map[string]any{"workers": 2, "rate": "100ms"},
 		},
 	}
-	mods, err := buildBlitzModules(logger, cfg, nopBlitzLogConsumer{})
+	mods, err := buildBlitzModules(logger, cfg, blitzConsumers{logs: nopBlitzLogConsumer{}})
 	require.NoError(t, err)
 	require.Len(t, mods, 1, "apache recipe should yield exactly one module")
 }
@@ -337,7 +337,7 @@ metrics:
 		Type:             generatorTypeBlitz,
 		AdditionalConfig: map[string]any{"blitz_yaml": yaml},
 	}
-	mods, err := buildBlitzModules(logger, cfg, nopBlitzLogConsumer{})
+	mods, err := buildBlitzModules(logger, cfg, blitzConsumers{logs: nopBlitzLogConsumer{}})
 	require.NoError(t, err)
 	require.Len(t, mods, 1)
 }
@@ -364,7 +364,7 @@ metrics:
 		Type:             generatorTypeBlitz,
 		AdditionalConfig: map[string]any{"blitz_yaml": yaml},
 	}
-	_, err := buildBlitzModules(logger, cfg, nopBlitzLogConsumer{})
+	_, err := buildBlitzModules(logger, cfg, blitzConsumers{logs: nopBlitzLogConsumer{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "hostmetrics", "rejection error should mention the rejected module type")
 }
@@ -402,7 +402,7 @@ func TestBuildBlitzModules_MissingShape(t *testing.T) {
 		Type:             generatorTypeBlitz,
 		AdditionalConfig: map[string]any{},
 	}
-	_, err := buildBlitzModules(logger, cfg, nopBlitzLogConsumer{})
+	_, err := buildBlitzModules(logger, cfg, blitzConsumers{logs: nopBlitzLogConsumer{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "neither a recipe nor blitz_yaml")
 }

--- a/receiver/telemetrygeneratorreceiver/internal/blitzpdata/metric_adapter.go
+++ b/receiver/telemetrygeneratorreceiver/internal/blitzpdata/metric_adapter.go
@@ -1,0 +1,215 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blitzpdata // import "github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver/internal/blitzpdata"
+
+import (
+	"context"
+	"time"
+
+	"github.com/observiq/blitz/embed"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+// MetricAdapter implements embed.MetricConsumer. Each ConsumeMetrics
+// call builds a fresh pmetric.Metrics from the batch and pushes it to
+// the receiver's downstream consumer.
+//
+// Shape mirrors LogAdapter: per-receiver-entry LockableAttrs maps for
+// resource and per-point attributes; blitz's per-point
+// `Metadata.Resource` and `Metadata.Attributes` merge over the configured
+// bases with locked keys preserved; points whose merged resource maps
+// fingerprint differently are emitted under separate `ResourceMetrics`
+// (Q1 resource grouping).
+//
+// Each embed.MetricPoint becomes one pmetric.Metric carrying a single
+// data point. Blitz emits pre-aggregated points (it is a generator,
+// not an aggregating SDK), so the receiver does not attempt to
+// coalesce same-name points into multi-point metrics — downstream
+// processors can do that if a pipeline needs it.
+type MetricAdapter struct {
+	consumer consumer.Metrics
+	resource LockableAttrs
+	attrs    LockableAttrs
+	logger   *zap.Logger
+}
+
+// NewMetricAdapter constructs an adapter that emits to the given
+// consumer. resource and attrs follow the same per-key locking semantics as
+// NewLogAdapter. A nil logger yields a no-op logger.
+func NewMetricAdapter(c consumer.Metrics, resource, attrs LockableAttrs, logger *zap.Logger) *MetricAdapter {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &MetricAdapter{
+		consumer: c,
+		resource: resource,
+		attrs:    attrs,
+		logger:   logger,
+	}
+}
+
+// ConsumeMetrics satisfies embed.MetricConsumer. Points are grouped by
+// merged-resource fingerprint (one ResourceMetrics per unique merged
+// resource, first-occurrence ordered); each point converts to one
+// pmetric.Metric with a single data point. Empty batches are no-ops.
+func (a *MetricAdapter) ConsumeMetrics(ctx context.Context, points []embed.MetricPoint) error {
+	if len(points) == 0 {
+		return nil
+	}
+
+	type group struct {
+		merged map[string]any
+		points []int
+	}
+	groups := make(map[string]*group)
+	order := make([]string, 0)
+	for i := range points {
+		merged := a.resource.MergeWithStringOverlay(points[i].Metadata.Resource)
+		fp := FingerprintMap(merged)
+		g, exists := groups[fp]
+		if !exists {
+			g = &group{merged: merged}
+			groups[fp] = g
+			order = append(order, fp)
+		}
+		g.points = append(g.points, i)
+	}
+
+	metrics := pmetric.NewMetrics()
+	for _, fp := range order {
+		g := groups[fp]
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		if err := rm.Resource().Attributes().FromRaw(g.merged); err != nil {
+			a.logger.Warn("blitzpdata: failed to set resource attributes", zap.Error(err))
+		}
+		sm := rm.ScopeMetrics().AppendEmpty()
+		sm.Scope().SetName(scopeName)
+		for _, idx := range g.points {
+			a.appendPoint(sm.Metrics().AppendEmpty(), &points[idx])
+		}
+	}
+	return a.consumer.ConsumeMetrics(ctx, metrics)
+}
+
+// appendPoint populates a fresh pmetric.Metric from a single
+// embed.MetricPoint.
+//
+// Type mapping:
+//   - gauge     → Gauge
+//   - sum       → Sum, cumulative, non-monotonic (an up-down value)
+//   - counter   → Sum, cumulative, monotonic (a classic counter)
+//   - histogram → Histogram, cumulative, with explicit bucket bounds
+//
+// Unknown metric types are emitted as Gauge with a warning — dropping
+// the point silently would make a misbehaving generator invisible, and
+// failing the whole batch for one bad point is disproportionate for a
+// telemetry generator.
+func (a *MetricAdapter) appendPoint(m pmetric.Metric, pt *embed.MetricPoint) {
+	m.SetName(pt.Name)
+	m.SetDescription(pt.Description)
+	m.SetUnit(pt.Unit)
+
+	ts := pt.Metadata.Timestamp
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+	pts := pcommon.NewTimestampFromTime(ts)
+
+	mergedAttrs := a.attrs.MergeWithStringOverlay(pt.Metadata.Attributes)
+
+	switch pt.Type {
+	case embed.MetricTypeGauge:
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		a.setNumberValue(dp, pt, pts, mergedAttrs)
+	case embed.MetricTypeSum:
+		sum := m.SetEmptySum()
+		sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		sum.SetIsMonotonic(false)
+		dp := sum.DataPoints().AppendEmpty()
+		a.setNumberValue(dp, pt, pts, mergedAttrs)
+	case embed.MetricTypeCounter:
+		sum := m.SetEmptySum()
+		sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		sum.SetIsMonotonic(true)
+		dp := sum.DataPoints().AppendEmpty()
+		a.setNumberValue(dp, pt, pts, mergedAttrs)
+	case embed.MetricTypeHistogram:
+		hist := m.SetEmptyHistogram()
+		hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		dp := hist.DataPoints().AppendEmpty()
+		dp.SetTimestamp(pts)
+		dp.SetCount(pt.HistogramCount)
+		dp.SetSum(pt.HistogramSum)
+		dp.SetMin(pt.HistogramMin)
+		dp.SetMax(pt.HistogramMax)
+		// OTel requires len(BucketCounts) == len(ExplicitBounds)+1.
+		// blitz is a generator, not an aggregating SDK, so a
+		// misconfigured generator can emit a mismatched pair. The
+		// pcommon slice FromRaw setters are void (they cannot report
+		// the violation), so writing a mismatched pair produces a
+		// histogram that breaks the invariant and only fails much later,
+		// deep in an exporter, with a confusing message. Validate here:
+		// on match, set both bounds and counts; on mismatch, warn
+		// (naming the metric + the lengths) and emit the point with
+		// aggregate stats only (count/sum/min/max, no buckets), which is
+		// still a valid — if less detailed — histogram. Empty/empty is
+		// the legitimate no-buckets case and passes through silently.
+		bounds := pt.HistogramBucketBounds
+		counts := pt.HistogramBucketCounts
+		switch {
+		case len(counts) == len(bounds)+1:
+			dp.ExplicitBounds().FromRaw(bounds)
+			dp.BucketCounts().FromRaw(counts)
+		case len(bounds) > 0 || len(counts) > 0:
+			a.logger.Warn("blitzpdata: histogram bucket bounds/counts violate len(counts)==len(bounds)+1; emitting point without buckets",
+				zap.String("metric", pt.Name),
+				zap.Int("bounds", len(bounds)),
+				zap.Int("counts", len(counts)))
+		}
+		if err := dp.Attributes().FromRaw(mergedAttrs); err != nil {
+			a.logger.Warn("blitzpdata: failed to set histogram point attributes", zap.Error(err))
+		}
+	default:
+		a.logger.Warn("blitzpdata: unknown metric type; emitting as gauge",
+			zap.String("metric", pt.Name), zap.String("type", string(pt.Type)))
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		a.setNumberValue(dp, pt, pts, mergedAttrs)
+	}
+}
+
+// setNumberValue writes the point's numeric value, timestamp, and
+// merged attributes onto a NumberDataPoint. IntValue wins when both
+// are non-nil (the embed contract documents them as mutually
+// exclusive, so both-set is a generator bug; preferring the int keeps
+// the choice deterministic). Neither set yields a zero-valued double
+// point — emitting zero is more diagnosable downstream than dropping
+// the point.
+func (a *MetricAdapter) setNumberValue(dp pmetric.NumberDataPoint, pt *embed.MetricPoint, ts pcommon.Timestamp, mergedAttrs map[string]any) {
+	dp.SetTimestamp(ts)
+	switch {
+	case pt.IntValue != nil:
+		dp.SetIntValue(*pt.IntValue)
+	case pt.DoubleValue != nil:
+		dp.SetDoubleValue(*pt.DoubleValue)
+	default:
+		dp.SetDoubleValue(0)
+	}
+	if err := dp.Attributes().FromRaw(mergedAttrs); err != nil {
+		a.logger.Warn("blitzpdata: failed to set point attributes", zap.Error(err))
+	}
+}

--- a/receiver/telemetrygeneratorreceiver/internal/blitzpdata/metric_adapter_test.go
+++ b/receiver/telemetrygeneratorreceiver/internal/blitzpdata/metric_adapter_test.go
@@ -1,0 +1,271 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blitzpdata
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/observiq/blitz/embed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap/zaptest"
+)
+
+func intPtr(v int64) *int64       { return &v }
+func floatPtr(v float64) *float64 { return &v }
+
+func TestMetricAdapter_EmptyBatch_NoPush(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	a := NewMetricAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeMetrics(context.Background(), nil))
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{}))
+	assert.Equal(t, 0, sink.DataPointCount(), "empty batches must not produce a downstream consume call")
+}
+
+func TestMetricAdapter_Gauge_IntValue(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	a := NewMetricAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	ts := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{{
+		Name:        "system.cpu.utilization",
+		Description: "CPU utilization",
+		Unit:        "1",
+		Type:        embed.MetricTypeGauge,
+		IntValue:    intPtr(42),
+		Metadata:    embed.MetricPointMetadata{Timestamp: ts},
+	}}))
+	m := firstMetric(t, sink.AllMetrics())
+	assert.Equal(t, "system.cpu.utilization", m.Name())
+	assert.Equal(t, "CPU utilization", m.Description())
+	assert.Equal(t, "1", m.Unit())
+	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
+	dp := m.Gauge().DataPoints().At(0)
+	assert.Equal(t, int64(42), dp.IntValue())
+	assert.Equal(t, pcommon.NewTimestampFromTime(ts), dp.Timestamp())
+}
+
+func TestMetricAdapter_Sum_NonMonotonic(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	a := NewMetricAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{{
+		Name:        "system.memory.usage",
+		Type:        embed.MetricTypeSum,
+		DoubleValue: floatPtr(1024.5),
+	}}))
+	m := firstMetric(t, sink.AllMetrics())
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	assert.False(t, m.Sum().IsMonotonic(), "sum maps to non-monotonic")
+	assert.Equal(t, pmetric.AggregationTemporalityCumulative, m.Sum().AggregationTemporality())
+	assert.Equal(t, 1024.5, m.Sum().DataPoints().At(0).DoubleValue())
+}
+
+func TestMetricAdapter_Counter_Monotonic(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	a := NewMetricAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{{
+		Name:     "system.network.packets",
+		Type:     embed.MetricTypeCounter,
+		IntValue: intPtr(998877),
+	}}))
+	m := firstMetric(t, sink.AllMetrics())
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	assert.True(t, m.Sum().IsMonotonic(), "counter maps to monotonic sum")
+	assert.Equal(t, int64(998877), m.Sum().DataPoints().At(0).IntValue())
+}
+
+func TestMetricAdapter_Histogram(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	a := NewMetricAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{{
+		Name:                  "http.server.duration",
+		Type:                  embed.MetricTypeHistogram,
+		HistogramCount:        10,
+		HistogramSum:          123.4,
+		HistogramMin:          1.5,
+		HistogramMax:          50.0,
+		HistogramBucketBounds: []float64{5, 10, 25},
+		HistogramBucketCounts: []uint64{2, 3, 4, 1},
+	}}))
+	m := firstMetric(t, sink.AllMetrics())
+	require.Equal(t, pmetric.MetricTypeHistogram, m.Type())
+	dp := m.Histogram().DataPoints().At(0)
+	assert.Equal(t, uint64(10), dp.Count())
+	assert.Equal(t, 123.4, dp.Sum())
+	assert.Equal(t, 1.5, dp.Min())
+	assert.Equal(t, 50.0, dp.Max())
+	assert.Equal(t, []float64{5, 10, 25}, dp.ExplicitBounds().AsRaw())
+	assert.Equal(t, []uint64{2, 3, 4, 1}, dp.BucketCounts().AsRaw())
+	assert.Equal(t, pmetric.AggregationTemporalityCumulative, m.Histogram().AggregationTemporality())
+}
+
+func TestMetricAdapter_Histogram_MismatchedBucketsDropped(t *testing.T) {
+	// OTel requires len(BucketCounts) == len(ExplicitBounds)+1. A
+	// misconfigured generator emitting a mismatched pair (here 3 bounds
+	// + 3 counts, should be 4) must not produce an invariant-violating
+	// histogram downstream. The adapter drops the buckets and keeps the
+	// aggregate stats.
+	sink := &consumertest.MetricsSink{}
+	a := NewMetricAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{{
+		Name:                  "broken.histogram",
+		Type:                  embed.MetricTypeHistogram,
+		HistogramCount:        9,
+		HistogramSum:          42.0,
+		HistogramBucketBounds: []float64{5, 10, 25},
+		HistogramBucketCounts: []uint64{2, 3, 4}, // one short — should be 4 entries
+	}}))
+	m := firstMetric(t, sink.AllMetrics())
+	require.Equal(t, pmetric.MetricTypeHistogram, m.Type())
+	dp := m.Histogram().DataPoints().At(0)
+	assert.Equal(t, uint64(9), dp.Count(), "aggregate stats preserved")
+	assert.Equal(t, 42.0, dp.Sum())
+	assert.Equal(t, 0, dp.ExplicitBounds().Len(), "mismatched bounds dropped")
+	assert.Equal(t, 0, dp.BucketCounts().Len(), "mismatched counts dropped")
+}
+
+func TestMetricAdapter_Histogram_NoBuckets_OK(t *testing.T) {
+	// Empty bounds + empty counts is the legitimate no-buckets case and
+	// passes through without a warning or an invariant violation.
+	sink := &consumertest.MetricsSink{}
+	a := NewMetricAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{{
+		Name:           "bucketless.histogram",
+		Type:           embed.MetricTypeHistogram,
+		HistogramCount: 5,
+		HistogramSum:   10.0,
+	}}))
+	m := firstMetric(t, sink.AllMetrics())
+	dp := m.Histogram().DataPoints().At(0)
+	assert.Equal(t, uint64(5), dp.Count())
+	assert.Equal(t, 0, dp.ExplicitBounds().Len())
+	assert.Equal(t, 0, dp.BucketCounts().Len())
+}
+
+func TestMetricAdapter_UnknownType_FallsBackToGauge(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	a := NewMetricAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{{
+		Name:        "mystery.metric",
+		Type:        embed.MetricType("exotic"),
+		DoubleValue: floatPtr(7),
+	}}))
+	m := firstMetric(t, sink.AllMetrics())
+	require.Equal(t, pmetric.MetricTypeGauge, m.Type(), "unknown types emit as gauge")
+	assert.Equal(t, 7.0, m.Gauge().DataPoints().At(0).DoubleValue())
+}
+
+func TestMetricAdapter_NoValue_EmitsZeroDouble(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	a := NewMetricAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{{
+		Name: "valueless.metric",
+		Type: embed.MetricTypeGauge,
+	}}))
+	m := firstMetric(t, sink.AllMetrics())
+	assert.Equal(t, 0.0, m.Gauge().DataPoints().At(0).DoubleValue())
+}
+
+func TestMetricAdapter_ZeroTimestamp_FallsBackToNow(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	a := NewMetricAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	before := time.Now()
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{{
+		Name:     "no.ts",
+		Type:     embed.MetricTypeGauge,
+		IntValue: intPtr(1),
+	}}))
+	after := time.Now()
+	m := firstMetric(t, sink.AllMetrics())
+	ts := m.Gauge().DataPoints().At(0).Timestamp().AsTime()
+	assert.False(t, ts.Before(before))
+	assert.False(t, ts.After(after))
+}
+
+func TestMetricAdapter_PerPointAttributes_MergeAndLock(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	attrs := LockableAttrs{
+		Base:   map[string]any{"service.team": "ops", "run.id": "base"},
+		Locked: map[string]struct{}{"service.team": {}},
+	}
+	a := NewMetricAdapter(sink, LockableAttrs{}, attrs, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{{
+		Name:     "m",
+		Type:     embed.MetricTypeGauge,
+		IntValue: intPtr(1),
+		Metadata: embed.MetricPointMetadata{
+			Attributes: map[string]string{
+				"service.team": "blitz-team", // locked — dropped
+				"run.id":       "blitz-run",  // unlocked — wins
+				"cpu":          "cpu0",       // blitz-only — lands
+			},
+		},
+	}}))
+	m := firstMetric(t, sink.AllMetrics())
+	got := m.Gauge().DataPoints().At(0).Attributes().AsRaw()
+	assert.Equal(t, "ops", got["service.team"])
+	assert.Equal(t, "blitz-run", got["run.id"])
+	assert.Equal(t, "cpu0", got["cpu"])
+}
+
+func TestMetricAdapter_PerPointResource_MergeLockAndGroup(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	resource := LockableAttrs{Base: map[string]any{"cluster.name": "gargantua"}}
+	a := NewMetricAdapter(sink, resource, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeMetrics(context.Background(), []embed.MetricPoint{
+		{Name: "a", Type: embed.MetricTypeGauge, IntValue: intPtr(1),
+			Metadata: embed.MetricPointMetadata{Resource: map[string]string{"host.name": "h1"}}},
+		{Name: "b", Type: embed.MetricTypeGauge, IntValue: intPtr(2),
+			Metadata: embed.MetricPointMetadata{Resource: map[string]string{"host.name": "h2"}}},
+		{Name: "c", Type: embed.MetricTypeGauge, IntValue: intPtr(3),
+			Metadata: embed.MetricPointMetadata{Resource: map[string]string{"host.name": "h1"}}},
+	}))
+	metrics := sink.AllMetrics()
+	require.Len(t, metrics, 1)
+	require.Equal(t, 2, metrics[0].ResourceMetrics().Len(), "two distinct resources → two ResourceMetrics")
+	rm0 := metrics[0].ResourceMetrics().At(0)
+	res0 := rm0.Resource().Attributes().AsRaw()
+	assert.Equal(t, "h1", res0["host.name"])
+	assert.Equal(t, "gargantua", res0["cluster.name"], "configured base flows into every group")
+	assert.Equal(t, 2, rm0.ScopeMetrics().At(0).Metrics().Len(), "h1 group carries points a and c")
+	rm1 := metrics[0].ResourceMetrics().At(1)
+	assert.Equal(t, "h2", rm1.Resource().Attributes().AsRaw()["host.name"])
+	assert.Equal(t, 1, rm1.ScopeMetrics().At(0).Metrics().Len())
+}
+
+func TestMetricAdapter_NilLogger_NoPanic(t *testing.T) {
+	sink := &consumertest.MetricsSink{}
+	a := NewMetricAdapter(sink, LockableAttrs{}, LockableAttrs{}, nil)
+	require.NotPanics(t, func() {
+		_ = a.ConsumeMetrics(context.Background(), []embed.MetricPoint{{Name: "x", Type: embed.MetricTypeGauge}})
+	})
+}
+
+// firstMetric pulls the single metric out of a sink that expects
+// exactly one batch with one resource, one scope, and one metric.
+func firstMetric(t *testing.T, metrics []pmetric.Metrics) pmetric.Metric {
+	t.Helper()
+	require.Len(t, metrics, 1, "expected exactly one pmetric.Metrics batch")
+	require.Equal(t, 1, metrics[0].ResourceMetrics().Len())
+	rm := metrics[0].ResourceMetrics().At(0)
+	require.Equal(t, 1, rm.ScopeMetrics().Len())
+	sm := rm.ScopeMetrics().At(0)
+	require.Equal(t, 1, sm.Metrics().Len())
+	return sm.Metrics().At(0)
+}

--- a/receiver/telemetrygeneratorreceiver/logs_receiver.go
+++ b/receiver/telemetrygeneratorreceiver/logs_receiver.go
@@ -90,7 +90,7 @@ func (r *logsGeneratorReceiver) buildBlitzRunner(logger *zap.Logger, cfg *Config
 			return fmt.Errorf("blitz generator[%d]: %w", i, err)
 		}
 		adapter := blitzpdata.NewLogAdapter(r.nextConsumer, resourceCfg, attrsCfg, parseBody, logger)
-		mods, err := buildBlitzModules(logger, g, adapter)
+		mods, err := buildBlitzModules(logger, g, blitzConsumers{logs: adapter})
 		if err != nil {
 			return fmt.Errorf("blitz generator[%d]: %w", i, err)
 		}

--- a/receiver/telemetrygeneratorreceiver/metrics_receiver.go
+++ b/receiver/telemetrygeneratorreceiver/metrics_receiver.go
@@ -18,9 +18,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/observiq/blitz/embed"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
+
+	"github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver/internal/blitzpdata"
 )
 
 type metricsGeneratorReceiver struct {
@@ -30,6 +33,12 @@ type metricsGeneratorReceiver struct {
 }
 
 // newMetricsReceiver creates a new metrics specific receiver.
+//
+// The Start/Shutdown lifecycle (including blitz runner orchestration
+// and ticker short-circuit) lives on the embedded
+// telemetryGeneratorReceiver — the constructor's only job is to
+// populate the fields that lifecycle reads: hasTickerGenerators and
+// blitzRunner.
 func newMetricsReceiver(ctx context.Context, logger *zap.Logger, cfg *Config, nextConsumer consumer.Metrics) (*metricsGeneratorReceiver, error) {
 	mr := &metricsGeneratorReceiver{
 		nextConsumer: nextConsumer,
@@ -45,7 +54,51 @@ func newMetricsReceiver(ctx context.Context, logger *zap.Logger, cfg *Config, ne
 	}
 	mr.hasTickerGenerators = len(mr.generators) > 0
 
+	if err := mr.buildBlitzRunner(logger, cfg); err != nil {
+		return nil, err
+	}
+
 	return mr, nil
+}
+
+// buildBlitzRunner constructs the embed.Runner from all Type: "blitz"
+// entries in cfg, if any. Each entry gets its own MetricAdapter
+// (preserving per-entry lockable resource + attribute config) wired into the
+// modules built for that entry; the modules from every entry are
+// aggregated into a single Runner stored on the embedded base type so
+// the shared Start/Shutdown lifecycle owns it.
+func (r *metricsGeneratorReceiver) buildBlitzRunner(logger *zap.Logger, cfg *Config) error {
+	var modules []embed.ProducerModule
+	for i, g := range cfg.Generators {
+		if g.Type != generatorTypeBlitz {
+			continue
+		}
+		// Attribute shapes were validated at config-validate time; re-parse
+		// here to build the adapter's base + locked-key structures.
+		resourceCfg, err := blitzpdata.ParseLockableAttrs(g.ResourceAttributes, "resource_attributes")
+		if err != nil {
+			return fmt.Errorf("blitz generator[%d]: %w", i, err)
+		}
+		attrsCfg, err := blitzpdata.ParseLockableAttrs(g.Attributes, "attributes")
+		if err != nil {
+			return fmt.Errorf("blitz generator[%d]: %w", i, err)
+		}
+		adapter := blitzpdata.NewMetricAdapter(r.nextConsumer, resourceCfg, attrsCfg, logger)
+		mods, err := buildBlitzModules(logger, g, blitzConsumers{metrics: adapter})
+		if err != nil {
+			return fmt.Errorf("blitz generator[%d]: %w", i, err)
+		}
+		modules = append(modules, mods...)
+	}
+	if len(modules) == 0 {
+		return nil
+	}
+	runner, err := embed.New(embed.Config{Modules: modules})
+	if err != nil {
+		return fmt.Errorf("construct blitz runner: %w", err)
+	}
+	r.blitzRunner = runner
+	return nil
 }
 
 // produce generates metrics from each generator and sends them to the next consumer


### PR DESCRIPTION
### Proposed Change

Adds the metrics signal path for `Type: "blitz"`, consuming blitz v0.19.0's
`MetricConsumer` contract (hostmetrics migration).

- New `internal/blitzpdata/metric_adapter.go`: `MetricAdapter` implements
  `embed.MetricConsumer`. Each `embed.MetricPoint` becomes one
  `pmetric.Metric` with a single data point — gauge → Gauge, sum →
  non-monotonic cumulative Sum, counter → monotonic cumulative Sum,
  histogram → cumulative Histogram with explicit bounds. Unknown types emit
  as Gauge with a warning rather than dropping silently.
- Same per-key locking + per-record metadata semantics as the LogAdapter:
  per-point `Metadata.Resource` / `Metadata.Attributes` merge over the
  entry's config bases, locked keys win, distinct merged resources split
  into separate `ResourceMetrics`.
- `buildBlitzModules` generalized to a `blitzConsumers` struct carrying all
  three signal-typed consumers; each receiver populates only its own slot.
  blitz's `LoadModules` rejects generators whose consumer slot is nil — that
  rejection is the wrong-signal validation (no receiver-side duplicate).
- `metrics_receiver.go` gains `buildBlitzRunner` (mirrors the logs path);
  curated recipes remain log-only and error with a pointer to `blitz_yaml`
  when used on a metrics pipeline.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
