### PR TITLE
feat(telemetrygeneratorreceiver): TraceAdapter + traces receiver blitz wiring (PIPE-1017)

### DIFF
--- a/receiver/telemetrygeneratorreceiver/generators.go
+++ b/receiver/telemetrygeneratorreceiver/generators.go
@@ -43,7 +43,9 @@ const (
 	generatorTypeOTLP generatorType = "otlp"
 
 	// generatorTypeBlitz is the generator type for blitz embed sources.
-	// Logs-only at v1; see PIPE-1017.
+	// Available on all three signal-type receiver instances (logs,
+	// metrics, traces); each builds its own signal-appropriate adapter.
+	// See PIPE-1017.
 	generatorTypeBlitz generatorType = "blitz"
 )
 

--- a/receiver/telemetrygeneratorreceiver/internal/blitzpdata/trace_adapter.go
+++ b/receiver/telemetrygeneratorreceiver/internal/blitzpdata/trace_adapter.go
@@ -1,0 +1,183 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blitzpdata // import "github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver/internal/blitzpdata"
+
+import (
+	"context"
+	"encoding/hex"
+
+	"github.com/observiq/blitz/embed"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+// TraceAdapter implements embed.TraceConsumer. Each ConsumeTraces call
+// builds a fresh ptrace.Traces from the batch and pushes it to the
+// receiver's downstream consumer.
+//
+// Shape mirrors LogAdapter / MetricAdapter: per-receiver-entry
+// LockableAttrs maps for resource and per-span attributes; blitz's per-span
+// `Metadata.Resource` and `Metadata.Attributes` merge over the configured
+// bases with locked keys preserved; spans whose merged resource maps
+// fingerprint differently are emitted under separate `ResourceSpans`
+// (Q1 resource grouping).
+type TraceAdapter struct {
+	consumer consumer.Traces
+	resource LockableAttrs
+	attrs    LockableAttrs
+	logger   *zap.Logger
+}
+
+// NewTraceAdapter constructs an adapter that emits to the given
+// consumer. resource and attrs follow the same per-key locking semantics as
+// NewLogAdapter. A nil logger yields a no-op logger.
+func NewTraceAdapter(c consumer.Traces, resource, attrs LockableAttrs, logger *zap.Logger) *TraceAdapter {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &TraceAdapter{
+		consumer: c,
+		resource: resource,
+		attrs:    attrs,
+		logger:   logger,
+	}
+}
+
+// ConsumeTraces satisfies embed.TraceConsumer. Spans are grouped by
+// merged-resource fingerprint (one ResourceSpans per unique merged
+// resource, first-occurrence ordered). Empty batches are no-ops.
+func (a *TraceAdapter) ConsumeTraces(ctx context.Context, spans []embed.Span) error {
+	if len(spans) == 0 {
+		return nil
+	}
+
+	type group struct {
+		merged map[string]any
+		spans  []int
+	}
+	groups := make(map[string]*group)
+	order := make([]string, 0)
+	for i := range spans {
+		merged := a.resource.MergeWithStringOverlay(spans[i].Metadata.Resource)
+		fp := FingerprintMap(merged)
+		g, exists := groups[fp]
+		if !exists {
+			g = &group{merged: merged}
+			groups[fp] = g
+			order = append(order, fp)
+		}
+		g.spans = append(g.spans, i)
+	}
+
+	traces := ptrace.NewTraces()
+	for _, fp := range order {
+		g := groups[fp]
+		rs := traces.ResourceSpans().AppendEmpty()
+		if err := rs.Resource().Attributes().FromRaw(g.merged); err != nil {
+			a.logger.Warn("blitzpdata: failed to set resource attributes", zap.Error(err))
+		}
+		ss := rs.ScopeSpans().AppendEmpty()
+		ss.Scope().SetName(scopeName)
+		for _, idx := range g.spans {
+			a.appendSpan(ss.Spans().AppendEmpty(), &spans[idx])
+		}
+	}
+	return a.consumer.ConsumeTraces(ctx, traces)
+}
+
+// appendSpan populates a fresh ptrace.Span from a single embed.Span.
+//
+// TraceID / SpanID / ParentSpanID are hex strings in the embed
+// contract; malformed IDs decode to the zero ID with a warning (the
+// span still flows — dropping it silently would make a misbehaving
+// generator invisible, and downstream pipelines surface zero-ID spans
+// loudly).
+func (a *TraceAdapter) appendSpan(s ptrace.Span, sp *embed.Span) {
+	s.SetTraceID(a.parseTraceID(sp.TraceID))
+	s.SetSpanID(a.parseSpanID(sp.SpanID))
+	if sp.ParentSpanID != "" {
+		s.SetParentSpanID(a.parseSpanID(sp.ParentSpanID))
+	}
+	s.SetName(sp.Name)
+	s.SetKind(spanKindFor(sp.Kind))
+	s.SetStartTimestamp(pcommon.NewTimestampFromTime(sp.StartTime))
+	s.SetEndTimestamp(pcommon.NewTimestampFromTime(sp.EndTime))
+
+	switch sp.StatusCode {
+	case 1:
+		s.Status().SetCode(ptrace.StatusCodeOk)
+	case 2:
+		s.Status().SetCode(ptrace.StatusCodeError)
+	default:
+		s.Status().SetCode(ptrace.StatusCodeUnset)
+	}
+	if sp.StatusMessage != "" {
+		s.Status().SetMessage(sp.StatusMessage)
+	}
+
+	mergedAttrs := a.attrs.MergeWithAnyOverlay(sp.Metadata.Attributes)
+	if err := s.Attributes().FromRaw(mergedAttrs); err != nil {
+		a.logger.Warn("blitzpdata: failed to set span attributes", zap.Error(err))
+	}
+}
+
+// parseTraceID decodes a 32-hex-char trace ID string. Malformed input
+// yields the zero TraceID with a warning.
+func (a *TraceAdapter) parseTraceID(s string) pcommon.TraceID {
+	var id pcommon.TraceID
+	b, err := hex.DecodeString(s)
+	if err != nil || len(b) != len(id) {
+		a.logger.Warn("blitzpdata: malformed trace ID; using zero ID", zap.String("trace_id", s))
+		return pcommon.NewTraceIDEmpty()
+	}
+	copy(id[:], b)
+	return id
+}
+
+// parseSpanID decodes a 16-hex-char span ID string. Malformed input
+// yields the zero SpanID with a warning.
+func (a *TraceAdapter) parseSpanID(s string) pcommon.SpanID {
+	var id pcommon.SpanID
+	b, err := hex.DecodeString(s)
+	if err != nil || len(b) != len(id) {
+		a.logger.Warn("blitzpdata: malformed span ID; using zero ID", zap.String("span_id", s))
+		return pcommon.NewSpanIDEmpty()
+	}
+	copy(id[:], b)
+	return id
+}
+
+// spanKindFor maps the embed contract's SpanKind strings to ptrace
+// span kinds. Unknown values map to Internal — the safest default for
+// generated telemetry (it implies no client/server relationship that
+// downstream service-graph processors would act on).
+func spanKindFor(k embed.SpanKind) ptrace.SpanKind {
+	switch k {
+	case embed.SpanKindServer:
+		return ptrace.SpanKindServer
+	case embed.SpanKindClient:
+		return ptrace.SpanKindClient
+	case embed.SpanKindProducer:
+		return ptrace.SpanKindProducer
+	case embed.SpanKindConsumer:
+		return ptrace.SpanKindConsumer
+	case embed.SpanKindInternal:
+		return ptrace.SpanKindInternal
+	default:
+		return ptrace.SpanKindInternal
+	}
+}

--- a/receiver/telemetrygeneratorreceiver/internal/blitzpdata/trace_adapter_test.go
+++ b/receiver/telemetrygeneratorreceiver/internal/blitzpdata/trace_adapter_test.go
@@ -1,0 +1,209 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blitzpdata
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/observiq/blitz/embed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap/zaptest"
+)
+
+const (
+	testTraceID = "0123456789abcdef0123456789abcdef"
+	testSpanID  = "0123456789abcdef"
+	testParent  = "fedcba9876543210"
+)
+
+func TestTraceAdapter_EmptyBatch_NoPush(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	a := NewTraceAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeTraces(context.Background(), nil))
+	require.NoError(t, a.ConsumeTraces(context.Background(), []embed.Span{}))
+	assert.Equal(t, 0, sink.SpanCount(), "empty batches must not produce a downstream consume call")
+}
+
+func TestTraceAdapter_FullSpan(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	a := NewTraceAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	start := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	end := start.Add(150 * time.Millisecond)
+	require.NoError(t, a.ConsumeTraces(context.Background(), []embed.Span{{
+		TraceID:       testTraceID,
+		SpanID:        testSpanID,
+		ParentSpanID:  testParent,
+		Name:          "GET /checkout",
+		Kind:          embed.SpanKindServer,
+		StartTime:     start,
+		EndTime:       end,
+		StatusCode:    2,
+		StatusMessage: "upstream timeout",
+	}}))
+	s := firstSpan(t, sink.AllTraces())
+	assert.Equal(t, testTraceID, s.TraceID().String())
+	assert.Equal(t, testSpanID, s.SpanID().String())
+	assert.Equal(t, testParent, s.ParentSpanID().String())
+	assert.Equal(t, "GET /checkout", s.Name())
+	assert.Equal(t, ptrace.SpanKindServer, s.Kind())
+	assert.Equal(t, pcommon.NewTimestampFromTime(start), s.StartTimestamp())
+	assert.Equal(t, pcommon.NewTimestampFromTime(end), s.EndTimestamp())
+	assert.Equal(t, ptrace.StatusCodeError, s.Status().Code())
+	assert.Equal(t, "upstream timeout", s.Status().Message())
+}
+
+func TestTraceAdapter_RootSpan_NoParent(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	a := NewTraceAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeTraces(context.Background(), []embed.Span{{
+		TraceID: testTraceID,
+		SpanID:  testSpanID,
+		Name:    "root",
+		Kind:    embed.SpanKindInternal,
+	}}))
+	s := firstSpan(t, sink.AllTraces())
+	assert.True(t, s.ParentSpanID().IsEmpty(), "empty ParentSpanID stays zero")
+}
+
+func TestTraceAdapter_StatusCodes(t *testing.T) {
+	cases := []struct {
+		code int
+		want ptrace.StatusCode
+	}{
+		{0, ptrace.StatusCodeUnset},
+		{1, ptrace.StatusCodeOk},
+		{2, ptrace.StatusCodeError},
+		{99, ptrace.StatusCodeUnset}, // out-of-contract value → Unset
+	}
+	for _, tc := range cases {
+		sink := &consumertest.TracesSink{}
+		a := NewTraceAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+		require.NoError(t, a.ConsumeTraces(context.Background(), []embed.Span{{
+			TraceID:    testTraceID,
+			SpanID:     testSpanID,
+			StatusCode: tc.code,
+		}}))
+		s := firstSpan(t, sink.AllTraces())
+		assert.Equal(t, tc.want, s.Status().Code(), "status code %d", tc.code)
+	}
+}
+
+func TestTraceAdapter_SpanKinds(t *testing.T) {
+	cases := []struct {
+		kind embed.SpanKind
+		want ptrace.SpanKind
+	}{
+		{embed.SpanKindInternal, ptrace.SpanKindInternal},
+		{embed.SpanKindServer, ptrace.SpanKindServer},
+		{embed.SpanKindClient, ptrace.SpanKindClient},
+		{embed.SpanKindProducer, ptrace.SpanKindProducer},
+		{embed.SpanKindConsumer, ptrace.SpanKindConsumer},
+		{embed.SpanKind("alien"), ptrace.SpanKindInternal}, // unknown → Internal
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, spanKindFor(tc.kind), "kind %q", tc.kind)
+	}
+}
+
+func TestTraceAdapter_MalformedIDs_ZeroWithWarning(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	a := NewTraceAdapter(sink, LockableAttrs{}, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeTraces(context.Background(), []embed.Span{{
+		TraceID: "not-hex-at-all",
+		SpanID:  "tooshort",
+		Name:    "still flows",
+	}}))
+	s := firstSpan(t, sink.AllTraces())
+	assert.True(t, s.TraceID().IsEmpty(), "malformed trace ID → zero")
+	assert.True(t, s.SpanID().IsEmpty(), "malformed span ID → zero")
+	assert.Equal(t, "still flows", s.Name(), "span still flows through")
+}
+
+func TestTraceAdapter_PerSpanAttributes_MergeAndLock(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	attrs := LockableAttrs{
+		Base:   map[string]any{"service.team": "ops", "run.id": "base"},
+		Locked: map[string]struct{}{"service.team": {}},
+	}
+	a := NewTraceAdapter(sink, LockableAttrs{}, attrs, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeTraces(context.Background(), []embed.Span{{
+		TraceID: testTraceID,
+		SpanID:  testSpanID,
+		Metadata: embed.SpanMetadata{
+			Attributes: map[string]any{
+				"service.team": "blitz-team", // locked — dropped
+				"run.id":       "blitz-run",  // unlocked — wins
+				"http.method":  "GET",        // blitz-only — lands
+			},
+		},
+	}}))
+	s := firstSpan(t, sink.AllTraces())
+	got := s.Attributes().AsRaw()
+	assert.Equal(t, "ops", got["service.team"])
+	assert.Equal(t, "blitz-run", got["run.id"])
+	assert.Equal(t, "GET", got["http.method"])
+}
+
+func TestTraceAdapter_PerSpanResource_MergeLockAndGroup(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	resource := LockableAttrs{Base: map[string]any{"cluster.name": "gargantua"}}
+	a := NewTraceAdapter(sink, resource, LockableAttrs{}, zaptest.NewLogger(t))
+	require.NoError(t, a.ConsumeTraces(context.Background(), []embed.Span{
+		{TraceID: testTraceID, SpanID: testSpanID, Name: "a",
+			Metadata: embed.SpanMetadata{Resource: map[string]string{"host.name": "h1"}}},
+		{TraceID: testTraceID, SpanID: testParent, Name: "b",
+			Metadata: embed.SpanMetadata{Resource: map[string]string{"host.name": "h2"}}},
+		{TraceID: testTraceID, SpanID: testSpanID, Name: "c",
+			Metadata: embed.SpanMetadata{Resource: map[string]string{"host.name": "h1"}}},
+	}))
+	traces := sink.AllTraces()
+	require.Len(t, traces, 1)
+	require.Equal(t, 2, traces[0].ResourceSpans().Len(), "two distinct resources → two ResourceSpans")
+	rs0 := traces[0].ResourceSpans().At(0)
+	res0 := rs0.Resource().Attributes().AsRaw()
+	assert.Equal(t, "h1", res0["host.name"])
+	assert.Equal(t, "gargantua", res0["cluster.name"], "configured base flows into every group")
+	assert.Equal(t, 2, rs0.ScopeSpans().At(0).Spans().Len(), "h1 group carries spans a and c")
+	rs1 := traces[0].ResourceSpans().At(1)
+	assert.Equal(t, "h2", rs1.Resource().Attributes().AsRaw()["host.name"])
+	assert.Equal(t, 1, rs1.ScopeSpans().At(0).Spans().Len())
+}
+
+func TestTraceAdapter_NilLogger_NoPanic(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	a := NewTraceAdapter(sink, LockableAttrs{}, LockableAttrs{}, nil)
+	require.NotPanics(t, func() {
+		_ = a.ConsumeTraces(context.Background(), []embed.Span{{TraceID: testTraceID, SpanID: testSpanID}})
+	})
+}
+
+// firstSpan pulls the single span out of a sink that expects exactly
+// one batch with one resource, one scope, and one span.
+func firstSpan(t *testing.T, traces []ptrace.Traces) ptrace.Span {
+	t.Helper()
+	require.Len(t, traces, 1, "expected exactly one ptrace.Traces batch")
+	require.Equal(t, 1, traces[0].ResourceSpans().Len())
+	rs := traces[0].ResourceSpans().At(0)
+	require.Equal(t, 1, rs.ScopeSpans().Len())
+	ss := rs.ScopeSpans().At(0)
+	require.Equal(t, 1, ss.Spans().Len())
+	return ss.Spans().At(0)
+}

--- a/receiver/telemetrygeneratorreceiver/traces_receiver.go
+++ b/receiver/telemetrygeneratorreceiver/traces_receiver.go
@@ -18,9 +18,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/observiq/blitz/embed"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+
+	"github.com/observiq/bindplane-otel-contrib/receiver/telemetrygeneratorreceiver/internal/blitzpdata"
 )
 
 type tracesGeneratorReceiver struct {
@@ -30,6 +33,12 @@ type tracesGeneratorReceiver struct {
 }
 
 // newTracesReceiver creates a new traces specific receiver.
+//
+// The Start/Shutdown lifecycle (including blitz runner orchestration
+// and ticker short-circuit) lives on the embedded
+// telemetryGeneratorReceiver — the constructor's only job is to
+// populate the fields that lifecycle reads: hasTickerGenerators and
+// blitzRunner.
 func newTracesReceiver(ctx context.Context, logger *zap.Logger, cfg *Config, nextConsumer consumer.Traces) (*tracesGeneratorReceiver, error) {
 	tr := &tracesGeneratorReceiver{
 		nextConsumer: nextConsumer,
@@ -46,7 +55,51 @@ func newTracesReceiver(ctx context.Context, logger *zap.Logger, cfg *Config, nex
 	}
 	tr.hasTickerGenerators = len(tr.generators) > 0
 
+	if err := tr.buildBlitzRunner(logger, cfg); err != nil {
+		return nil, err
+	}
+
 	return tr, nil
+}
+
+// buildBlitzRunner constructs the embed.Runner from all Type: "blitz"
+// entries in cfg, if any. Each entry gets its own TraceAdapter
+// (preserving per-entry lockable resource + attribute config) wired into the
+// modules built for that entry; the modules from every entry are
+// aggregated into a single Runner stored on the embedded base type so
+// the shared Start/Shutdown lifecycle owns it.
+func (r *tracesGeneratorReceiver) buildBlitzRunner(logger *zap.Logger, cfg *Config) error {
+	var modules []embed.ProducerModule
+	for i, g := range cfg.Generators {
+		if g.Type != generatorTypeBlitz {
+			continue
+		}
+		// Attribute shapes were validated at config-validate time; re-parse
+		// here to build the adapter's base + locked-key structures.
+		resourceCfg, err := blitzpdata.ParseLockableAttrs(g.ResourceAttributes, "resource_attributes")
+		if err != nil {
+			return fmt.Errorf("blitz generator[%d]: %w", i, err)
+		}
+		attrsCfg, err := blitzpdata.ParseLockableAttrs(g.Attributes, "attributes")
+		if err != nil {
+			return fmt.Errorf("blitz generator[%d]: %w", i, err)
+		}
+		adapter := blitzpdata.NewTraceAdapter(r.nextConsumer, resourceCfg, attrsCfg, logger)
+		mods, err := buildBlitzModules(logger, g, blitzConsumers{traces: adapter})
+		if err != nil {
+			return fmt.Errorf("blitz generator[%d]: %w", i, err)
+		}
+		modules = append(modules, mods...)
+	}
+	if len(modules) == 0 {
+		return nil
+	}
+	runner, err := embed.New(embed.Config{Modules: modules})
+	if err != nil {
+		return fmt.Errorf("construct blitz runner: %w", err)
+	}
+	r.blitzRunner = runner
+	return nil
 }
 
 // produce generates traces from each generator and sends them to the next consumer


### PR DESCRIPTION
### Proposed Change

Adds the traces signal path for `Type: "blitz"`, consuming blitz v0.19.0's
`TraceConsumer` contract (traces migration).

- New `internal/blitzpdata/trace_adapter.go`: `TraceAdapter` implements
  `embed.TraceConsumer`. Converts `embed.Span` → `ptrace.Span`: hex
  trace/span/parent IDs (malformed IDs decode to the zero ID with a warning
  — the span still flows), span kind mapping (unknown → Internal), start/end
  timestamps, status code 0/1/2 → Unset/Ok/Error + message.
- Same per-key locking + per-record metadata semantics as the other
  adapters: per-span `Metadata.Resource` / `Metadata.Attributes` merge over
  the entry's config bases, locked keys win, distinct merged resources split
  into separate `ResourceSpans`.
- `traces_receiver.go` gains `buildBlitzRunner` (mirrors logs/metrics).
- Stale "logs-only at v1" comment on `generatorTypeBlitz` updated.

With this PR, all three signal-type receivers support blitz generation.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
