### PR TITLE
feat(asimstandardizationprocessor): add attribution_fields config

### DIFF
--- a/processor/asimstandardizationprocessor/README.md
+++ b/processor/asimstandardizationprocessor/README.md
@@ -53,6 +53,7 @@ Records that do **not** match any `event_mapping` are dropped.
 | -- | -- | -- | -- | -- |
 | `event_mappings` | []EventMapping | `[]` | No | Ordered list of event mappings. The first mapping whose `filter` matches a record wins. |
 | `runtime_validation` | bool | `true` | No | Coerce mapped values to their target ASIM column types and drop records missing any ASIM common mandatory column. See [Runtime validation](#runtime-validation). |
+| `attribution_fields` | map[string]string | `{}` | No | Constant key/value pairs added to `AdditionalFields.Attribution` on every transformed record. Lets downstream connector-health queries disambiguate records from this pipeline when multiple sources write into the same ASIM table. See [AdditionalFields preservation](#additionalfields-preservation). |
 
 ### EventMapping
 
@@ -120,6 +121,31 @@ ASimAuthenticationEventLogs
 | extend raw = AdditionalFields
 | project TimeGenerated, ActorUsername, TargetUsername, raw
 ```
+
+### With `attribution_fields` set
+
+When `attribution_fields` is non-empty, the processor wraps the column so
+the original body and the attribution markers coexist:
+
+```json
+"AdditionalFields": {
+  "OriginalEvent": { ...the pre-transform body... },
+  "Attribution":   { "bindplane_source": "bindplane", "bindplane_pipeline_id": "pipeline-42" }
+}
+```
+
+The original body remains queryable, one level deeper:
+
+```kusto
+ASimAuthenticationEventLogs
+| where tostring(AdditionalFields.Attribution.bindplane_source) == "bindplane"
+| extend raw = AdditionalFields.OriginalEvent
+| project TimeGenerated, ActorUsername, TargetUsername, raw
+```
+
+When `attribution_fields` is empty/unset (the default), `AdditionalFields`
+keeps the prior flat shape — the original body unwrapped — so any existing
+consumer queries continue to work unchanged.
 
 ## Example configuration
 

--- a/processor/asimstandardizationprocessor/config.go
+++ b/processor/asimstandardizationprocessor/config.go
@@ -93,6 +93,20 @@ type Config struct {
 	//     storm that ends in silent data loss.
 	// Set to false to opt out and pass mapped records through unchanged.
 	RuntimeValidation *bool `mapstructure:"runtime_validation"`
+
+	// AttributionFields, when non-empty, adds an "Attribution" sub-object to
+	// the AdditionalFields column on every transformed record with these
+	// keys/values copied as-is. The original log body is preserved under
+	// AdditionalFields.OriginalEvent, so its keys remain queryable via
+	// `AdditionalFields.OriginalEvent.<field>` in KQL. When empty (default),
+	// AdditionalFields is set directly to the original body — the prior shape
+	// and behavior, backwards-compatible.
+	//
+	// Typical use: tag every record processed through a known pipeline with a
+	// stable marker (e.g. "bindplane_source": "bindplane") so downstream
+	// connector-health queries can disambiguate records emitted by this
+	// pipeline from other sources writing into the same shared ASIM table.
+	AttributionFields map[string]string `mapstructure:"attribution_fields,omitempty"`
 }
 
 // IsKnownTargetTable returns true if the given string is a supported ASIM

--- a/processor/asimstandardizationprocessor/processor.go
+++ b/processor/asimstandardizationprocessor/processor.go
@@ -55,6 +55,9 @@ type asimStandardizationProcessor struct {
 	logger            *zap.Logger
 	eventMappings     []compiledEventMapping
 	runtimeValidation bool
+	// attributionFields, when non-empty, is merged into AdditionalFields as
+	// an "Attribution" sub-object on every transformed record. See Config.
+	attributionFields map[string]string
 }
 
 func newASIMStandardizationProcessor(logger *zap.Logger, config *Config) (*asimStandardizationProcessor, error) {
@@ -104,10 +107,21 @@ func newASIMStandardizationProcessor(logger *zap.Logger, config *Config) (*asimS
 		runtimeValidation = *config.RuntimeValidation
 	}
 
+	// Defensive copy so a later mutation of the caller's map cannot bleed
+	// through into the processor's runtime state.
+	var attributionFields map[string]string
+	if len(config.AttributionFields) > 0 {
+		attributionFields = make(map[string]string, len(config.AttributionFields))
+		for k, v := range config.AttributionFields {
+			attributionFields[k] = v
+		}
+	}
+
 	return &asimStandardizationProcessor{
 		logger:            logger,
 		eventMappings:     compiled,
 		runtimeValidation: runtimeValidation,
+		attributionFields: attributionFields,
 	}, nil
 }
 
@@ -171,7 +185,21 @@ func (asp *asimStandardizationProcessor) processLogRecord(log plog.LogRecord, re
 		}
 
 		newBody[eventSchemaColumn] = eventMapping.eventSchema
-		if originalBody != nil {
+		if len(asp.attributionFields) > 0 {
+			// Wrap so the original body stays queryable as
+			// AdditionalFields.OriginalEvent while the constant attribution
+			// markers live under AdditionalFields.Attribution.
+			wrapped := map[string]any{}
+			if originalBody != nil {
+				wrapped["OriginalEvent"] = originalBody
+			}
+			attribution := make(map[string]any, len(asp.attributionFields))
+			for k, v := range asp.attributionFields {
+				attribution[k] = v
+			}
+			wrapped["Attribution"] = attribution
+			newBody[additionalFieldsColumn] = wrapped
+		} else if originalBody != nil {
 			newBody[additionalFieldsColumn] = originalBody
 		}
 

--- a/processor/asimstandardizationprocessor/processor_test.go
+++ b/processor/asimstandardizationprocessor/processor_test.go
@@ -532,3 +532,107 @@ func TestCoerce_StringTimeDotTimeUsesRFC3339Nano(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "2026-05-04T21:30:00Z", got)
 }
+
+func TestAttributionFields_AddsAttributionAndPreservesOriginal(t *testing.T) {
+	p := newProcessor(t, &Config{
+		EventMappings: []EventMapping{
+			{
+				TargetTable:   TargetTableAuthentication,
+				FieldMappings: minimalAuthFieldMappings,
+			},
+		},
+		AttributionFields: map[string]string{
+			"bindplane_source":      "bindplane",
+			"bindplane_pipeline_id": "pipeline-42",
+		},
+	})
+
+	out, err := p.processLogs(context.Background(), newLogsWithBody(authInputBody()))
+	require.NoError(t, err)
+	require.Equal(t, 1, countLogRecords(out))
+
+	body := firstRecord(t, out).Body().Map().AsRaw()
+	af, ok := body["AdditionalFields"].(map[string]any)
+	require.True(t, ok, "AdditionalFields must be wrapped as a map when AttributionFields is set, got %T", body["AdditionalFields"])
+
+	attribution, ok := af["Attribution"].(map[string]any)
+	require.True(t, ok, "AdditionalFields.Attribution must be a map, got %T", af["Attribution"])
+	require.Equal(t, "bindplane", attribution["bindplane_source"])
+	require.Equal(t, "pipeline-42", attribution["bindplane_pipeline_id"])
+
+	original, ok := af["OriginalEvent"].(map[string]any)
+	require.True(t, ok, "AdditionalFields.OriginalEvent must mirror the input body, got %T", af["OriginalEvent"])
+	require.Equal(t, "alice", original["user"], "OriginalEvent must preserve the pre-transform body so its fields remain queryable")
+}
+
+func TestAttributionFields_UnsetIsBackwardsCompatible(t *testing.T) {
+	// When AttributionFields is unset (nil), AdditionalFields keeps its prior
+	// shape — set directly to the original body (no wrapping). This is the
+	// no-op path for any consumer that does not opt in.
+	p := newProcessor(t, &Config{
+		EventMappings: []EventMapping{
+			{
+				TargetTable:   TargetTableAuthentication,
+				FieldMappings: minimalAuthFieldMappings,
+			},
+		},
+	})
+
+	out, err := p.processLogs(context.Background(), newLogsWithBody(authInputBody()))
+	require.NoError(t, err)
+	body := firstRecord(t, out).Body().Map().AsRaw()
+
+	af, ok := body["AdditionalFields"].(map[string]any)
+	require.True(t, ok, "AdditionalFields must equal the original body shape, got %T", body["AdditionalFields"])
+	require.Equal(t, "alice", af["user"], "no Attribution wrapping when AttributionFields is unset")
+	require.NotContains(t, af, "Attribution", "Attribution sub-object must not appear when AttributionFields is unset")
+	require.NotContains(t, af, "OriginalEvent", "OriginalEvent wrapping must not appear when AttributionFields is unset")
+}
+
+func TestAttributionFields_EmptyMapBehavesAsUnset(t *testing.T) {
+	// An explicit empty map is treated the same as nil — no wrapping.
+	p := newProcessor(t, &Config{
+		EventMappings: []EventMapping{
+			{
+				TargetTable:   TargetTableAuthentication,
+				FieldMappings: minimalAuthFieldMappings,
+			},
+		},
+		AttributionFields: map[string]string{},
+	})
+
+	out, err := p.processLogs(context.Background(), newLogsWithBody(authInputBody()))
+	require.NoError(t, err)
+	body := firstRecord(t, out).Body().Map().AsRaw()
+
+	af, ok := body["AdditionalFields"].(map[string]any)
+	require.True(t, ok)
+	require.NotContains(t, af, "Attribution")
+	require.NotContains(t, af, "OriginalEvent")
+}
+
+func TestAttributionFields_CallerMapMutationDoesNotLeak(t *testing.T) {
+	// Defensive copy: mutating the map after constructing the processor must
+	// not change what the processor writes.
+	caller := map[string]string{"bindplane_source": "bindplane"}
+	p := newProcessor(t, &Config{
+		EventMappings: []EventMapping{
+			{
+				TargetTable:   TargetTableAuthentication,
+				FieldMappings: minimalAuthFieldMappings,
+			},
+		},
+		AttributionFields: caller,
+	})
+
+	caller["bindplane_source"] = "tampered"
+	caller["new_key"] = "also-tampered"
+
+	out, err := p.processLogs(context.Background(), newLogsWithBody(authInputBody()))
+	require.NoError(t, err)
+	body := firstRecord(t, out).Body().Map().AsRaw()
+	af := body["AdditionalFields"].(map[string]any)
+	attribution := af["Attribution"].(map[string]any)
+	require.Equal(t, "bindplane", attribution["bindplane_source"])
+	require.NotContains(t, attribution, "new_key")
+}


### PR DESCRIPTION
## Summary

Adds an optional `attribution_fields` map to the `asim_standardization` processor config. When non-empty, the processor wraps the `AdditionalFields` column as `{OriginalEvent, Attribution}` so the original pre-transform body is preserved under `AdditionalFields.OriginalEvent` and the supplied constant key/value pairs land under `AdditionalFields.Attribution`. When empty/unset (default), `AdditionalFields` keeps the prior flat shape, set directly to the original body, so existing consumers are unaffected.

## Why

Bindplane is preparing a Microsoft Sentinel Content Hub solution. Its connector-health KQL needs to disambiguate records emitted by Bindplane pipelines from other sources writing into the same shared ASIM table (Sentinel customers commonly have multiple writers per table). Native ASIM tables have a fixed schema and DCR ``transformKql`` cannot add columns, so the marker has to ride inside the existing `AdditionalFields` dynamic column. `attribution_fields` is the user-controlled knob that puts it there.

## What changes

- `config.go` — adds `AttributionFields map[string]string \`mapstructure:\"attribution_fields,omitempty\"\`` to ``Config``.
- `processor.go` — stores the map on the processor with a defensive copy from the constructor, and wraps ``AdditionalFields`` when the map is non-empty.
- `processor_test.go` — four new tests:
  - ``TestAttributionFields_AddsAttributionAndPreservesOriginal``
  - ``TestAttributionFields_UnsetIsBackwardsCompatible``
  - ``TestAttributionFields_EmptyMapBehavesAsUnset``
  - ``TestAttributionFields_CallerMapMutationDoesNotLeak``
- `README.md` — new row in the Configuration table; a new ``### With attribution_fields set`` subsection under ``AdditionalFields preservation`` with an example KQL query against the wrapped shape.

## Behavior

| Config | ``AdditionalFields`` output |
|---|---|
| ``attribution_fields`` unset or ``{}`` | ``<original body>`` (today's shape, unchanged) |
| ``attribution_fields: { k: v, ... }`` | ``{ OriginalEvent: <original body>, Attribution: { k: v, ... } }`` |

## Backwards compatibility

The wrapping fires **only** when ``attribution_fields`` is non-empty. Existing pipelines without the knob produce byte-identical output to the prior release.

## Test plan

- [x] ``go test -race ./processor/asimstandardizationprocessor/...`` — passes including the four new ``TestAttributionFields_*`` cases.
- [x] ``go vet ./...`` clean.
- [x] ``gofmt -s -l .`` clean.
- [ ] CI green.


## First consumer

``bindplane-op-enterprise`` will inject ``attribution_fields: { bindplane_source: \"bindplane\" }`` into every emitted ``asim_standardization`` processor in a follow-up PR, and bump the destination-type's match block to ``>= 1.8.0``. The Bindplane Sentinel Content Hub solution PR (the eventual end consumer) then queries ``tostring(AdditionalFields.Attribution.bindplane_source) == \"bindplane\"``.

PIPE-1055