### PR TITLE
feat(bindplaneextension): add support bundle shapes

### DIFF
--- a/extension/bindplaneextension/config.go
+++ b/extension/bindplaneextension/config.go
@@ -37,6 +37,10 @@ type Config struct {
 	TopologyInterval time.Duration `mapstructure:"topology_interval"`
 	// ExtraMeasurementsAttributes are a map of key-value pairs to add to all reported measurements.
 	ExtraMeasurementsAttributes map[string]string `mapstructure:"extra_measurements_attributes,omitempty"`
+	// SupportBundleEncryptionPublicKeyPath is an optional path to a PEM-encoded RSA public key
+	// used to encrypt support bundles into BNDL format before upload.
+	// When omitted the default embedded key is used.
+	SupportBundleEncryptionPublicKeyPath string `mapstructure:"support_bundle_encryption_public_key_path,omitempty"`
 }
 
 // Validate returns an error if the config is invalid

--- a/extension/bindplaneextension/internal/bundle/bundler.go
+++ b/extension/bindplaneextension/internal/bundle/bundler.go
@@ -1,0 +1,33 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import "context"
+
+// Bundler collects support bundles and delivers them to the server.
+//
+//go:generate mockery --name Bundler --filename mock_bundler.go --structname MockBundler --output mocks
+type Bundler interface {
+	// Collect gathers all configured artifacts and returns the encrypted bundle bytes.
+	Collect(ctx context.Context) ([]byte, error)
+
+	// SendToURL POSTs the bundle bytes to uploadURL.
+	// sessionID is forwarded as the X-Bindplane-Session-ID header.
+	SendToURL(ctx context.Context, data []byte, sessionID string, uploadURL string) error
+
+	// SendErrorToURL notifies the server that bundle collection failed.
+	// The error message is posted as plain text with X-Bindplane-Support-Bundle-Status: failed.
+	SendErrorToURL(ctx context.Context, sessionID string, errMessage string, uploadURL string) error
+}

--- a/extension/bindplaneextension/internal/bundle/capability.go
+++ b/extension/bindplaneextension/internal/bundle/capability.go
@@ -1,0 +1,22 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+// Capability is the OpAMP custom-message capability string advertised to the server.
+// The server uses this to know the agent can produce support bundles.
+const Capability = "com.bindplane.supportbundle"
+
+// RequestType is the OpAMP custom-message type sent by the server to request a bundle.
+const RequestType = "requestSupportBundle"

--- a/extension/bindplaneextension/internal/bundle/doc.go
+++ b/extension/bindplaneextension/internal/bundle/doc.go
@@ -1,0 +1,18 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bundle defines types, constants, and interfaces for support bundle
+// streaming over OpAMP custom messages. No HTTP calls, file I/O, or goroutines
+// live here — only shapes that both the implementation and tests depend on.
+package bundle

--- a/extension/bindplaneextension/internal/bundle/manager.go
+++ b/extension/bindplaneextension/internal/bundle/manager.go
@@ -1,0 +1,28 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import "context"
+
+// Manager handles incoming OpAMP custom messages that request a support bundle.
+//
+//go:generate mockery --name Manager --filename mock_manager.go --structname MockManager --output mocks
+type Manager interface {
+	// HandleRequest processes a single server-initiated bundle request.
+	// capability and msgType must match Capability and RequestType.
+	// data is the raw CustomMessage.Data bytes (YAML-encoded RequestPayload).
+	// uploadURL is where the finished bundle (or error notification) should be POSTed.
+	HandleRequest(ctx context.Context, capability string, msgType string, data []byte, uploadURL string)
+}

--- a/extension/bindplaneextension/internal/bundle/options.go
+++ b/extension/bindplaneextension/internal/bundle/options.go
@@ -1,0 +1,46 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+// Options controls what the Bundler collects and how it encrypts the output.
+type Options struct {
+	// ManagerConfigPath is the path to the OpAMP manager config file.
+	ManagerConfigPath string
+	// CollectorConfigPath is the path to the OTel collector config file.
+	CollectorConfigPath string
+	// CollectorLogDir is the directory containing collector log files.
+	// When empty, the implementation derives it from CollectorConfigPath as <configDir>/log.
+	CollectorLogDir string
+	// CollectorManagerConfig is the path to the collector's manager config (may equal ManagerConfigPath).
+	CollectorManagerConfig string
+	// CollectorProfileDir is the directory containing pprof profiles to include.
+	CollectorProfileDir string
+	// CollectorInstallRoot is the collector install root directory. When set, the bundle
+	// includes plugins/, version.txt, and other install-level artifacts.
+	CollectorInstallRoot string
+	// OutputDir is where temporary bundle files are written. Defaults to os.TempDir().
+	OutputDir string
+
+	// EncryptionPublicKeyPEM is the PEM-encoded RSA public key used to encrypt the bundle
+	// into BNDL format. When nil the default embedded key is used.
+	EncryptionPublicKeyPEM []byte
+
+	IncludeConfig       bool
+	IncludeLogs         bool
+	IncludeSystemInfo   bool
+	IncludeProfiles     bool
+	IncludeNetworkState bool
+	ProfileMaxAge       int
+}

--- a/extension/bindplaneextension/internal/bundle/request.go
+++ b/extension/bindplaneextension/internal/bundle/request.go
@@ -1,0 +1,42 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RequestPayload is the YAML body the server embeds in a CustomMessage Data field
+// when requesting a support bundle.
+type RequestPayload struct {
+	SessionID string `yaml:"session_id"`
+}
+
+// ParseRequestPayload decodes the YAML bytes from a CustomMessage and returns the payload.
+// An empty data slice returns a zero-value payload without error.
+func ParseRequestPayload(data []byte) (RequestPayload, error) {
+	if len(data) == 0 {
+		return RequestPayload{}, nil
+	}
+	var p RequestPayload
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return RequestPayload{}, fmt.Errorf("parse support bundle request payload: %w", err)
+	}
+	p.SessionID = strings.TrimSpace(p.SessionID)
+	return p, nil
+}

--- a/extension/bindplaneextension/internal/bundle/request_test.go
+++ b/extension/bindplaneextension/internal/bundle/request_test.go
@@ -1,0 +1,63 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestPayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      []byte
+		wantID    string
+		wantErr   bool
+	}{
+		{
+			name:   "valid yaml",
+			data:   []byte("session_id: abc-123\n"),
+			wantID: "abc-123",
+		},
+		{
+			name:   "whitespace trimmed",
+			data:   []byte("session_id: \"  spaced  \"\n"),
+			wantID: "spaced",
+		},
+		{
+			name:   "empty data returns zero value",
+			data:   nil,
+			wantID: "",
+		},
+		{
+			name:    "invalid yaml",
+			data:    []byte(":\t:bad"),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseRequestPayload(tc.data)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantID, got.SessionID)
+		})
+	}
+}

--- a/extension/bindplaneextension/internal/bundle/upload_url.go
+++ b/extension/bindplaneextension/internal/bundle/upload_url.go
@@ -1,0 +1,57 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// UploadURL derives the support bundle REST endpoint from the OpAMP WebSocket endpoint and agent ID.
+//
+// Example: wss://example.com/opamp + "abc" → https://example.com/v1/agents/abc/support-bundle
+//
+// Returns an empty string if the endpoint scheme is not ws:// or wss://.
+func UploadURL(opampEndpoint, agentID string) string {
+	base, err := httpOrigin(opampEndpoint)
+	if err != nil {
+		return ""
+	}
+	return base + "/v1/agents/" + url.PathEscape(agentID) + "/support-bundle"
+}
+
+// httpOrigin converts a WebSocket URL to its HTTP origin (scheme + host, no path).
+func httpOrigin(endpoint string) (string, error) {
+	var httpEndpoint string
+	switch {
+	case strings.HasPrefix(endpoint, "wss://"):
+		httpEndpoint = "https://" + endpoint[6:]
+	case strings.HasPrefix(endpoint, "ws://"):
+		httpEndpoint = "http://" + endpoint[5:]
+	default:
+		return "", fmt.Errorf("unsupported OpAMP endpoint scheme: %s", endpoint)
+	}
+
+	parsed, err := url.Parse(httpEndpoint)
+	if err != nil {
+		return "", err
+	}
+	parsed.Path = ""
+	parsed.RawPath = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}

--- a/extension/bindplaneextension/internal/bundle/upload_url_test.go
+++ b/extension/bindplaneextension/internal/bundle/upload_url_test.go
@@ -1,0 +1,68 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		agentID  string
+		want     string
+	}{
+		{
+			name:     "wss endpoint",
+			endpoint: "wss://example.com/opamp",
+			agentID:  "abc-123",
+			want:     "https://example.com/v1/agents/abc-123/support-bundle",
+		},
+		{
+			name:     "ws endpoint",
+			endpoint: "ws://localhost:4317/opamp",
+			agentID:  "agent-1",
+			want:     "http://localhost:4317/v1/agents/agent-1/support-bundle",
+		},
+		{
+			name:     "agent ID is path-escaped",
+			endpoint: "wss://example.com/opamp",
+			agentID:  "agent/with/slashes",
+			want:     "https://example.com/v1/agents/agent%2Fwith%2Fslashes/support-bundle",
+		},
+		{
+			name:     "unsupported scheme returns empty",
+			endpoint: "https://example.com/opamp",
+			agentID:  "abc",
+			want:     "",
+		},
+		{
+			name:     "empty endpoint returns empty",
+			endpoint: "",
+			agentID:  "abc",
+			want:     "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UploadURL(tc.endpoint, tc.agentID)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Define Go types, constants, and interfaces for support bundle streaming via OpAMP custom messages. No HTTP calls, file I/O, or goroutines — pure shapes that both the implementation (PR 2) and tests depend on.

- internal/bundle: Capability/RequestType constants, RequestPayload + ParseRequestPayload, Options, Bundler interface, Manager interface, UploadURL helper
- config.go: SupportBundleEncryptionPublicKeyPath field

<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed