### PR TITLE
feat(bindplaneextension): implement support bundle streaming via OpAMP

### DIFF
--- a/extension/bindplaneextension/config.go
+++ b/extension/bindplaneextension/config.go
@@ -16,6 +16,8 @@ package bindplaneextension
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -37,10 +39,29 @@ type Config struct {
 	TopologyInterval time.Duration `mapstructure:"topology_interval"`
 	// ExtraMeasurementsAttributes are a map of key-value pairs to add to all reported measurements.
 	ExtraMeasurementsAttributes map[string]string `mapstructure:"extra_measurements_attributes,omitempty"`
-	// SupportBundleEncryptionPublicKeyPath is an optional path to a PEM-encoded RSA public key
-	// used to encrypt support bundles into BNDL format before upload.
-	// When omitted the default embedded key is used.
-	SupportBundleEncryptionPublicKeyPath string `mapstructure:"support_bundle_encryption_public_key_path,omitempty"`
+	// SupportBundle configures support bundle collection and upload.
+	SupportBundle SupportBundleConfig `mapstructure:"support_bundle,omitempty"`
+}
+
+// SupportBundleConfig holds all knobs for on-demand support bundle collection.
+type SupportBundleConfig struct {
+	// OpAMPEndpoint is the WebSocket endpoint of the OpAMP server (e.g. wss://example.com/opamp).
+	// Used to derive the REST upload URL.
+	OpAMPEndpoint string `mapstructure:"opamp_endpoint,omitempty"`
+	// AgentID is the agent's unique identifier, used to construct the upload path.
+	AgentID string `mapstructure:"agent_id,omitempty"`
+	// CollectorConfigPath is the path to the OTel collector config file to include in bundles.
+	CollectorConfigPath string `mapstructure:"collector_config_path,omitempty"`
+	// CollectorLogDir is the directory containing collector log files.
+	CollectorLogDir string `mapstructure:"collector_log_dir,omitempty"`
+	// ManagerConfigPath is the path to the OpAMP manager config file.
+	ManagerConfigPath string `mapstructure:"manager_config_path,omitempty"`
+	// CollectorInstallRoot is the collector install root directory. When set the bundle
+	// includes plugins/, version.txt, and other install-level artifacts.
+	CollectorInstallRoot string `mapstructure:"collector_install_root,omitempty"`
+	// EncryptionPublicKeyPath is an optional path to a PEM-encoded RSA public key used to
+	// encrypt bundles into BNDL format. When omitted the default embedded key is used.
+	EncryptionPublicKeyPath string `mapstructure:"encryption_public_key_path,omitempty"`
 }
 
 // Validate returns an error if the config is invalid
@@ -51,6 +72,12 @@ func (c Config) Validate() error {
 
 	if c.TopologyInterval < 0 {
 		return errors.New("topology interval must be positive or 0")
+	}
+
+	if path := c.SupportBundle.EncryptionPublicKeyPath; path != "" {
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Errorf("support_bundle.encryption_public_key_path %q: %w", path, err)
+		}
 	}
 
 	return nil

--- a/extension/bindplaneextension/extension.go
+++ b/extension/bindplaneextension/extension.go
@@ -19,10 +19,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/golang/snappy"
+	"github.com/observiq/bindplane-otel-contrib/extension/bindplaneextension/internal/bundle"
 	"github.com/observiq/bindplane-otel-contrib/pkg/measurements"
 	"github.com/observiq/bindplane-otel-contrib/processor/topologyprocessor"
 	"github.com/open-telemetry/opamp-go/client/types"
@@ -39,6 +42,8 @@ type bindplaneExtension struct {
 	topologyRegistry                  *topologyprocessor.ResettableTopologyRegistry
 	customCapabilityHandlerThroughput opampcustommessages.CustomCapabilityHandler
 	customCapabilityHandlerTopology   opampcustommessages.CustomCapabilityHandler
+	bundleCapabilityHandler           opampcustommessages.CustomCapabilityHandler
+	bundleManager                     bundle.Manager
 
 	doneChan chan struct{}
 	wg       *sync.WaitGroup
@@ -64,6 +69,10 @@ func (b *bindplaneExtension) Start(_ context.Context, host component.Host) error
 
 	// Set up custom capabilities if enabled
 	if b.cfg.OpAMP != emptyComponentID {
+		if err := b.setupBundleManager(); err != nil {
+			return fmt.Errorf("setup support bundle manager: %w", err)
+		}
+
 		err := b.setupCustomCapabilities(host)
 		if err != nil {
 			return fmt.Errorf("setup capability handler: %w", err)
@@ -78,8 +87,40 @@ func (b *bindplaneExtension) Start(_ context.Context, host component.Host) error
 			b.wg.Add(1)
 			go b.reportTopologyLoop()
 		}
+
+		if b.bundleCapabilityHandler != nil {
+			b.wg.Add(1)
+			go b.handleBundleMessages()
+		}
 	}
 
+	return nil
+}
+
+func (b *bindplaneExtension) setupBundleManager() error {
+	cfg := b.cfg.SupportBundle
+
+	opts := bundle.Options{
+		CollectorConfigPath:    cfg.CollectorConfigPath,
+		CollectorLogDir:        cfg.CollectorLogDir,
+		ManagerConfigPath:      cfg.ManagerConfigPath,
+		CollectorManagerConfig: cfg.ManagerConfigPath,
+		CollectorInstallRoot:   cfg.CollectorInstallRoot,
+		IncludeConfig:          true,
+		IncludeLogs:            true,
+		IncludeSystemInfo:      true,
+	}
+
+	if cfg.EncryptionPublicKeyPath != "" {
+		keyPEM, err := os.ReadFile(cfg.EncryptionPublicKeyPath)
+		if err != nil {
+			return fmt.Errorf("read encryption public key: %w", err)
+		}
+		opts.EncryptionPublicKeyPEM = keyPEM
+	}
+
+	httpClient := &http.Client{Timeout: 10 * time.Minute}
+	b.bundleManager = bundle.NewDefaultManager(b.logger, bundle.NewDefaultBundler(httpClient, opts))
 	return nil
 }
 
@@ -121,6 +162,11 @@ func (b *bindplaneExtension) setupCustomCapabilities(host component.Host) error 
 		}
 	}
 
+	b.bundleCapabilityHandler, err = registry.Register(bundle.Capability)
+	if err != nil {
+		return fmt.Errorf("register support bundle capability: %w", err)
+	}
+
 	return nil
 }
 
@@ -131,6 +177,29 @@ func (b *bindplaneExtension) Dependencies() []component.ID {
 	}
 
 	return []component.ID{b.cfg.OpAMP}
+}
+
+func (b *bindplaneExtension) handleBundleMessages() {
+	defer b.wg.Done()
+
+	for {
+		select {
+		case msg := <-b.bundleCapabilityHandler.Message():
+			if msg == nil {
+				return
+			}
+			uploadURL := bundle.UploadURL(b.cfg.SupportBundle.OpAMPEndpoint, b.cfg.SupportBundle.AgentID)
+			go b.bundleManager.HandleRequest(
+				context.Background(),
+				msg.GetCapability(),
+				msg.GetType(),
+				msg.GetData(),
+				uploadURL,
+			)
+		case <-b.doneChan:
+			return
+		}
+	}
 }
 
 func (b *bindplaneExtension) reportMetricsLoop() {
@@ -241,6 +310,10 @@ func (b *bindplaneExtension) Shutdown(ctx context.Context) error {
 
 	if b.customCapabilityHandlerTopology != nil {
 		b.customCapabilityHandlerTopology.Unregister()
+	}
+
+	if b.bundleCapabilityHandler != nil {
+		b.bundleCapabilityHandler.Unregister()
 	}
 
 	return nil

--- a/extension/bindplaneextension/go.mod
+++ b/extension/bindplaneextension/go.mod
@@ -4,6 +4,7 @@ go 1.25.9
 
 require (
 	github.com/golang/snappy v1.0.0
+	github.com/observiq/bindplane-otel-contrib/pkg/support-util v0.0.0
 	github.com/observiq/bindplane-otel-contrib/pkg/measurements v1.7.0
 	github.com/observiq/bindplane-otel-contrib/processor/topologyprocessor v1.7.0
 	github.com/open-telemetry/opamp-go v0.23.0
@@ -17,6 +18,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.59.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -54,8 +56,9 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/observiq/bindplane-otel-contrib/pkg/support-util => ../../pkg/support-util
 
 replace github.com/observiq/bindplane-otel-contrib/pkg/measurements => ../../pkg/measurements
 

--- a/extension/bindplaneextension/internal/bundle/bundler_impl.go
+++ b/extension/bindplaneextension/internal/bundle/bundler_impl.go
@@ -1,0 +1,164 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/observiq/bindplane-otel-contrib/pkg/support-util/bundle"
+	"github.com/observiq/bindplane-otel-contrib/pkg/support-util/bundle/sources"
+)
+
+// defaultEncryptionPublicKeyPEM is the RSA public key used to produce encrypted BNDL files
+// when no override path is configured. The server holds the corresponding private key.
+var defaultEncryptionPublicKeyPEM = []byte(`-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtIPujVs2zj7vhIU4A8tJ
+suf05io4mbE3xmWxj0m2naDDemY7a4Ic5TJGGAV/+M3hYHtNDEt7glTI30kcqPR1
+KUdl5idU2DpeOphHQ/2LbgirrP49rz+wOchp6F6M3V2Au8HUhpAXWsCc6+93ub+F
+dDXu7ocKTHR0h0Baz4kKEpPEBuNY858hCjkhkdMXh3eg2iD3B2o227oJf41iomGm
+BfMkTuwC1NDYmAIhtLC4ojS7qJ3M+G/Cd+XqPvurlWNKQRUoFkcv5P31akqoZEK0
+Y8GlDX9ckM8HIgnHi/UaSUOESexPLDzCQTzqJ1kBeS7C3rorifzZu2n9AVoltLmm
+zwIDAQAB
+-----END PUBLIC KEY-----`)
+
+type defaultBundler struct {
+	httpClient *http.Client
+	opts       Options
+}
+
+// NewDefaultBundler returns a Bundler backed by bindplane-support-util.
+// If httpClient is nil, http.DefaultClient is used.
+func NewDefaultBundler(httpClient *http.Client, opts Options) Bundler {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &defaultBundler{httpClient: httpClient, opts: opts}
+}
+
+// Collect gathers configured artifacts and returns the encrypted bundle bytes.
+func (b *defaultBundler) Collect(_ context.Context) ([]byte, error) {
+	opts := bundle.DefaultBundleOptions()
+	opts.OutputDir = b.opts.OutputDir
+	if opts.OutputDir == "" {
+		opts.OutputDir = os.TempDir()
+	}
+
+	opts.CollectorConfigPath = b.opts.CollectorConfigPath
+	opts.CollectorManagerConfigPath = b.opts.CollectorManagerConfig
+	opts.CollectorLogDir = b.opts.CollectorLogDir
+	opts.CollectorProfileDir = b.opts.CollectorProfileDir
+	opts.CollectorInstallRoot = b.opts.CollectorInstallRoot
+	opts.IncludeConfig = b.opts.IncludeConfig
+	opts.IncludeLogs = b.opts.IncludeLogs
+	opts.IncludeSystemInfo = b.opts.IncludeSystemInfo
+	opts.IncludeProfiles = b.opts.IncludeProfiles
+	opts.IncludeNetworkState = b.opts.IncludeNetworkState
+	if b.opts.ProfileMaxAge > 0 {
+		opts.ProfileMaxAge = b.opts.ProfileMaxAge
+	}
+
+	encKey := b.opts.EncryptionPublicKeyPEM
+	if len(encKey) == 0 {
+		encKey = defaultEncryptionPublicKeyPEM
+	}
+	opts.Encryption.Enabled = true
+	opts.Encryption.PublicKeyPEM = encKey
+
+	var artifactSources []bundle.ArtifactSource
+	if b.opts.CollectorLogDir != "" {
+		artifactSources = append(artifactSources, sources.NewCollectorLogSource(b.opts.CollectorLogDir))
+	}
+	if b.opts.CollectorConfigPath != "" {
+		artifactSources = append(artifactSources, sources.NewCollectorConfigSource(b.opts.CollectorConfigPath))
+	}
+	if b.opts.CollectorManagerConfig != "" {
+		artifactSources = append(artifactSources, sources.NewCollectorManagerConfigSource(b.opts.CollectorManagerConfig))
+	}
+	if b.opts.ManagerConfigPath != "" {
+		artifactSources = append(artifactSources, sources.NewConfigSource(b.opts.ManagerConfigPath))
+	}
+	if b.opts.CollectorProfileDir != "" && b.opts.IncludeProfiles {
+		artifactSources = append(artifactSources, sources.NewCollectorProfileSource(b.opts.CollectorProfileDir))
+	}
+	if b.opts.CollectorInstallRoot != "" {
+		artifactSources = append(artifactSources, sources.NewCollectorRootExtrasSource())
+		artifactSources = append(artifactSources, sources.NewCollectorPluginsSource())
+	}
+	if b.opts.IncludeSystemInfo {
+		artifactSources = append(artifactSources, sources.NewSystemInfoSource())
+	}
+
+	path, err := bundle.CreateBundleFromOptions(opts, artifactSources)
+	if err != nil {
+		return nil, fmt.Errorf("create bundle: %w", err)
+	}
+	defer os.Remove(path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read bundle file: %w", err)
+	}
+	return data, nil
+}
+
+// SendToURL POSTs the encrypted bundle bytes to uploadURL.
+func (b *defaultBundler) SendToURL(ctx context.Context, data []byte, sessionID string, uploadURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("create bundle upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("X-Bindplane-Session-ID", sessionID)
+
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("upload support bundle: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("support bundle upload returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// SendErrorToURL notifies the server that bundle collection failed.
+func (b *defaultBundler) SendErrorToURL(ctx context.Context, sessionID string, errMessage string, uploadURL string) error {
+	if sessionID == "" {
+		return nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, bytes.NewReader([]byte(errMessage)))
+	if err != nil {
+		return fmt.Errorf("create bundle error request: %w", err)
+	}
+	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+	req.Header.Set("X-Bindplane-Session-ID", sessionID)
+	req.Header.Set("X-Bindplane-Support-Bundle-Status", "failed")
+
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send support bundle error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("support bundle error notification returned status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/extension/bindplaneextension/internal/bundle/manager_impl.go
+++ b/extension/bindplaneextension/internal/bundle/manager_impl.go
@@ -1,0 +1,69 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+type defaultManager struct {
+	logger  *zap.Logger
+	bundler Bundler
+}
+
+// NewDefaultManager returns a Manager that drives the given Bundler.
+func NewDefaultManager(logger *zap.Logger, bundler Bundler) Manager {
+	return &defaultManager{logger: logger, bundler: bundler}
+}
+
+// HandleRequest processes a server-initiated bundle request.
+// Messages whose capability or type do not match are silently ignored.
+func (m *defaultManager) HandleRequest(ctx context.Context, capability string, msgType string, data []byte, uploadURL string) {
+	if capability != Capability || msgType != RequestType {
+		return
+	}
+
+	payload, err := ParseRequestPayload(data)
+	if err != nil || payload.SessionID == "" {
+		m.logger.Error("support bundle request has missing or invalid session_id", zap.Error(err))
+		return
+	}
+	if uploadURL == "" {
+		m.logger.Error("support bundle upload URL is empty; cannot upload")
+		return
+	}
+
+	m.logger.Info("support bundle requested by server, collecting...")
+	bundleData, err := m.bundler.Collect(ctx)
+	if err != nil {
+		m.logger.Error("failed to collect support bundle", zap.Error(err))
+		if sendErr := m.bundler.SendErrorToURL(ctx, payload.SessionID, err.Error(), uploadURL); sendErr != nil {
+			m.logger.Debug("could not send bundle failure notification to server", zap.Error(sendErr))
+		}
+		return
+	}
+
+	if err := m.bundler.SendToURL(ctx, bundleData, payload.SessionID, uploadURL); err != nil {
+		m.logger.Error("failed to upload support bundle", zap.Error(err))
+		if sendErr := m.bundler.SendErrorToURL(ctx, payload.SessionID, err.Error(), uploadURL); sendErr != nil {
+			m.logger.Debug("could not send bundle failure notification to server", zap.Error(sendErr))
+		}
+		return
+	}
+
+	m.logger.Info("support bundle uploaded successfully")
+}

--- a/extension/bindplaneextension/internal/bundle/manager_impl_test.go
+++ b/extension/bindplaneextension/internal/bundle/manager_impl_test.go
@@ -1,0 +1,136 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+// fakeBundler is a test double for Bundler.
+type fakeBundler struct {
+	collectData []byte
+	collectErr  error
+	sendCalls   []sendCall
+	errorCalls  []errorCall
+}
+
+type sendCall struct {
+	data      []byte
+	sessionID string
+	uploadURL string
+}
+
+type errorCall struct {
+	sessionID  string
+	errMessage string
+	uploadURL  string
+}
+
+func (f *fakeBundler) Collect(_ context.Context) ([]byte, error) {
+	return f.collectData, f.collectErr
+}
+
+func (f *fakeBundler) SendToURL(_ context.Context, data []byte, sessionID string, uploadURL string) error {
+	f.sendCalls = append(f.sendCalls, sendCall{data: data, sessionID: sessionID, uploadURL: uploadURL})
+	return nil
+}
+
+func (f *fakeBundler) SendErrorToURL(_ context.Context, sessionID string, errMessage string, uploadURL string) error {
+	f.errorCalls = append(f.errorCalls, errorCall{sessionID: sessionID, errMessage: errMessage, uploadURL: uploadURL})
+	return nil
+}
+
+func newManager(t *testing.T, b Bundler) Manager {
+	t.Helper()
+	return NewDefaultManager(zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel)), b)
+}
+
+func TestDefaultManager_HandleRequest_success(t *testing.T) {
+	fb := &fakeBundler{collectData: []byte("bundle-bytes")}
+	m := newManager(t, fb)
+
+	m.HandleRequest(context.Background(), Capability, RequestType,
+		[]byte("session_id: sess-1\n"), "https://example.com/upload")
+
+	require.Len(t, fb.sendCalls, 1)
+	assert.Equal(t, "sess-1", fb.sendCalls[0].sessionID)
+	assert.Equal(t, "https://example.com/upload", fb.sendCalls[0].uploadURL)
+	assert.Equal(t, []byte("bundle-bytes"), fb.sendCalls[0].data)
+	assert.Empty(t, fb.errorCalls)
+}
+
+func TestDefaultManager_HandleRequest_collectFails(t *testing.T) {
+	fb := &fakeBundler{collectErr: errors.New("disk full")}
+	m := newManager(t, fb)
+
+	m.HandleRequest(context.Background(), Capability, RequestType,
+		[]byte("session_id: sess-2\n"), "https://example.com/upload")
+
+	assert.Empty(t, fb.sendCalls)
+	require.Len(t, fb.errorCalls, 1)
+	assert.Equal(t, "sess-2", fb.errorCalls[0].sessionID)
+	assert.Contains(t, fb.errorCalls[0].errMessage, "disk full")
+}
+
+func TestDefaultManager_HandleRequest_wrongCapability(t *testing.T) {
+	fb := &fakeBundler{collectData: []byte("bundle")}
+	m := newManager(t, fb)
+
+	m.HandleRequest(context.Background(), "other.capability", RequestType,
+		[]byte("session_id: sess-3\n"), "https://example.com/upload")
+
+	assert.Empty(t, fb.sendCalls)
+	assert.Empty(t, fb.errorCalls)
+}
+
+func TestDefaultManager_HandleRequest_wrongType(t *testing.T) {
+	fb := &fakeBundler{collectData: []byte("bundle")}
+	m := newManager(t, fb)
+
+	m.HandleRequest(context.Background(), Capability, "otherType",
+		[]byte("session_id: sess-4\n"), "https://example.com/upload")
+
+	assert.Empty(t, fb.sendCalls)
+	assert.Empty(t, fb.errorCalls)
+}
+
+func TestDefaultManager_HandleRequest_missingSessionID(t *testing.T) {
+	fb := &fakeBundler{collectData: []byte("bundle")}
+	m := newManager(t, fb)
+
+	m.HandleRequest(context.Background(), Capability, RequestType,
+		[]byte("session_id: \n"), "https://example.com/upload")
+
+	assert.Empty(t, fb.sendCalls)
+	assert.Empty(t, fb.errorCalls)
+}
+
+func TestDefaultManager_HandleRequest_emptyUploadURL(t *testing.T) {
+	fb := &fakeBundler{collectData: []byte("bundle")}
+	m := newManager(t, fb)
+
+	m.HandleRequest(context.Background(), Capability, RequestType,
+		[]byte("session_id: sess-5\n"), "")
+
+	assert.Empty(t, fb.sendCalls)
+	assert.Empty(t, fb.errorCalls)
+}


### PR DESCRIPTION
- internal/bundle: add defaultBundler (collects encrypted BNDL via support-util, POSTs to server with X-Bindplane-Session-ID) and defaultManager (parses request payload, drives collect+upload flow, sends error notification on failure)
- config.go: replace flat EncryptionPublicKeyPath field with SupportBundleConfig sub-struct (OpAMPEndpoint, AgentID, paths, key)
- extension.go: register com.bindplane.supportbundle capability on Start, drain handler.Message() in a goroutine, unregister on Shutdown

<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed