### PR TITLE
fix(m365receiver): tolerate auth failures instead of failing collector startup

### DIFF
--- a/receiver/m365receiver/logs.go
+++ b/receiver/m365receiver/logs.go
@@ -150,7 +150,7 @@ func (l *m365LogsReceiver) ensureToken(ctx context.Context) error {
 
 	for _, a := range l.audits {
 		if err := l.client.StartSubscription(ctx, l.startRoot+a.route); err != nil {
-			return fmt.Errorf("error starting %s audit subscription: %w", a.name, err)
+			return fmt.Errorf("starting %s audit subscription: %w", a.name, err)
 		}
 	}
 

--- a/receiver/m365receiver/logs.go
+++ b/receiver/m365receiver/logs.go
@@ -61,6 +61,12 @@ type m365LogsReceiver struct {
 	record       *logRecord
 	root         string
 	startRoot    string
+
+	// connected tracks whether we have successfully acquired a token and
+	// started the audit subscriptions. It is only read/written from the
+	// single polling goroutine (and Start, which happens-before it), so it
+	// does not require synchronization.
+	connected bool
 }
 
 type logRecord struct {
@@ -104,20 +110,8 @@ func (l *m365LogsReceiver) Start(ctx context.Context, host component.Host) error
 		return err
 	}
 
-	// create m365 log client, create token and start audit subscriptions
+	// create m365 log client
 	l.client = newM365Client(httpClient, l.cfg, "https://manage.office.com/.default")
-	err = l.client.GetToken(ctx)
-	if err != nil {
-		l.logger.Error("error creating authorization token", zap.Error(err))
-		return err
-	}
-	for _, a := range l.audits {
-		err = l.client.StartSubscription(ctx, l.startRoot+a.route)
-		if err != nil {
-			l.logger.Error("error starting audit subscriptions", zap.Error(err))
-			return err
-		}
-	}
 
 	// set cancel function
 	cancelCtx, cancel := context.WithCancel(ctx)
@@ -131,7 +125,37 @@ func (l *m365LogsReceiver) Start(ctx context.Context, host component.Host) error
 	l.storageClient = storageClient
 	l.loadCheckpoint(cancelCtx)
 
+	// Attempt to acquire a token and start subscriptions, but do not fail the
+	// collector if it fails (e.g. an expired client secret). The poll loop will handle the keep retrying until connectivity is restored.
+	if err := l.ensureToken(ctx); err != nil {
+		l.logger.Warn("unable to connect to M365 on startup; will keep retrying while polling", zap.Error(err))
+	}
+
 	return l.startPolling(cancelCtx)
+}
+
+// ensureToken acquires an authorization token and starts the audit
+// subscriptions. It is safe to call repeatedly: StartSubscription is idempotent
+// on the M365 side, so a partially-completed attempt is retried in full on the
+// next call. On success it marks the receiver connected and becomes a no-op
+// thereafter.
+func (l *m365LogsReceiver) ensureToken(ctx context.Context) error {
+	if l.connected {
+		return nil
+	}
+
+	if err := l.client.GetToken(ctx); err != nil {
+		return fmt.Errorf("error creating authorization token: %w", err)
+	}
+
+	for _, a := range l.audits {
+		if err := l.client.StartSubscription(ctx, l.startRoot+a.route); err != nil {
+			return fmt.Errorf("error starting %s audit subscription: %w", a.name, err)
+		}
+	}
+
+	l.connected = true
+	return nil
 }
 
 func (l *m365LogsReceiver) Shutdown(ctx context.Context) error {
@@ -173,6 +197,13 @@ func (l *m365LogsReceiver) startPolling(ctx context.Context) error {
 
 // spins a go routine for each audit type/endpoint
 func (l *m365LogsReceiver) pollLogs(ctx context.Context) error {
+	// Ensure we have a valid token and active subscriptions before polling. If
+	// this fails (e.g. an expired client secret), skip this cycle and retry on
+	// the next tick
+	if err := l.ensureToken(ctx); err != nil {
+		return err
+	}
+
 	var st string
 	if l.record.NextStartTime != nil {
 		st = l.record.NextStartTime.Format(layout)

--- a/receiver/m365receiver/logs.go
+++ b/receiver/m365receiver/logs.go
@@ -145,7 +145,7 @@ func (l *m365LogsReceiver) ensureToken(ctx context.Context) error {
 	}
 
 	if err := l.client.GetToken(ctx); err != nil {
-		return fmt.Errorf("error creating authorization token: %w", err)
+		return fmt.Errorf("creating authorization token: %w", err)
 	}
 
 	for _, a := range l.audits {

--- a/receiver/m365receiver/logs_test.go
+++ b/receiver/m365receiver/logs_test.go
@@ -48,6 +48,7 @@ func TestStartPolling(t *testing.T) {
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	l.cancel = cancel
 	l.record = &logRecord{}
+	l.connected = true
 
 	err := l.startPolling(cancelCtx)
 	require.NoError(t, err)
@@ -72,6 +73,7 @@ func TestPollLogs(t *testing.T) {
 	file := filepath.Join("testdata", "logs", "testPollLogs", "input.json")
 	client.On("GetJSON", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(client.loadTestLogs(t, file), nil)
 	rcv.record = &logRecord{}
+	rcv.connected = true
 
 	err := rcv.pollLogs(context.Background())
 	require.NoError(t, err)
@@ -152,6 +154,40 @@ func TestPollErrHandle(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return sink.LogRecordCount() > 0
 	}, 5*time.Second, 1*time.Second)
+}
+
+func TestPollLogsReconnect(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.TenantID = "testTenantID"
+	cfg.Logs.PollInterval = 1 * time.Second
+
+	sink := &consumertest.LogsSink{}
+	rcv := newM365Logs(cfg, receivertest.NewNopSettings(typ), sink)
+	client := &mockLogsClient{}
+	rcv.client = client
+	rcv.record = &logRecord{}
+
+	// First poll: token acquisition fails (e.g. expired client secret). The
+	// receiver should surface the error but stay alive and remain unconnected.
+	client.On("GetToken", mock.Anything).Return(fmt.Errorf("invalid_client")).Once()
+	err := rcv.pollLogs(context.Background())
+	require.Error(t, err)
+	require.False(t, rcv.connected)
+
+	// Second poll: the secret has been restored, so the token is acquired and
+	// the receiver connects and consumes logs.
+	file := filepath.Join("testdata", "logs", "testPollLogs", "input.json")
+	client.On("GetToken", mock.Anything).Return(nil).Once()
+	client.On("GetJSON", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(client.loadTestLogs(t, file), nil)
+	err = rcv.pollLogs(context.Background())
+	require.NoError(t, err)
+	require.True(t, rcv.connected)
+	require.Positive(t, sink.LogRecordCount())
+
+	// Subsequent polls reuse the existing connection: GetToken is not called again.
+	err = rcv.pollLogs(context.Background())
+	require.NoError(t, err)
+	client.AssertNumberOfCalls(t, "GetToken", 2)
 }
 
 func TestParseOptionalAttributes(t *testing.T) {


### PR DESCRIPTION

<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
A component's start should not rely on external factors like token expiry or anything on that front otherwise the collector will fail to start with what is considered a valid configuration at one moment but invalid at a later date. 

This changes the m365 receiver component to not have this state and effectively logs error messages rather than failing to start.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed