### PR TITLE
ci: migrate from Namespace.so to GitHub Actions runners (PLAT-1019)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -24,18 +24,18 @@ jobs:
     if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]'
     needs:
       - optimize_ci
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     strategy:
       matrix:
         target: [build-linux, build-darwin, build-windows]
     steps:
       - name: Checkout Contrib
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           path: contrib
 
       - name: Checkout Collector
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: observIQ/bindplane-otel-collector
           ref: main
@@ -49,9 +49,14 @@ jobs:
           cache: false
 
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Build Collector with Contrib Modules
         run: make -C contrib ${{ matrix.target }} COLLECTOR_PATH=../collector

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,7 +25,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip != 'true'
     needs:
       - optimize_ci
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
       pull-requests: read
@@ -39,7 +39,7 @@ jobs:
       dependabot: ${{ steps.filter.outputs.dependabot == 'true' || steps.filter.outputs.checks == 'true' || steps.filter.outputs.makefile == 'true' }}
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Detect changed files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
@@ -71,51 +71,67 @@ jobs:
     if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]'
     needs:
       - optimize_ci
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: "internal/tools/go.mod"
-          cache: false # Use Namespace caching instead
+          cache: false # Use the dedicated actions/cache step instead
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
 
   check-fmt:
     if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true'
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: "internal/tools/go.mod"
-          cache: false # Use Namespace caching instead
+          cache: false # Use the dedicated actions/cache step instead
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
       - name: Check Formatting
@@ -123,28 +139,36 @@ jobs:
 
   check-license:
     if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && (needs.detect-changes.outputs.go == 'true' || needs.detect-changes.outputs.scripts == 'true')
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: "internal/tools/go.mod"
-          cache: false # Use Namespace caching instead
+          cache: false # Use the dedicated actions/cache step instead
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
       - name: Check License Headers
@@ -152,28 +176,36 @@ jobs:
 
   gosec:
     if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true'
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Source
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: "internal/tools/go.mod"
-          cache: false # Use Namespace caching instead
+          cache: false # Use the dedicated actions/cache step instead
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
       - name: Run Gosec Security Scanner
@@ -181,28 +213,36 @@ jobs:
 
   misspell:
     if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.misspell == 'true'
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: "internal/tools/go.mod"
-          cache: false # Use Namespace caching instead
+          cache: false # Use the dedicated actions/cache step instead
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
       - name: Check for Misspelled Words in Doc Files
@@ -210,28 +250,36 @@ jobs:
 
   lint:
     if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.go == 'true'
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: "internal/tools/go.mod"
-          cache: false # Use Namespace caching instead
+          cache: false # Use the dedicated actions/cache step instead
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
       - name: Run Revive Linter
@@ -239,28 +287,36 @@ jobs:
 
   check-generate:
     if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.generate == 'true'
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - setup-tools
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: "internal/tools/go.mod"
-          cache: false # Use Namespace caching instead
+          cache: false # Use the dedicated actions/cache step instead
       - name: Set up Go cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
-          cache: go
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Cache Tools
         id: tool-cache
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-gotools-${{ hashFiles('**/go.sum', '**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-gotools-
       - name: Install Tools
         run: make install-tools
       - name: Run Code Generation
@@ -275,24 +331,24 @@ jobs:
   # Below checks don't need to run `make install-tools`
   check-mod-paths:
     if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && needs.detect-changes.outputs.gomod == 'true'
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Check Module Paths
         run: make check-mod-paths
 
   check-dependabot:
     if: needs.optimize_ci.outputs.skip != 'true' && github.actor != 'dependabot[bot]' && (needs.detect-changes.outputs.dependabot == 'true' || needs.detect-changes.outputs.gomod == 'true')
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     needs:
       - optimize_ci
       - detect-changes
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Check Dependabot
         run: make check-dependabot

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     if: needs.optimize_ci.outputs.skip != 'true'
     needs:
       - optimize_ci
-    runs-on: namespace-profile-bindplane-default-ubuntu-24-04
+    runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
       pull-requests: read
@@ -34,7 +34,7 @@ jobs:
       go: ${{ steps.filter.outputs.go == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.makefile == 'true' }}
     steps:
       - name: Checkout Sources
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Detect changed files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
@@ -62,25 +62,25 @@ jobs:
         include:
           # Ubuntu - All tests
           - os: ubuntu
-            runner: namespace-profile-bindplane-default-ubuntu-24-04-32x64
+            runner: ubuntu-latest-32-cores
             test_cmd: make test
           # macOS - All tests
           - os: macos
-            runner: namespace-profile-bindplane-default-macos-15
+            runner: macos-15-xlarge
             test_cmd: make test
           # Windows - All tests
           - os: windows
-            runner: namespace-profile-bindplane-default-windows-2022-16x32
+            runner: windows-2022-16-cores
             test_cmd: make test
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: Checkout Sources (Namespace)
+      - name: Checkout Sources (Unix)
         if: matrix.os != 'windows'
-        uses: namespacelabs/nscloud-checkout-action@c79c9a72c5df9e9590f9de7718b2f232c3e75879 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Checkout Sources (Windows)
         if: matrix.os == 'windows'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -88,27 +88,45 @@ jobs:
           go-version-file: "internal/tools/go.mod"
           cache: false
 
-      - name: Cache Go (Namespace)
-        if: matrix.os != 'windows'
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+      - name: Cache Go build (Ubuntu)
+        if: matrix.os == 'ubuntu'
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
-          cache: go
+          path: /home/runner/.cache/go-build
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/*.go') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
+
+      - name: Cache Go build (macOS)
+        if: matrix.os == 'macos'
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
+        with:
+          path: /Users/runner/Library/Caches/go-build
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/*.go') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
 
       - name: Cache Go modules (Ubuntu)
         if: matrix.os == 'ubuntu'
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: /home/runner/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
 
       - name: Cache Go modules (macOS)
         if: matrix.os == 'macos'
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: /Users/runner/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
 
       - name: Cache Go modules (Windows)
         if: matrix.os == 'windows'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: C:\Users\runneradmin\go\pkg\mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
@@ -117,7 +135,7 @@ jobs:
 
       - name: Cache Go build cache (Windows)
         if: matrix.os == 'windows'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: C:\Users\runneradmin\AppData\Local\go-build
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/*.go') }}
@@ -126,19 +144,25 @@ jobs:
 
       - name: Cache Tools (Ubuntu)
         if: matrix.os == 'ubuntu'
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: /home/runner/go/bin
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('internal/tools/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-tools-
 
       - name: Cache Tools (macOS)
         if: matrix.os == 'macos'
-        uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9 # v1
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: /Users/runner/go/bin
+          key: ${{ runner.os }}-go-tools-${{ hashFiles('internal/tools/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-tools-
 
       - name: Cache Tools (Windows)
         if: matrix.os == 'windows'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
         with:
           path: C:\Users\runneradmin\go\bin
           key: ${{ runner.os }}-go-tools-${{ hashFiles('internal/tools/go.sum') }}
@@ -148,17 +172,7 @@ jobs:
       - name: Install Tools
         run: make install-tools-ci
 
-      - name: Run Tests (Windows)
-        if: matrix.os == 'windows'
-        run: ${{ matrix.test_cmd }}
-        env:
-          TMPDIR: D:\Temp
-          TMP: D:\Temp
-          TEMP: D:\Temp
-          GOTMPDIR: D:\Temp
-
       - name: Run Tests
-        if: matrix.os != 'windows'
         run: ${{ matrix.test_cmd }}
 
   test-summary:


### PR DESCRIPTION
**Overview**

We are migrating from Namespace.so back to Github Actions Runners.