### PR TITLE
ci(build-check): build against matching collector branch for otel bumps

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -34,11 +34,30 @@ jobs:
         with:
           path: contrib
 
+      # OTel version bumps are coordinated breaking changes that must land in
+      # contrib and collector in lockstep, so contrib cannot always build
+      # against collector's main. For OTel-bump branches only (deps/otel-*),
+      # if a collector branch exists with the same name, build against it;
+      # otherwise use main.
+      - name: Resolve collector ref
+        id: collector_ref
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          if [ "${BRANCH#deps/otel-}" != "$BRANCH" ] && git ls-remote --exit-code --heads \
+            https://github.com/observIQ/bindplane-otel-collector.git "$BRANCH" >/dev/null 2>&1; then
+            echo "ref=$BRANCH" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Build Check::Found matching collector branch '$BRANCH'; building contrib against it."
+          else
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Build Check::No matching collector branch; building contrib against collector 'main'."
+          fi
+
       - name: Checkout Collector
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: observIQ/bindplane-otel-collector
-          ref: main
+          ref: ${{ steps.collector_ref.outputs.ref }}
           path: collector
 
       - name: Setup Go


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Coordinated OTel version bumps are often breaking changes that must land in contrib and collector in lockstep. If we only update one, CI will typically fail.

In order to get around this, we need CI for OTel dependencies to run against a branch of bindplane-otel-collector that is also on the bumped version of OTel.

In order to accomplish this, we're going to resolve the collector ref before checkout: for deps/otel-* head branches that have a same-named collector branch, build against that branch; otherwise fall back to main.

Assisted-by: Claude Opus 4.8

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed