### PR TITLE
fix(gcspubsubeventreceiver): detect gzip and format from content, not label

### DIFF
--- a/receiver/gcspubsubeventreceiver/README.md
+++ b/receiver/gcspubsubeventreceiver/README.md
@@ -37,15 +37,19 @@ Certain error conditions cause the receiver to nack a message rather than ack it
 
 ## File Format Support
 
-The receiver automatically detects the file format based on the file extension and content type:
+The receiver detects the file format from the object's content, not from its name or content type. A correctly formatted object is parsed even when its extension or `Content-Type` is wrong, missing, or generic (GCS commonly reports `application/octet-stream`).
 
 | Format | Detection |
 |---|---|
-| Avro OCF | `.avro`, `.avro.gz` extension or `application/avro` content type |
-| JSON | `.json`, `.json.gz` extension or `application/json` content type |
-| Plain text | All other files; parsed line by line |
+| Avro OCF | Leading `Obj\x01` magic bytes |
+| JSON | Leading `{` followed by `"`/`}`, or `[` followed by `{`/`]` (object, or array of objects) |
+| Plain text | Everything else; parsed line by line |
 
-Gzip-compressed files are transparently decompressed before parsing.
+Gzip compression is likewise detected from content (the `1f 8b` magic), not from the `.gz` extension or a `Content-Encoding: gzip` label. Compressed objects are transparently decompressed before parsing. When the label disagrees with the detected content, a warning is logged and the content wins. This fixes objects that carry a `.gz` name but hold uncompressed bytes, which previously failed to parse and were redelivered indefinitely.
+
+### Unsupported content
+
+Content that is not text, Avro, or JSON (for example an image or a PDF) is not parsed as text. It is rejected with its detected MIME type and the message is nacked for DLQ processing, rather than being emitted as garbled lines.
 
 ## Configuration
 

--- a/receiver/gcspubsubeventreceiver/go.mod
+++ b/receiver/gcspubsubeventreceiver/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	cloud.google.com/go/pubsub v1.51.0
 	cloud.google.com/go/storage v1.63.0
+	github.com/gabriel-vasile/mimetype v1.4.13
 	github.com/google/go-cmp v0.7.0
 	github.com/linkedin/goavro/v2 v2.15.0
 	github.com/observiq/bindplane-otel-contrib/internal/storageclient v1.10.0

--- a/receiver/gcspubsubeventreceiver/go.sum
+++ b/receiver/gcspubsubeventreceiver/go.sum
@@ -50,6 +50,8 @@ github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMD
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
+github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/receiver/gcspubsubeventreceiver/internal/worker/avro_ocf_parser.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/avro_ocf_parser.go
@@ -16,7 +16,9 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"iter"
 	"slices"
 
@@ -53,9 +55,14 @@ func NewAvroOcfParser(reader BufferedReader, logger *zap.Logger) LogParser {
 }
 
 // StartsWithAvroOcfMagic checks if the reader starts with the Avro OCF magic string.
+// A stream shorter than the magic (io.EOF from Peek) simply is not Avro, so that
+// case returns (false, nil) rather than an error.
 func StartsWithAvroOcfMagic(reader BufferedReader) (bool, error) {
 	bytes, err := reader.Peek(len(avroOcfMagicBytes))
 	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return false, nil
+		}
 		return false, err
 	}
 	return slices.Equal(bytes, avroOcfMagicBytes), nil

--- a/receiver/gcspubsubeventreceiver/internal/worker/detection_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/detection_test.go
@@ -1,0 +1,365 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+const testMaxLogSize = 4096
+
+// gzipBytes returns the gzip-compressed form of s.
+func gzipBytes(t *testing.T, s string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, err := w.Write([]byte(s))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}
+
+// readAllFromStream builds a LogStream over body and returns the decoded content
+// produced by BufferedReader.
+func readAllFromStream(t *testing.T, stream *LogStream) ([]byte, error) {
+	t.Helper()
+	br, err := stream.BufferedReader(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return io.ReadAll(br)
+}
+
+// TestBufferedReader_ContentAuthoritativeGzip verifies gzip is decided from the
+// object's bytes, not from its name or Content-Encoding label.
+func TestBufferedReader_ContentAuthoritativeGzip(t *testing.T) {
+	t.Parallel()
+
+	gzipEnc := "gzip"
+
+	testCases := []struct {
+		name            string
+		objectName      string
+		contentEncoding *string
+		body            []byte
+		want            string
+	}{
+		{
+			// The customer bug: uncompressed content under a .gz name must not be
+			// fed to gzip.NewReader.
+			name:       "uncompressed bytes under .gz name read as raw",
+			objectName: "logs/app.log.gz",
+			body:       []byte("hello\nworld\n"),
+			want:       "hello\nworld\n",
+		},
+		{
+			name:       "real gzip without .gz name is decompressed",
+			objectName: "logs/app.log",
+			body:       gzipBytes(t, "hello\nworld\n"),
+			want:       "hello\nworld\n",
+		},
+		{
+			name:            "Content-Encoding gzip on plaintext body reads as raw",
+			objectName:      "logs/app.log",
+			contentEncoding: &gzipEnc,
+			body:            []byte("plain text line\n"),
+			want:            "plain text line\n",
+		},
+		{
+			name:            "real gzip with matching Content-Encoding is decompressed",
+			objectName:      "logs/app.log",
+			contentEncoding: &gzipEnc,
+			body:            gzipBytes(t, "compressed payload\n"),
+			want:            "compressed payload\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stream := &LogStream{
+				Name:            tc.objectName,
+				ContentEncoding: tc.contentEncoding,
+				Body:            io.NopCloser(bytes.NewReader(tc.body)),
+				MaxLogSize:      testMaxLogSize,
+				Logger:          zap.NewNop(),
+			}
+
+			got, err := readAllFromStream(t, stream)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(got))
+		})
+	}
+}
+
+// TestBufferedReader_TinyAndEmpty verifies short objects do not error.
+func TestBufferedReader_TinyAndEmpty(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		body []byte
+	}{
+		{"empty", []byte("")},
+		{"one byte", []byte("x")},
+		{"one byte under .gz name", []byte("x")},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			name := "obj"
+			if strings.Contains(tc.name, ".gz") {
+				name = "obj.gz"
+			}
+			stream := &LogStream{
+				Name:       name,
+				Body:       io.NopCloser(bytes.NewReader(tc.body)),
+				MaxLogSize: testMaxLogSize,
+				Logger:     zap.NewNop(),
+			}
+			got, err := readAllFromStream(t, stream)
+			require.NoError(t, err)
+			require.Equal(t, tc.body, got)
+		})
+	}
+}
+
+// TestBufferedReader_LabelMismatchWarns verifies a warning is emitted when the
+// gzip label disagrees with the detected content.
+func TestBufferedReader_LabelMismatchWarns(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	stream := &LogStream{
+		Name:       "logs/app.log.gz", // labeled gzip
+		Body:       io.NopCloser(bytes.NewReader([]byte("not compressed\n"))),
+		MaxLogSize: testMaxLogSize,
+		Logger:     logger,
+	}
+
+	_, err := readAllFromStream(t, stream)
+	require.NoError(t, err)
+	require.Positive(t, logs.FilterMessageSnippet("label").Len(),
+		"expected a warning about the gzip label disagreeing with content")
+}
+
+// TestBufferedReader_NoWarnWhenLabelMatches verifies no mismatch warning fires
+// when label and content agree.
+func TestBufferedReader_NoWarnWhenLabelMatches(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	stream := &LogStream{
+		Name:       "logs/app.log", // no gzip label
+		Body:       io.NopCloser(bytes.NewReader([]byte("plain\n"))),
+		MaxLogSize: testMaxLogSize,
+		Logger:     logger,
+	}
+
+	_, err := readAllFromStream(t, stream)
+	require.NoError(t, err)
+	require.Zero(t, logs.FilterMessageSnippet("label").Len(),
+		"expected no mismatch warning when label matches content")
+}
+
+// TestStartsWithJSONObjectOrArray verifies the strengthened structural rule:
+// a leading '{' must be followed by '"' or '}', and a leading '[' by '{' or ']'.
+func TestStartsWithJSONObjectOrArray(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"records object", `{"Records":[{"a":1}]}`, true},
+		{"empty object", `{}`, true},
+		{"object with leading whitespace", "   \n\t{\"x\":1}", true},
+		{"object inner whitespace before key", `{  "x": 1}`, true},
+		{"array of objects", `[{"a":1},{"b":2}]`, true},
+		{"empty array", `[]`, true},
+		{"array with whitespace then object", `[  {} ]`, true},
+		{"timestamp log line", `[2024-01-01T00:00:00Z] INFO started`, false},
+		{"array of numbers", `[1,2,3]`, false},
+		{"array of strings", `["a","b"]`, false},
+		{"plain text", "not json at all", false},
+		{"empty input", "", false},
+		{"lone open brace", "{", false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			br := NewBufferedReader(strings.NewReader(tc.input), testMaxLogSize)
+			got, err := StartsWithJSONObjectOrArray(br)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestStartsWithAvroOcfMagic verifies the magic check and that short inputs do
+// not error.
+func TestStartsWithAvroOcfMagic(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		input []byte
+		want  bool
+	}{
+		{"avro magic", append([]byte("Obj\x01"), []byte("schema...")...), true},
+		{"not avro", []byte("PK\x03\x04rest"), false},
+		{"short input", []byte("Ob"), false},
+		{"empty input", []byte(""), false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			br := NewBufferedReader(bytes.NewReader(tc.input), testMaxLogSize)
+			got, err := StartsWithAvroOcfMagic(br)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestNewParser_ContentAuthoritative verifies parser selection ignores the
+// extension/content-type and routes on content alone.
+func TestNewParser_ContentAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	avro := string(append([]byte("Obj\x01"), []byte("\x04\x14avro.schema")...))
+
+	testCases := []struct {
+		name        string
+		objectName  string
+		contentType *string
+		content     string
+		tryDecoding bool
+		wantType    string
+	}{
+		{
+			name:        "json content with wrong extension is json",
+			objectName:  "data.bin",
+			content:     `[{"a":1}]`,
+			tryDecoding: true,
+			wantType:    "*worker.jsonParser",
+		},
+		{
+			name:        "avro content with wrong extension is avro",
+			objectName:  "data.bin",
+			content:     avro,
+			tryDecoding: true,
+			wantType:    "*worker.avroOcfParser",
+		},
+		{
+			name:        "timestamp log line is line parser",
+			objectName:  "data.json", // even a .json name must not force JSON
+			content:     `[2024-01-01T00:00:00Z] INFO started`,
+			tryDecoding: true,
+			wantType:    "*worker.lineParser",
+		},
+		{
+			name:        "tryDecoding false is always line parser",
+			objectName:  "data.json",
+			content:     `[{"a":1}]`,
+			tryDecoding: false,
+			wantType:    "*worker.lineParser",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stream := LogStream{
+				Name:        tc.objectName,
+				ContentType: tc.contentType,
+				MaxLogSize:  testMaxLogSize,
+				Logger:      zap.NewNop(),
+				TryDecoding: tc.tryDecoding,
+			}
+			br := NewBufferedReader(strings.NewReader(tc.content), testMaxLogSize)
+			parser, err := newParser(context.Background(), stream, br)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantType, typeName(parser))
+		})
+	}
+}
+
+// typeName returns the concrete type name of the parser for assertion.
+func typeName(p LogParser) string {
+	switch p.(type) {
+	case *jsonParser:
+		return "*worker.jsonParser"
+	case *avroOcfParser:
+		return "*worker.avroOcfParser"
+	case *lineParser:
+		return "*worker.lineParser"
+	default:
+		return "unknown"
+	}
+}
+
+// TestNewParser_UnsupportedContentDLQ verifies content that is not text, Avro, or
+// JSON produces an ErrUnsupportedContent that maps to the unsupported-file DLQ
+// condition, rather than being line-parsed as garbled text.
+func TestNewParser_UnsupportedContentDLQ(t *testing.T) {
+	t.Parallel()
+
+	// PNG signature + IHDR chunk start, enough for mimetype to detect image/png.
+	png := []byte{
+		0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R',
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	}
+	stream := LogStream{
+		Name:        "logs/object",
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+	br := NewBufferedReader(bytes.NewReader(png), testMaxLogSize)
+	_, err := newParser(context.Background(), stream, br)
+	require.Error(t, err)
+
+	var unsupported ErrUnsupportedContent
+	require.ErrorAs(t, err, &unsupported)
+	require.Equal(t, "image/png", unsupported.MIMEType)
+	require.Equal(t, dlqErrorKindUnsupportedFile, dlqConditionKind(err))
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/json_parser.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/json_parser.go
@@ -53,31 +53,63 @@ func NewJSONParser(reader BufferedReader) LogParser {
 	}
 }
 
-// StartsWithJSONObjectOrArray returns true if the reader starts with a JSON object or
-// array, allowing some space before the starting delimiter. It uses Peek and will not
-// move the reader.
+// jsonPeekBytes is the number of leading bytes inspected to classify the stream
+// as JSON. It only needs to reach the second meaningful byte past any leading
+// whitespace, so a small window is sufficient.
+const jsonPeekBytes = 512
+
+// StartsWithJSONObjectOrArray reports whether the reader begins with one of the
+// JSON shapes this parser supports: an object (`{...}` or `{}`) or an array of
+// objects (`[{...}]` or `[]`). It uses Peek and does not advance the reader.
+//
+// A leading `{` or `[` alone is too weak: a common log line such as
+// `[2024-01-01T00:00:00Z] INFO ...` starts with `[` but is not JSON. So the check
+// is structural. After leading whitespace, the first meaningful byte must be `{`
+// or `[`, and the next meaningful byte must confirm the shape:
+//
+//   - `{` must be followed by `"` (a key) or `}` (empty object);
+//   - `[` must be followed by `{` (array of objects) or `]` (empty array).
+//
+// This accepts array-of-objects, `{"Records":[...]}`, `{}` and `[]`, and rejects
+// `[2024-...]`, `[1,2,3]`, and `["a","b"]`, all of which route to line parsing.
 func StartsWithJSONObjectOrArray(reader BufferedReader) (bool, error) {
-	// allow some leading whitespace
-	bytes, err := reader.Peek(128)
+	buf, err := reader.Peek(jsonPeekBytes)
 	if err != nil {
-		// if we have less than 128 bytes and we get an EOF, we will just look at the bytes
-		// returned below
+		// Fewer than jsonPeekBytes available is fine; classify from what we have.
 		if !errors.Is(err, io.EOF) {
 			return false, fmt.Errorf("peek: %w", err)
 		}
 	}
-	for _, b := range bytes {
-		switch b {
-		case '{', '[':
-			return true, nil
+
+	open, rest, ok := firstMeaningfulByte(buf)
+	if !ok {
+		return false, nil
+	}
+
+	switch open {
+	case '{':
+		next, _, ok := firstMeaningfulByte(rest)
+		return ok && (next == '"' || next == '}'), nil
+	case '[':
+		next, _, ok := firstMeaningfulByte(rest)
+		return ok && (next == '{' || next == ']'), nil
+	default:
+		return false, nil
+	}
+}
+
+// firstMeaningfulByte returns the first non-whitespace byte in buf, the bytes
+// following it, and whether one was found.
+func firstMeaningfulByte(buf []byte) (b byte, rest []byte, ok bool) {
+	for i := 0; i < len(buf); i++ {
+		switch buf[i] {
 		case ' ', '\t', '\n', '\r':
-			// allow some leading whitespace
 			continue
 		default:
-			return false, nil
+			return buf[i], buf[i+1:], true
 		}
 	}
-	return false, nil
+	return 0, nil, false
 }
 
 // Parse parses the JSON stream into a sequence of log records. The JSON stream is

--- a/receiver/gcspubsubeventreceiver/internal/worker/parser.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/parser.go
@@ -16,12 +16,24 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"iter"
-	"strings"
 
+	"github.com/gabriel-vasile/mimetype"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 )
+
+// ErrUnsupportedContent is returned when the decoded content is a recognized but
+// unsupported type (for example an image or a PDF). It carries the detected MIME
+// type and maps to the unsupported-file DLQ condition.
+type ErrUnsupportedContent struct {
+	MIMEType string
+}
+
+func (e ErrUnsupportedContent) Error() string {
+	return fmt.Sprintf("unsupported content type: %s", e.MIMEType)
+}
 
 // LogParser is an interface that can parse a log stream into a sequence of log records
 // and can also append a single log body to a LogRecord.
@@ -65,16 +77,39 @@ func newParser(ctx context.Context, stream LogStream, reader BufferedReader) (pa
 	if isJSON {
 		return NewJSONParser(reader), nil
 	}
-	return NewLineParser(reader), nil
+
+	// Terminal: the content is neither Avro nor JSON. Recognized text is parsed
+	// line by line; recognized non-text content (an image, a PDF, an unknown
+	// binary) is rejected so it lands in the DLQ instead of being emitted as
+	// garbled lines.
+	header, _ := reader.Peek(detectionPeekBytes)
+	if len(header) == 0 {
+		// Empty object: nothing to parse, but not an error.
+		return NewLineParser(reader), nil
+	}
+	detected := mimetype.Detect(header)
+	if isTextMIME(detected) {
+		return NewLineParser(reader), nil
+	}
+	return nil, ErrUnsupportedContent{MIMEType: detected.String()}
 }
 
-func isJSON(_ context.Context, stream LogStream, reader BufferedReader) (bool, error) {
-	// check if the file extension or content type is json
-	if !isJSONExtension(stream.Name) && !isJSONContentType(stream.ContentType) {
-		return false, nil
+// isTextMIME reports whether the detected type is textual by walking its parent
+// chain up to text/plain (mimetype models text formats as descendants of it).
+func isTextMIME(mt *mimetype.MIME) bool {
+	for m := mt; m != nil; m = m.Parent() {
+		if m.Is("text/plain") {
+			return true
+		}
 	}
+	return false
+}
 
-	// check if the stream starts with a json object or array
+// isJSON reports whether the stream content is JSON. Detection is content-only:
+// the object name and content type are not consulted, because customers routinely
+// store JSON under a wrong or missing extension and GCS reports a generic content
+// type such as application/octet-stream.
+func isJSON(_ context.Context, stream LogStream, reader BufferedReader) (bool, error) {
 	startsWithJSONObjectOrArray, err := StartsWithJSONObjectOrArray(reader)
 	if err != nil {
 		stream.Logger.Warn("failed to check if starts with json object or array", zap.Error(err))
@@ -84,13 +119,9 @@ func isJSON(_ context.Context, stream LogStream, reader BufferedReader) (bool, e
 	return startsWithJSONObjectOrArray, nil
 }
 
+// isAvroOcf reports whether the stream content is Avro OCF, based solely on the
+// object's leading magic bytes.
 func isAvroOcf(_ context.Context, stream LogStream, reader BufferedReader) (bool, error) {
-	// check if the file extension or content type is avro
-	if !isAvroExtension(stream.Name) && !isAvroContentType(stream.ContentType) {
-		return false, nil
-	}
-
-	// check if the stream starts with the avro ocf magic string
 	startsWithAvroOcfMagic, err := StartsWithAvroOcfMagic(reader)
 	if err != nil {
 		stream.Logger.Warn("failed to check if starts with avro ocf magic", zap.Error(err))
@@ -98,20 +129,4 @@ func isAvroOcf(_ context.Context, stream LogStream, reader BufferedReader) (bool
 	}
 
 	return startsWithAvroOcfMagic, nil
-}
-
-func isJSONExtension(name string) bool {
-	return strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".json.gz")
-}
-
-func isJSONContentType(contentType *string) bool {
-	return contentType != nil && strings.HasPrefix(*contentType, "application/json")
-}
-
-func isAvroExtension(name string) bool {
-	return strings.HasSuffix(name, ".avro") || strings.HasSuffix(name, ".avro.gz")
-}
-
-func isAvroContentType(contentType *string) bool {
-	return contentType != nil && strings.HasPrefix(*contentType, "application/avro")
 }

--- a/receiver/gcspubsubeventreceiver/internal/worker/stream.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/stream.go
@@ -15,14 +15,22 @@
 package worker
 
 import (
+	"bufio"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 
+	"github.com/gabriel-vasile/mimetype"
 	"go.uber.org/zap"
 )
+
+// detectionPeekBytes is the number of leading bytes inspected for content
+// detection. It matches mimetype's default read limit so detection sees the same
+// window the library would.
+const detectionPeekBytes = 3072
 
 // LogStream is a struct containing the information about a stream of logs.
 type LogStream struct {
@@ -35,32 +43,53 @@ type LogStream struct {
 	TryDecoding     bool
 }
 
-// BufferedReader returns a BufferedReader for the log stream. If the content is gzipped
-// (content-encoding: gzip or ends with .gz), it will be decompressed.
+// BufferedReader returns a BufferedReader for the log stream. Compression is
+// decided from the object's actual bytes, not from its name or Content-Encoding
+// label: customers set both incorrectly, and GCS decompressive transcoding can
+// strip compression while leaving the label in place. The label is only used to
+// surface a warning when it disagrees with the detected content.
 func (stream *LogStream) BufferedReader(_ context.Context) (BufferedReader, error) {
-	// Check if content is gzipped and decompress if needed
-	if stream.ContentEncoding != nil {
-		switch *stream.ContentEncoding {
-		case "gzip":
-			gzipReader, err := gzip.NewReader(stream.Body)
-			if err != nil {
-				return nil, fmt.Errorf("create gzip reader: %w", err)
-			}
-			return NewBufferedReader(gzipReader, stream.MaxLogSize), nil
+	// Wrap the body so the leading bytes can be inspected without consuming them.
+	// The same wrapper is handed downstream, so no bytes are lost.
+	br := bufio.NewReaderSize(stream.Body, detectionPeekBytes)
 
-		default:
-			stream.Logger.Warn("unsupported content encoding", zap.String("content_encoding", *stream.ContentEncoding))
-			return NewBufferedReader(stream.Body, stream.MaxLogSize), nil
-		}
+	reader, err := stream.decompress(br)
+	if err != nil {
+		return nil, err
+	}
+	return NewBufferedReader(reader, stream.MaxLogSize), nil
+}
+
+// decompress detects the compression of the peeked content and returns a reader
+// over the decompressed bytes. Unknown or uncompressed content is passed through
+// unchanged.
+func (stream *LogStream) decompress(br *bufio.Reader) (io.Reader, error) {
+	header, err := br.Peek(detectionPeekBytes)
+	// A short object yields io.EOF (fewer than detectionPeekBytes available); that
+	// is expected and the partial header is still valid for detection.
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("peek content: %w", err)
 	}
 
-	if strings.HasSuffix(stream.Name, ".gz") {
-		gzipReader, err := gzip.NewReader(stream.Body)
+	detected := mimetype.Detect(header)
+
+	labeledGzip := strings.HasSuffix(stream.Name, ".gz") ||
+		(stream.ContentEncoding != nil && *stream.ContentEncoding == "gzip")
+	contentGzip := detected.Is("application/gzip")
+	if labeledGzip != contentGzip {
+		stream.Logger.Warn("compression label disagrees with content",
+			zap.String("name", stream.Name),
+			zap.Bool("labeled_gzip", labeledGzip),
+			zap.String("detected_content_type", detected.String()))
+	}
+
+	if contentGzip {
+		gzipReader, err := gzip.NewReader(br)
 		if err != nil {
 			return nil, fmt.Errorf("create gzip reader: %w", err)
 		}
-		return NewBufferedReader(gzipReader, stream.MaxLogSize), nil
+		return gzipReader, nil
 	}
 
-	return NewBufferedReader(stream.Body, stream.MaxLogSize), nil
+	return br, nil
 }

--- a/receiver/gcspubsubeventreceiver/internal/worker/worker.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/worker.go
@@ -474,6 +474,11 @@ func dlqConditionKind(err error) dlqErrorKind {
 	if errors.Is(err, ErrNotArrayOrKnownObject) {
 		return dlqErrorKindUnsupportedFile
 	}
+	// Recognized but unsupported content (image, PDF, unknown binary).
+	var unsupported ErrUnsupportedContent
+	if errors.As(err, &unsupported) {
+		return dlqErrorKindUnsupportedFile
+	}
 	return dlqErrorKindNone
 }
 


### PR DESCRIPTION
### Proposed Change

The receiver chose whether to gunzip an object from its name (`.gz`) or `Content-Encoding: gzip` instead of its actual bytes. Uncompressed content stored under a `.gz` name hit `gzip.NewReader`, failed with `invalid header`, and never parsed. Pub/Sub then redelivered the message over and over.

Now the receiver reads the object's leading bytes, detects the type with `gabriel-vasile/mimetype`, and routes on that. Gzip is the only codec wired up here: gzip bytes get decompressed, everything else is read as-is. A `.gz` file that isn't really gzip reads fine, and a real gzip file without the `.gz` name still decompresses. The name and `Content-Encoding` only trigger a warning when they disagree with the bytes.

Avro and JSON detection no longer depends on the file extension. Avro is matched by its `Obj\x01` magic. JSON is matched by structure: `{` then `"` or `}`, or `[` then `{` or `]`. That covers objects and arrays of objects, and skips log lines like `[2024-01-01T00:00:00Z] ...`. Plain text is confirmed with mimetype. Anything that is not text, Avro, or JSON (an image, for instance) is no longer read as text; it goes to the DLQ with its detected type.

First change in a stacked series. Later PRs add more compression codecs and archive support.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
