### PR TITLE
feat(gcspubsubeventreceiver): add zip archive support

### DIFF
--- a/receiver/gcspubsubeventreceiver/README.md
+++ b/receiver/gcspubsubeventreceiver/README.md
@@ -71,8 +71,11 @@ Archive objects are detected from content and expanded transparently: each entry
 | Archive | Detection |
 |---|---|
 | tar | Content magic (`ustar`) |
+| zip | Content magic (`PK`) |
 
 Because compression is detected and stripped before archive detection runs, compressed tarballs work with no extra configuration: a `.tar.gz`, `.tar.zst`, `.tar.xz`, or `.tar.bz2` object is decompressed, re-detected as a tar, and expanded. This is content-driven and does not depend on the object's name.
+
+tar is read as a stream and never fully buffered. zip requires random access, so a zip object is materialized to a temporary file (in the OS temp directory) that is removed once the archive is fully read or if any error occurs.
 
 Archive handling notes:
 

--- a/receiver/gcspubsubeventreceiver/internal/worker/archive.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/archive.go
@@ -96,6 +96,8 @@ func archiveBackendFor(detected *mimetype.MIME, reader io.Reader) (func() (archi
 	switch {
 	case detected.Is("application/x-tar"):
 		return func() (archiveBackend, error) { return newTarBackend(reader), nil }, true
+	case detected.Is("application/zip"):
+		return func() (archiveBackend, error) { return newZipBackend(reader) }, true
 	default:
 		return nil, false
 	}
@@ -275,6 +277,12 @@ func (a *archiveProducer) consumeEntry(ctx context.Context, entry archiveEntry, 
 	if err != nil {
 		a.skipEntry(ctx, entry.Name(), fmt.Errorf("open entry: %w", err))
 		return false
+	}
+	// Random-access backends (zip/7z/rar) return a per-entry io.ReadCloser that
+	// must be closed once the entry is consumed. Streaming backends (tar) return
+	// the shared stream reader, which is not an io.Closer and is left untouched.
+	if c, ok := er.(io.Closer); ok {
+		defer func() { _ = c.Close() }()
 	}
 
 	capped := &cappingReader{

--- a/receiver/gcspubsubeventreceiver/internal/worker/archive_zip.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/archive_zip.go
@@ -1,0 +1,110 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"archive/zip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// archiveTempDir is the directory used to materialize random-access archives
+// (zip, and later 7z/rar). An empty value uses the OS default temp directory.
+// It is a package variable so tests can point it at a scratch directory and
+// assert nothing is left behind.
+var archiveTempDir = ""
+
+// zipBackend is a random-access archiveBackend over stdlib archive/zip. zip
+// needs an io.ReaderAt and a total size, which a streaming GCS body does not
+// provide, so the body is materialized to a temp file first. The temp file is
+// removed by Close on every path.
+type zipBackend struct {
+	zr   *zip.Reader
+	f    *os.File
+	next int
+}
+
+var _ archiveBackend = (*zipBackend)(nil)
+
+// newZipBackend materializes reader to a temp file and opens a zip reader over
+// it. On any failure it cleans up the temp file before returning, so a failed
+// open never leaks.
+func newZipBackend(reader io.Reader) (archiveBackend, error) {
+	f, err := os.CreateTemp(archiveTempDir, "gcspubsub-zip-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+
+	// Guard so a failure anywhere below removes the temp file.
+	ok := false
+	defer func() {
+		if !ok {
+			_ = f.Close()
+			_ = os.Remove(f.Name())
+		}
+	}()
+
+	size, err := io.Copy(f, reader)
+	if err != nil {
+		return nil, fmt.Errorf("materialize archive: %w", err)
+	}
+
+	zr, err := zip.NewReader(f, size)
+	if err != nil {
+		// The bytes materialized fine but are not a valid zip: corrupt content,
+		// not a transient IO error. Classify it as a DLQ condition.
+		return nil, ErrCorruptArchive{Type: "zip", Err: err}
+	}
+
+	ok = true
+	return &zipBackend{zr: zr, f: f}, nil
+}
+
+// Next advances to the next zip entry, or returns io.EOF when exhausted.
+func (b *zipBackend) Next() (archiveEntry, error) {
+	if b.next >= len(b.zr.File) {
+		return nil, io.EOF
+	}
+	f := b.zr.File[b.next]
+	b.next++
+	return &zipEntry{f: f}, nil
+}
+
+// Close closes and removes the materialized temp file.
+func (b *zipBackend) Close() error {
+	name := b.f.Name()
+	cerr := b.f.Close()
+	rerr := os.Remove(name)
+	return errors.Join(cerr, rerr)
+}
+
+// zipEntry is a single zip member. Open returns a fresh io.ReadCloser that the
+// producer closes once the entry is consumed.
+type zipEntry struct {
+	f *zip.File
+}
+
+var _ archiveEntry = (*zipEntry)(nil)
+
+func (e *zipEntry) Name() string { return e.f.Name }
+
+func (e *zipEntry) IsDir() bool {
+	return e.f.FileInfo().IsDir() || strings.HasSuffix(e.f.Name, "/")
+}
+
+func (e *zipEntry) Open() (io.Reader, error) { return e.f.Open() }

--- a/receiver/gcspubsubeventreceiver/internal/worker/archive_zip_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/archive_zip_test.go
@@ -1,0 +1,186 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// zipBytes builds a zip archive in memory from the given entries.
+func zipBytes(t *testing.T, files []tarFile) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, f := range files {
+		if f.dir {
+			_, err := zw.Create(f.name + "/")
+			require.NoError(t, err)
+			continue
+		}
+		w, err := zw.Create(f.name)
+		require.NoError(t, err)
+		_, err = w.Write(f.body)
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+// errReader always fails, to exercise materialization-failure cleanup.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("injected read error") }
+
+// withArchiveTempDir points archiveTempDir at a scratch dir for the duration of a
+// test and returns the dir so the test can assert it is left empty.
+func withArchiveTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	prev := archiveTempDir
+	archiveTempDir = dir
+	t.Cleanup(func() { archiveTempDir = prev })
+	return dir
+}
+
+func requireDirEmpty(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, entries, "temp dir should have no leftover files")
+}
+
+// TestArchiveZip_HeterogeneousEntries verifies a zip with text, JSON and Avro
+// entries is detected and each entry is parsed on its own terms.
+func TestArchiveZip_HeterogeneousEntries(t *testing.T) {
+	dir := withArchiveTempDir(t)
+
+	body := zipBytes(t, []tarFile{
+		{name: "a.log", body: []byte("line1\nline2\n")},
+		{name: "b.json", body: []byte(`[{"msg":"j1"},{"msg":"j2"}]`)},
+		{name: "c.avro", body: avroOcfBytes(t, []string{"av1", "av2"})},
+	})
+
+	bodies, _, err := driveArchive(t, body, Offset{})
+	require.NoError(t, err)
+	require.Len(t, bodies, 6)
+	all := joined(bodies)
+	for _, want := range []string{"line1", "line2", "j1", "j2", "av1", "av2"} {
+		require.Contains(t, all, want)
+	}
+	requireDirEmpty(t, dir)
+}
+
+// TestArchiveZip_DirectoryEntrySkipped verifies directory entries are skipped.
+func TestArchiveZip_DirectoryEntrySkipped(t *testing.T) {
+	dir := withArchiveTempDir(t)
+
+	body := zipBytes(t, []tarFile{
+		{name: "d", dir: true},
+		{name: "d/a.log", body: []byte("hello\nworld\n")},
+	})
+	bodies, _, err := driveArchive(t, body, Offset{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"hello", "world"}, bodies)
+	requireDirEmpty(t, dir)
+}
+
+// TestArchiveZip_EntryCountLimit verifies the shared bomb-limit machinery applies
+// to the zip backend and routes to the DLQ.
+func TestArchiveZip_EntryCountLimit(t *testing.T) {
+	dir := withArchiveTempDir(t)
+
+	raw := zipBytes(t, []tarFile{
+		{name: "a.log", body: []byte("x\n")},
+		{name: "b.log", body: []byte("x\n")},
+		{name: "c.log", body: []byte("x\n")},
+	})
+	ap := &archiveProducer{
+		stream: LogStream{Name: "o", MaxLogSize: testMaxLogSize, Logger: zap.NewNop(), TryDecoding: true},
+		open:   func() (archiveBackend, error) { return newZipBackend(bytes.NewReader(raw)) },
+		limits: archiveLimits{maxEntries: 2, maxEntryBytes: 1 << 30, maxTotalBytes: 1 << 30},
+	}
+	seq, err := ap.records(context.Background(), Offset{})
+	require.NoError(t, err)
+
+	var fatal error
+	for _, rerr := range seq {
+		if rerr != nil {
+			fatal = rerr
+			break
+		}
+	}
+	require.Error(t, fatal)
+	var limitErr ErrArchiveLimitExceeded
+	require.ErrorAs(t, fatal, &limitErr)
+	require.Equal(t, dlqErrorKindUnsupportedFile, dlqConditionKind(fatal))
+	requireDirEmpty(t, dir)
+}
+
+// TestArchiveZip_Resume verifies the (entryIndex, offset) resume model works for
+// the zip backend: resuming at entry 1 skips entry 0 entirely.
+func TestArchiveZip_Resume(t *testing.T) {
+	dir := withArchiveTempDir(t)
+
+	body := zipBytes(t, []tarFile{
+		{name: "0.log", body: []byte("a1\na2\n")},
+		{name: "1.json", body: []byte(`[{"msg":"j1"},{"msg":"j2"}]`)},
+		{name: "2.log", body: []byte("c1\n")},
+	})
+
+	all, _, err := driveArchive(t, body, Offset{})
+	require.NoError(t, err)
+	require.Len(t, all, 5)
+
+	fromEntry1, _, err := driveArchive(t, body, Offset{EntryIndex: 1, Offset: 0})
+	require.NoError(t, err)
+	require.Len(t, fromEntry1, 3) // j1,j2 + c1
+	require.NotContains(t, joined(fromEntry1), "a1")
+	require.Contains(t, joined(fromEntry1), "j1")
+	require.Contains(t, joined(fromEntry1), "c1")
+	requireDirEmpty(t, dir)
+}
+
+// TestArchiveZip_TempCleanupOnMaterializeError verifies a failed materialization
+// removes the temp file so nothing leaks.
+func TestArchiveZip_TempCleanupOnMaterializeError(t *testing.T) {
+	dir := withArchiveTempDir(t)
+
+	_, err := newZipBackend(errReader{})
+	require.Error(t, err)
+	requireDirEmpty(t, dir)
+}
+
+// TestArchiveZip_TempCleanupOnBadZip verifies a materialized but invalid zip
+// (bytes that are not a real zip) is cleaned up and classified as a corrupt
+// archive (a DLQ condition), not a generic transient failure.
+func TestArchiveZip_TempCleanupOnBadZip(t *testing.T) {
+	dir := withArchiveTempDir(t)
+
+	// "PK\x03\x04" prefix looks zip-ish but the rest is not a valid archive.
+	_, err := newZipBackend(bytes.NewReader([]byte("PK\x03\x04 not a real zip")))
+	require.Error(t, err)
+	var corrupt ErrCorruptArchive
+	require.ErrorAs(t, err, &corrupt)
+	require.Equal(t, dlqErrorKindUnsupportedFile, dlqConditionKind(err))
+	requireDirEmpty(t, dir)
+}


### PR DESCRIPTION
### Proposed Change

This adds a zip backend. Unlike tar, `archive/zip` needs random access, so the object is written to a temp file first, then read with `zip.NewReader`. The temp file is removed on every exit path, including errors and panics. GCS objects can be large, so this trades disk for being able to read zip at all.

Iteration, the bomb limits, and per-member resume come from the previous change; only the zip backend is new.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
