### PR TITLE
chore(chronicleexporter): add `v1` api version option

### DIFF
--- a/exporter/chronicleexporter/README.md
+++ b/exporter/chronicleexporter/README.md
@@ -25,7 +25,7 @@ The exporter supports two protocols, each of which targets a different Chronicle
 | `https`    | [Chronicle API](https://docs.cloud.google.com/chronicle/docs/reference/ingestion-methods)                             | Yes         |
 | `gRPC`     | [Backstory (Malachite) Ingestion API](https://docs.cloud.google.com/chronicle/docs/reference/ingestion-api)           |             |
 
-**`https` is the recommended protocol.** It targets the newer Chronicle API, supports the `v1alpha` and `v1beta` API versions, and uses improved security practices. The `gRPC` protocol targets the legacy Backstory Ingestion API and is retained for backwards compatibility with existing deployments.
+**`https` is the recommended protocol.** It targets the newer Chronicle API, supports the `v1alpha`, `v1beta`, and `v1` API versions, and uses improved security practices. The `gRPC` protocol targets the legacy Backstory Ingestion API and is retained for backwards compatibility with existing deployments.
 
 ## Configuration
 
@@ -38,7 +38,7 @@ The exporter can be configured using the following fields:
 | `location`                      | string            |                                        | `false`  | The Chronicle region (e.g. `us`, `europe`). Required when `protocol` is `https`.                                                                                                         |
 | `project`                       | string            |                                        | `false`  | The Google Cloud project ID. Required when `protocol` is `https`.                                                                                                                        |
 | `customer_id`                   | string            |                                        | `false`  | The Chronicle customer (instance) ID used for sending logs. Required when `protocol` is `https`.                                                                                         |
-| `api_version`                   | string            | `v1alpha`                              | `false`  | The Chronicle API version to use. Valid values are `v1alpha` and `v1beta`. Only applies to `https` protocol.                                                                             |
+| `api_version`                   | string            | `v1alpha`                              | `false`  | The Chronicle API version to use. Valid values are `v1alpha`, `v1beta`, and `v1`. Only applies to `https` protocol.                                                                             |
 | `override_endpoint`             | bool              | `false`                                | `false`  | Whether to ignore the `location` field when constructing the endpoint. Only applies to `https` protocol.                                                                                 |
 | `creds_file_path`               | string            |                                        | `false`  | The file path to the Google credentials JSON file. Mutually exclusive with `creds`. If neither is set, the exporter falls back to Google Application Default Credentials.                |
 | `creds`                         | string            |                                        | `false`  | The Google credentials JSON. Mutually exclusive with `creds_file_path`. If neither is set, the exporter falls back to Google Application Default Credentials.                            |

--- a/exporter/chronicleexporter/config.go
+++ b/exporter/chronicleexporter/config.go
@@ -36,6 +36,7 @@ const (
 	protocolGRPC      = "gRPC"
 	apiVersionV1Alpha = "v1alpha"
 	apiVersionV1Beta  = "v1beta"
+	apiVersionV1      = "v1"
 )
 
 // Config defines configuration for the Chronicle exporter.
@@ -168,7 +169,7 @@ func (cfg *Config) Validate() error {
 			return errors.New("positive batch request size limit is required when protocol is https")
 		}
 		if cfg.APIVersion != "" {
-			if cfg.APIVersion != apiVersionV1Alpha && cfg.APIVersion != apiVersionV1Beta {
+			if cfg.APIVersion != apiVersionV1Alpha && cfg.APIVersion != apiVersionV1Beta && cfg.APIVersion != apiVersionV1 {
 				return fmt.Errorf("invalid API version: %s", cfg.APIVersion)
 			}
 		}

--- a/exporter/chronicleexporter/config_test.go
+++ b/exporter/chronicleexporter/config_test.go
@@ -184,6 +184,22 @@ func TestConfigValidate(t *testing.T) {
 			},
 		},
 		{
+			desc: "Valid https config with v1 API version",
+			config: &Config{
+				Endpoint:                  "myendpoint.com",
+				CredsFilePath:             "/path/to/creds_file",
+				LogType:                   "log_type_example",
+				Protocol:                  protocolHTTPS,
+				Compression:               noCompression,
+				Project:                   "project_example",
+				Location:                  "location_example",
+				Forwarder:                 "forwarder_example",
+				BatchRequestSizeLimitHTTP: defaultBatchRequestSizeLimitHTTP,
+				HTTPResponseHeaderTimeout: 10 * time.Second,
+				APIVersion:                "v1",
+			},
+		},
+		{
 			desc: "Invalid API version",
 			config: &Config{
 				Endpoint:                  "myendpoint.com",


### PR DESCRIPTION
### Proposed Change
The `v1` api version of the `logs.import` endpoint used by the HTTPS chronicle exporter was released recently: [link](https://docs.cloud.google.com/chronicle/docs/reference/rest/v1/projects.locations.instances.logTypes.logs/import)

This PR adds "v1" as a supported option for the `api_version` parameter of the chronicle exporter config.

I've done a quick smoke test to validate logs are properly ingested into Google SecOps with the new v1 api option:

<img width="903" height="274" alt="image" src="https://github.com/user-attachments/assets/22c1d863-5bd0-453f-a946-a333c1f33e6d" />


##### Checklist
- [x] Changes are tested
- [x] CI has passed