### PR TITLE
[‎extension/opampgateway]: fix: server.tls config used in upstream dialer

### DIFF
--- a/extension/opampgateway/factory.go
+++ b/extension/opampgateway/factory.go
@@ -44,7 +44,7 @@ func defaultConfig() component.Config {
 	}
 }
 
-func createOpAMPGateway(_ context.Context, cs extension.Settings, cfg component.Config) (extension.Extension, error) {
+func createOpAMPGateway(ctx context.Context, cs extension.Settings, cfg component.Config) (extension.Extension, error) {
 	t, err := metadata.NewTelemetryBuilder(cs.TelemetrySettings)
 	if err != nil {
 		return nil, fmt.Errorf("create telemetry builder: %w", err)
@@ -52,10 +52,15 @@ func createOpAMPGateway(_ context.Context, cs extension.Settings, cfg component.
 
 	oCfg := cfg.(*Config)
 
+	tlsConfig, err := oCfg.Server.TLS.LoadTLSConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load upstream TLS config: %w", err)
+	}
+
 	settings := gateway.Settings{
 		UpstreamOpAMPAddress: oCfg.Server.Endpoint,
 		Headers:              oCfg.Server.Headers,
-		TLS:                  oCfg.Server.TLS,
+		TLSConfig:            tlsConfig,
 		UpstreamConnections:  oCfg.Server.Connections,
 		OpAMPServer:          oCfg.Listener,
 	}

--- a/extension/opampgateway/factory_test.go
+++ b/extension/opampgateway/factory_test.go
@@ -1,0 +1,50 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opampgateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/extension/extensiontest"
+)
+
+// TestCreateOpAMPGatewayInvalidUpstreamTLSConfig verifies that an invalid
+// server.tls configuration (e.g. a ca_file that cannot be read) fails
+// extension creation instead of silently being ignored.
+func TestCreateOpAMPGatewayInvalidUpstreamTLSConfig(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{
+			Endpoint:    "wss://localhost:4320/v1/opamp",
+			Connections: 1,
+			TLS: configtls.ClientConfig{
+				Config: configtls.Config{
+					CAFile: "testdata/does-not-exist.pem",
+				},
+			},
+		},
+		Listener: confighttp.ServerConfig{
+			NetAddr: confignet.AddrConfig{Endpoint: "127.0.0.1:0"},
+		},
+	}
+
+	factory := NewFactory()
+	_, err := factory.Create(context.Background(), extensiontest.NewNopSettings(typ), cfg)
+	require.ErrorContains(t, err, "load upstream TLS config")
+}

--- a/extension/opampgateway/internal/gateway/client.go
+++ b/extension/opampgateway/internal/gateway/client.go
@@ -58,9 +58,11 @@ func newClient(settings Settings, telemetry *metadata.TelemetryBuilder, callback
 	pool := newConnectionPool(settings.UpstreamConnections, logger)
 	connections := newConnections[*upstreamConnection]()
 	connectionAssignments := newConnectionAssignments(connections, pool)
+	dialer := *websocket.DefaultDialer
+	dialer.TLSClientConfig = settings.TLSConfig
 	return &client{
 		logger:                logger,
-		dialer:                *websocket.DefaultDialer,
+		dialer:                dialer,
 		pool:                  pool,
 		upstreamConnections:   connections,
 		connectionAssignments: connectionAssignments,

--- a/extension/opampgateway/internal/gateway/gateway.go
+++ b/extension/opampgateway/internal/gateway/gateway.go
@@ -18,6 +18,7 @@ package gateway
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"time"
@@ -27,7 +28,6 @@ import (
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
-	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
@@ -45,7 +45,7 @@ var (
 type Settings struct {
 	UpstreamOpAMPAddress string
 	Headers              http.Header
-	TLS                  configtls.ClientConfig
+	TLSConfig            *tls.Config
 	UpstreamConnections  int
 	OpAMPServer          confighttp.ServerConfig
 	AuthTimeout          time.Duration

--- a/extension/opampgateway/internal/gateway/gateway_test.go
+++ b/extension/opampgateway/internal/gateway/gateway_test.go
@@ -456,6 +456,36 @@ func (s *testOpAMPServer) URL() string {
 	return "ws" + s.server.URL[len("http"):]
 }
 
+// newTestOpAMPServerTLS creates a test OpAMP server that serves over TLS using
+// the given PEM-encoded certificate and key.
+func newTestOpAMPServerTLS(t *testing.T, certPEM, keyPEM string) *testOpAMPServer {
+	t.Helper()
+
+	s := &testOpAMPServer{
+		t:      t,
+		recvCh: make(chan upstreamMessage, 128),
+		connCh: make(chan *websocket.Conn, 32),
+		errCh:  make(chan error, 32),
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(*http.Request) bool { return true },
+		},
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	cert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+	require.NoError(t, err)
+
+	s.server = httptest.NewUnstartedServer(http.HandlerFunc(s.handle))
+	s.server.Listener = listener
+	s.server.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+	s.server.StartTLS()
+	t.Cleanup(s.Close)
+
+	return s
+}
+
 func (s *testOpAMPServer) handle(w http.ResponseWriter, r *http.Request) {
 	// extract the connection id from the request
 	id := r.Header.Get("X-Opamp-Gateway-Connection-Id")
@@ -1157,6 +1187,54 @@ func TestGatewayTLSConnection(t *testing.T) {
 	plainURL := fmt.Sprintf("ws://%s%s", gw.server.addr.String(), handlePath)
 	_, _, err = websocket.DefaultDialer.Dial(plainURL, nil)
 	require.Error(t, err, "plain ws:// connection should fail against TLS server")
+}
+
+// TestGatewayUpstreamTLSConnection verifies that the gateway applies
+// settings.TLSConfig to the upstream dialer. Without it, a wss:// upstream
+// signed by a private CA fails the handshake with "certificate signed by
+// unknown authority" even though the CA is configured.
+func TestGatewayUpstreamTLSConnection(t *testing.T) {
+	t.Parallel()
+
+	certPEM, keyPEM, _ := generateTestTLSPEM(t)
+
+	upstream := newTestOpAMPServerTLS(t, certPEM, keyPEM)
+
+	testTel := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, testTel.Shutdown(context.Background()))
+	})
+	telemetry, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
+	require.NoError(t, err)
+
+	clientTLS := configtls.ClientConfig{
+		Config: configtls.Config{
+			CAPem: configopaque.String(certPEM),
+		},
+	}
+	tlsConfig, err := clientTLS.LoadTLSConfig(context.Background())
+	require.NoError(t, err)
+
+	settings := Settings{
+		UpstreamOpAMPAddress: upstream.URL(),
+		Headers: http.Header{
+			"Authorization": []string{"Secret-Key test-secret"},
+		},
+		TLSConfig:           tlsConfig,
+		UpstreamConnections: 1,
+		OpAMPServer:         confighttp.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: "127.0.0.1:0", Transport: confignet.TransportTypeTCP}},
+	}
+
+	logger := zaptest.NewLogger(t)
+	gw := New(logger, settings, telemetry)
+	require.NoError(t, gw.Start(context.Background(), componenttest.NewNopHost(), testTel.NewTelemetrySettings()))
+	t.Cleanup(func() { _ = gw.Shutdown(context.Background()) })
+
+	upstream.WaitForConnection(t, 5*time.Second)
+	require.Eventually(t, func() bool {
+		conn, ok := gw.client.upstreamConnections.get("upstream-0")
+		return ok && conn.isConnected()
+	}, 5*time.Second, 10*time.Millisecond, "gateway did not establish TLS connection to upstream")
 }
 
 func TestGatewayGracefulShutdownWithActiveConnections(t *testing.T) {


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
I was using this with mtls end to end for an application to help learn opamp and noticed the `server.tls` block (`configtls.ClientConfig`) is parsed, validated, and carried all the way to the gateway internals, but is never applied to the upstream dialer. Every wss:// upstream connection uses bare system trust store, breaking private-CA and mTLS setups.

Fix:
- gateway.Settings.TLS (unused configtls.ClientConfig) → Settings.TLSConfig *tls.Config
- client.go: newClient set dialer.TLSClientConfig = settings.TLSConfig
- factory.go: load TLS config via LoadTLSConfig(ctx), return error on failure, pass into Settings.TLSConfig
- Added tests: TLS dial success against private-CA upstream, and error propagation for bad ca_file

##### Checklist
- [x] Changes are tested
- [x] CI has passed