### PR TITLE
chore(tests): replace pcapreceiver sleeps with require.Never and bounded waits (PIPE-986)

### DIFF
--- a/receiver/pcapreceiver/receiver_test.go
+++ b/receiver/pcapreceiver/receiver_test.go
@@ -211,9 +211,10 @@ func TestProcessPacket_InvalidPacket(t *testing.T) {
 	ctx := context.Background()
 	receiver.processPacket(ctx, lines)
 
-	// Consumer should not have received any logs
-	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, 0, sink.LogRecordCount())
+	// Consumer should not have received any logs; confirm the count stays zero.
+	require.Never(t, func() bool {
+		return sink.LogRecordCount() != 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestProcessPacket_ICMPNoPort(t *testing.T) {

--- a/receiver/pcapreceiver/receiver_unix_test.go
+++ b/receiver/pcapreceiver/receiver_unix_test.go
@@ -213,9 +213,10 @@ func TestReadPackets_Unix_EmptyInput(t *testing.T) {
 
 	go receiver.readPackets(ctx, stdout)
 
-	// Wait a bit to ensure no packets are processed
-	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, 0, sink.LogRecordCount())
+	// No packets should be processed; confirm the count stays zero.
+	require.Never(t, func() bool {
+		return sink.LogRecordCount() != 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestReadPackets_Unix_MalformedPacket(t *testing.T) {
@@ -235,9 +236,10 @@ func TestReadPackets_Unix_MalformedPacket(t *testing.T) {
 
 	go receiver.readPackets(ctx, stdout)
 
-	// Wait a bit - malformed packets should not be processed
-	time.Sleep(200 * time.Millisecond)
-	require.Equal(t, 0, sink.LogRecordCount())
+	// Malformed packets should not be processed; confirm the count stays zero.
+	require.Never(t, func() bool {
+		return sink.LogRecordCount() != 0
+	}, 200*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestReadPackets_Unix_LargePacket(t *testing.T) {
@@ -291,10 +293,11 @@ func TestReadPackets_Unix_PacketWithOnlyTimestamp(t *testing.T) {
 
 	go receiver.readPackets(ctx, stdout)
 
-	// Wait a bit - packets without hex data should fail parsing
-	time.Sleep(200 * time.Millisecond)
-	// Should have attempted to process but failed due to missing hex data
-	require.Equal(t, 0, sink.LogRecordCount())
+	// Packets without hex data should fail parsing and never be processed; confirm
+	// the count stays zero.
+	require.Never(t, func() bool {
+		return sink.LogRecordCount() != 0
+	}, 200*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestReadPackets_Unix_IPv6Packet(t *testing.T) {
@@ -389,12 +392,19 @@ func TestReadPackets_Unix_ScannerError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go receiver.readPackets(ctx, stdout)
+	done := make(chan struct{})
+	go func() {
+		receiver.readPackets(ctx, stdout)
+		close(done)
+	}()
 
-	// Wait for error to be handled
-	time.Sleep(200 * time.Millisecond)
-	// Should handle error gracefully without panicking
-	_ = sink.LogRecordCount()
+	// readPackets should return once the scanner hits the injected error, handling it
+	// gracefully without panicking. Wait for it to exit rather than sleeping.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readPackets did not return after scanner error")
+	}
 }
 
 // errorReader is a test utility that returns an error after reading some data

--- a/receiver/pcapreceiver/receiver_windows_test.go
+++ b/receiver/pcapreceiver/receiver_windows_test.go
@@ -304,10 +304,8 @@ func TestShutdown_Windows(t *testing.T) {
 	err := receiver.Start(ctx, componenttest.NewNopHost())
 	require.NoError(t, err)
 
-	// Wait a short time for goroutines to start
-	time.Sleep(10 * time.Millisecond)
-
-	// Shutdown
+	// Shutdown. The handle is stored synchronously in Start, so it is closed on
+	// Shutdown regardless of whether the read goroutine has started.
 	err = receiver.Shutdown(ctx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
### Proposed Change
Replaces the negative-assertion sleeps with `require.Never`, which polls the condition across the window instead of checking once after a fixed wait. The scanner-error test waits for `readPackets` to return; the Windows lifecycle test drops a sleep the synchronous handle setup in `Start` made unnecessary.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
