### PR TITLE
chore(tests): drive gcspubsubeventreceiver tracker TTL tests with an injected clock (PIPE-986)

### DIFF
--- a/receiver/gcspubsubeventreceiver/go.mod
+++ b/receiver/gcspubsubeventreceiver/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bodgit/sevenzip v1.6.5
 	github.com/gabriel-vasile/mimetype v1.4.15
 	github.com/google/go-cmp v0.7.0
+	github.com/jonboulle/clockwork v0.5.0
 	github.com/klauspost/compress v1.19.1
 	github.com/linkedin/goavro/v2 v2.15.0
 	github.com/nwaples/rardecode/v2 v2.2.5

--- a/receiver/gcspubsubeventreceiver/go.sum
+++ b/receiver/gcspubsubeventreceiver/go.sum
@@ -93,6 +93,8 @@ github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaX
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=

--- a/receiver/gcspubsubeventreceiver/receiver.go
+++ b/receiver/gcspubsubeventreceiver/receiver.go
@@ -26,6 +26,7 @@ import (
 	subscriber "cloud.google.com/go/pubsub/apiv1"
 	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
 	"cloud.google.com/go/storage"
+	"github.com/jonboulle/clockwork"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pipeline"
@@ -418,12 +419,16 @@ type recentTracker struct {
 	mu   sync.Mutex
 	seen map[objectKey]time.Time
 	ttl  time.Duration
+	// clock backs the TTL window; real in production, a fake clock in tests so
+	// expiry can be exercised without sleeping.
+	clock clockwork.Clock
 }
 
 func newRecentTracker(ttl time.Duration) *recentTracker {
 	return &recentTracker{
-		seen: make(map[objectKey]time.Time),
-		ttl:  ttl,
+		seen:  make(map[objectKey]time.Time),
+		ttl:   ttl,
+		clock: clockwork.NewRealClock(),
 	}
 }
 
@@ -431,7 +436,7 @@ func newRecentTracker(ttl time.Duration) *recentTracker {
 func (rt *recentTracker) Mark(key objectKey) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
-	rt.seen[key] = time.Now()
+	rt.seen[key] = rt.clock.Now()
 }
 
 // IsDuplicate returns true if the key was processed within the TTL window.
@@ -439,7 +444,7 @@ func (rt *recentTracker) IsDuplicate(key objectKey) bool {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	if t, ok := rt.seen[key]; ok {
-		if time.Since(t) < rt.ttl {
+		if rt.clock.Now().Sub(t) < rt.ttl {
 			return true
 		}
 		delete(rt.seen, key) // expired
@@ -451,7 +456,7 @@ func (rt *recentTracker) IsDuplicate(key objectKey) bool {
 func (rt *recentTracker) Evict() {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
-	now := time.Now()
+	now := rt.clock.Now()
 	for k, t := range rt.seen {
 		if now.Sub(t) >= rt.ttl {
 			delete(rt.seen, k)

--- a/receiver/gcspubsubeventreceiver/receiver_test.go
+++ b/receiver/gcspubsubeventreceiver/receiver_test.go
@@ -22,6 +22,7 @@ import (
 	subscriber "cloud.google.com/go/pubsub/apiv1"
 	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
 	"cloud.google.com/go/pubsub/pstest"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -216,10 +217,12 @@ func TestRecentTracker_Expiry(t *testing.T) {
 	t.Parallel()
 
 	key := objectKey{Bucket: "b", Object: "o", Generation: "1"}
+	fclock := clockwork.NewFakeClock()
 	rt := newRecentTracker(1 * time.Millisecond) // tiny TTL for test
+	rt.clock = fclock
 
 	rt.Mark(key)
-	time.Sleep(5 * time.Millisecond) // wait for expiry
+	fclock.Advance(2 * time.Millisecond) // advance past the TTL
 
 	require.False(t, rt.IsDuplicate(key), "expired key must not be duplicate")
 }
@@ -228,10 +231,12 @@ func TestRecentTracker_Expiry(t *testing.T) {
 func TestRecentTracker_Evict(t *testing.T) {
 	t.Parallel()
 
+	fclock := clockwork.NewFakeClock()
 	rt := newRecentTracker(1 * time.Millisecond)
+	rt.clock = fclock
 	rt.Mark(objectKey{Bucket: "b", Object: "o", Generation: "1"})
 
-	time.Sleep(5 * time.Millisecond)
+	fclock.Advance(2 * time.Millisecond)
 	rt.Evict()
 
 	rt.mu.Lock()


### PR DESCRIPTION
### Proposed Change
Injects a `clockwork` clock into the recent-duplicate tracker so the TTL-expiry tests advance a fake clock instead of sleeping past the window. Production keeps the real clock.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
