### PR TITLE
chore: `bindplaneextension` Deprecate the bindplane extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ pkg/                Public utility packages
 |---|---|
 | [awss3eventextension](extension/awss3eventextension) | Downloads newly created S3 objects to a specified directory by reading from an SQS queue |
 | [badgerextension](extension/badgerextension) | Provides persistent storage using BadgerDB |
-| [bindplaneextension](extension/bindplaneextension) | Stores Bindplane-specific information for custom collector distributions |
+| [bindplaneextension](extension/bindplaneextension) | Deprecated. Stores Bindplane-specific information for custom collector distributions |
 | [opampgateway](extension/opampgateway) | Relays OpAMP messages between downstream agents and an upstream OpAMP server *(alpha)* |
 | [pebbleextension](extension/pebbleextension) | Provides persistent storage using Pebble |
 

--- a/extension/bindplaneextension/README.md
+++ b/extension/bindplaneextension/README.md
@@ -1,4 +1,8 @@
-# Bindplane Extension
+# Bindplane Extension (Deprecated)
+
+> **Deprecated.** The `throughputmeasurement` and `topology` processors now report their own state directly over an opamp extension: each processor takes an `opamp` component ID, all instances of a processor type share a single reporter (its `interval` — and, for throughput, `extra_labels` — comes from a `global` block carried by one processor), and it sends the same wire format this extension sends (snappy-encoded OTLP protobuf on `com.bindplane.measurements.v1`, snappy-encoded JSON on `com.bindplane.topology`). See the [throughputmeasurement](../../processor/throughputmeasurementprocessor/README.md) and [topology](../../processor/topologyprocessor/README.md) processor READMEs.
+>
+> This extension is kept for backwards compatibility with Bindplane servers that render it (via the processors' deprecated `bindplane_extension` field) and will be removed in a future release. Newer Bindplane servers configure the processors' `opamp` parameter and do not instantiate this extension.
 
 This extension is used by Bindplane in custom distributions to store Bindplane specific information.
 

--- a/extension/bindplaneextension/extension.go
+++ b/extension/bindplaneextension/extension.go
@@ -60,6 +60,9 @@ func newBindplaneExtension(logger *zap.Logger, cfg *Config) *bindplaneExtension 
 }
 
 func (b *bindplaneExtension) Start(_ context.Context, host component.Host) error {
+	b.logger.Warn("The bindplane extension is deprecated and will be removed in a future release. " +
+		"Configure the throughputmeasurement and topology processors with the `opamp` parameter instead.")
+
 	var emptyComponentID component.ID
 
 	// Set up custom capabilities if enabled

--- a/extension/bindplaneextension/internal/metadata/generated_status.go
+++ b/extension/bindplaneextension/internal/metadata/generated_status.go
@@ -14,5 +14,5 @@ var (
 )
 
 const (
-	ExtensionStability = component.StabilityLevelBeta
+	ExtensionStability = component.StabilityLevelDeprecated
 )

--- a/extension/bindplaneextension/metadata.yaml
+++ b/extension/bindplaneextension/metadata.yaml
@@ -6,7 +6,11 @@ status:
     active: [observIQ/fleet, observIQ/pipeline, observIQ/platformteam, observIQ/ai]
   class: extension
   stability:
-    beta: [extension]
+    deprecated: [extension]
+  deprecation:
+    extension:
+      date: "2026-08-10"
+      migration: "Configure the throughputmeasurement and topology processors with the `opamp` parameter and `global` block instead; see those processors' READMEs."
 
 tests:
   config:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Deprecates the Bindplane extension. Updated throughput measurement and topology processors should be configured to register with the opamp extension. Logs a warning if used. Preserved for backwards compatibility.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed