### PR TITLE
fix(extension/opampgateway): create downstream connection cancel at construction to fix data race (PIPE-1237)

### DIFF
--- a/extension/opampgateway/internal/gateway/downstream_connection.go
+++ b/extension/opampgateway/internal/gateway/downstream_connection.go
@@ -41,6 +41,9 @@ type downstreamConnection struct {
 	telemetry *metadata.TelemetryBuilder
 	logger    *zap.Logger
 
+	// ctx and cancel are created at construction so cancel is never nil, even when close()
+	// races the start goroutine (PIPE-1237). ctx governs the reader and writer.
+	ctx    context.Context
 	cancel context.CancelFunc
 
 	// sentCustomCapabilities tracks whether the cached CustomCapabilities have been
@@ -50,7 +53,8 @@ type downstreamConnection struct {
 	sentCustomCapabilities atomic.Bool
 }
 
-func newDownstreamConnection(conn *websocket.Conn, telemetry *metadata.TelemetryBuilder, upstreamConnection *upstreamConnection, id string, logger *zap.Logger) *downstreamConnection {
+func newDownstreamConnection(ctx context.Context, conn *websocket.Conn, telemetry *metadata.TelemetryBuilder, upstreamConnection *upstreamConnection, id string, logger *zap.Logger) *downstreamConnection {
+	connCtx, cancel := context.WithCancel(ctx)
 	return &downstreamConnection{
 		conn:               conn,
 		upstreamConnection: upstreamConnection,
@@ -58,6 +62,8 @@ func newDownstreamConnection(conn *websocket.Conn, telemetry *metadata.Telemetry
 		telemetry:          telemetry,
 		logger:             logger.Named("downstream-connection").With(zap.String("id", id)),
 		writeChan:          make(chan *message),
+		ctx:                connCtx,
+		cancel:             cancel,
 
 		// the error channel is buffered to prevent blocking the reader goroutine if it
 		// encounters an error. it will return immediately after reporting the error and the
@@ -71,8 +77,10 @@ func newDownstreamConnection(conn *websocket.Conn, telemetry *metadata.Telemetry
 // start will start the reader and writer goroutines and wait for the context to be done
 // or an error to be sent on the error channel. if an error is sent on the error channel,
 // the connection will be stopped and the context will be cancelled.
-func (c *downstreamConnection) start(ctx context.Context, callbacks ConnectionCallbacks[*downstreamConnection]) {
-	ctx, c.cancel = context.WithCancel(ctx)
+func (c *downstreamConnection) start(callbacks ConnectionCallbacks[*downstreamConnection]) {
+	// ctx and cancel are initialized in newDownstreamConnection, so a concurrent close()
+	// never observes a nil cancel (PIPE-1237).
+	ctx := c.ctx
 	defer c.cancel()
 
 	// start the reader in a separate goroutine and cancel the context if it returns, likely

--- a/extension/opampgateway/internal/gateway/downstream_connection.go
+++ b/extension/opampgateway/internal/gateway/downstream_connection.go
@@ -42,7 +42,7 @@ type downstreamConnection struct {
 	logger    *zap.Logger
 
 	// ctx and cancel are created at construction so cancel is never nil, even when close()
-	// races the start goroutine (PIPE-1237). ctx governs the reader and writer.
+	// races the start goroutine. ctx governs the reader and writer.
 	ctx    context.Context
 	cancel context.CancelFunc
 
@@ -79,7 +79,7 @@ func newDownstreamConnection(ctx context.Context, conn *websocket.Conn, telemetr
 // the connection will be stopped and the context will be cancelled.
 func (c *downstreamConnection) start(callbacks ConnectionCallbacks[*downstreamConnection]) {
 	// ctx and cancel are initialized in newDownstreamConnection, so a concurrent close()
-	// never observes a nil cancel (PIPE-1237).
+	// never observes a nil cancel.
 	ctx := c.ctx
 	defer c.cancel()
 

--- a/extension/opampgateway/internal/gateway/downstream_connection_test.go
+++ b/extension/opampgateway/internal/gateway/downstream_connection_test.go
@@ -1,0 +1,39 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestDownstreamConnectionCloseBeforeStart is a regression test for PIPE-1237. A downstream
+// connection can be closed in the window between being registered and its start goroutine
+// running. Because ctx and cancel are created at construction, close() must be safe and must
+// cancel the connection context without depending on start() having run.
+func TestDownstreamConnectionCloseBeforeStart(t *testing.T) {
+	c := newDownstreamConnection(context.Background(), nil, nil, nil, "test", zap.NewNop())
+
+	require.NoError(t, c.close())
+
+	select {
+	case <-c.ctx.Done():
+	default:
+		t.Fatal("expected connection context to be cancelled after close before start")
+	}
+}

--- a/extension/opampgateway/internal/gateway/downstream_connection_test.go
+++ b/extension/opampgateway/internal/gateway/downstream_connection_test.go
@@ -22,7 +22,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// TestDownstreamConnectionCloseBeforeStart is a regression test for PIPE-1237. A downstream
+// TestDownstreamConnectionCloseBeforeStart is a regression test for the close-before-start race. A downstream
 // connection can be closed in the window between being registered and its start goroutine
 // running. Because ctx and cancel are created at construction, close() must be safe and must
 // cancel the connection context without depending on start() having run.

--- a/extension/opampgateway/internal/gateway/server.go
+++ b/extension/opampgateway/internal/gateway/server.go
@@ -274,7 +274,7 @@ func (s *server) handleRequest(w http.ResponseWriter, r *http.Request) {
 	s.telemetry.OpampgatewayConnections.Add(context.Background(), 1, directionDownstream)
 
 	// create the downstream connection
-	c := newDownstreamConnection(conn, s.telemetry, upstreamConnection, id, s.logger)
+	c := newDownstreamConnection(s.shutdownCtx, conn, s.telemetry, upstreamConnection, id, s.logger)
 	s.addDownstreamConnection(id, c)
 
 	// start the connection in a goroutine to prevent blocking the handler
@@ -288,7 +288,7 @@ func (s *server) handleRequest(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error("downstream connection removed before it could be started", zap.String("downstream_connection_id", id))
 			return
 		}
-		conn.start(s.shutdownCtx, s.callbacks)
+		conn.start(s.callbacks)
 	}()
 }
 


### PR DESCRIPTION
### Proposed Change

`downstreamConnection.cancel` was assigned in `start()` but read and invoked by
`close()`. A connection closed in the window before its start goroutine ran raced on
`cancel`, and could invoke a nil func. `-race` flagged it.

This creates the connection context and its cancel at construction instead.
`newDownstreamConnection` takes the parent context and derives the cancelable context
once, so `close()` cancels safely whether or not `start()` has run. `start()` no longer
creates the context.

Validate: the added `TestDownstreamConnectionCloseBeforeStart` builds a connection,
closes it without ever starting it, and asserts its context is cancelled. It fails
before the fix and passes after. The package is clean under `go test -race -count=20`.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
