### PR TITLE
fix(lookupprocessor): build the CSV index off-lock and publish via atomic pointer (PIPE-1179)

### DIFF
--- a/processor/lookupprocessor/csv.go
+++ b/processor/lookupprocessor/csv.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
+	"sync/atomic"
 )
 
 var (
@@ -34,19 +34,29 @@ var (
 	errLookupColumnNotFound = errors.New("lookup column not found")
 )
 
-// CSVFile is a file that contains csv data
+// index maps a lookup key to the remaining columns of its row.
+type index map[string]map[string]string
+
+// CSVFile is a file that contains csv data.
+//
+// The index is published through an atomic pointer rather than guarded by a
+// lock, so a reload never blocks concurrent lookups. Load builds the whole
+// index off to the side and swaps it in with a single Store, which leaves
+// readers observing either the complete previous index or the complete new
+// one, never a partial rebuild.
 type CSVFile struct {
 	filepath     string
 	lookupColumn string
-	data         map[string]map[string]string
-	mux          *sync.RWMutex
+	data         atomic.Pointer[index]
+
+	// readHook runs after a reload has built the new index but before it is
+	// published, so a test can hold a reload in flight and observe that lookups
+	// proceed against the still-published old index. It is nil in production.
+	readHook func()
 }
 
-// Load loads the csv into memory
+// Load reads the csv and publishes a freshly built index.
 func (c *CSVFile) Load() error {
-	c.mux.Lock()
-	defer c.mux.Unlock()
-
 	file, err := os.Open(c.filepath)
 	if err != nil {
 		return fmt.Errorf("open file: %w", err)
@@ -64,7 +74,11 @@ func (c *CSVFile) Load() error {
 		return fmt.Errorf("index records: %w", err)
 	}
 
-	c.data = data
+	if c.readHook != nil {
+		c.readHook()
+	}
+
+	c.data.Store(&data)
 	return nil
 }
 
@@ -72,14 +86,12 @@ func (c *CSVFile) Load() error {
 // The context is accepted to satisfy the LookupSource interface; CSV lookups
 // are in-memory and do not block on it.
 func (c *CSVFile) Lookup(_ context.Context, key string) (map[string]string, error) {
-	c.mux.RLock()
-	defer c.mux.RUnlock()
-
-	if c.data == nil {
+	data := c.data.Load()
+	if data == nil {
 		return nil, errCSVNotLoaded
 	}
 
-	results, ok := c.data[key]
+	results, ok := (*data)[key]
 	if !ok {
 		return nil, errKeyNotFound
 	}
@@ -88,7 +100,7 @@ func (c *CSVFile) Lookup(_ context.Context, key string) (map[string]string, erro
 }
 
 // indexRecords indexes the records by the lookup column
-func indexRecords(records [][]string, lookupColumn string) (map[string]map[string]string, error) {
+func indexRecords(records [][]string, lookupColumn string) (index, error) {
 	if len(records) == 0 {
 		return nil, errNoRecords
 	}
@@ -99,7 +111,7 @@ func indexRecords(records [][]string, lookupColumn string) (map[string]map[strin
 		return nil, fmt.Errorf("find lookup index: %w", err)
 	}
 
-	result := make(map[string]map[string]string)
+	result := make(index)
 	for _, record := range records[1:] {
 		lookupKey := record[lookupIndex]
 		result[lookupKey] = make(map[string]string)
@@ -137,7 +149,6 @@ func (c *CSVFile) Close() error {
 // NewCSVFile creates a new CSVFile
 func NewCSVFile(filepath string, lookupColumn string) *CSVFile {
 	return &CSVFile{
-		mux:          &sync.RWMutex{},
 		filepath:     filepath,
 		lookupColumn: lookupColumn,
 	}

--- a/processor/lookupprocessor/csv_reload_stall_test.go
+++ b/processor/lookupprocessor/csv_reload_stall_test.go
@@ -1,0 +1,108 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lookupprocessor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeStallCSV writes a small host-keyed CSV and returns its path.
+func writeStallCSV(t *testing.T, rows int) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "assets.csv")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+
+	_, err = fmt.Fprintln(f, "host,owner,env")
+	require.NoError(t, err)
+	for i := 0; i < rows; i++ {
+		_, err = fmt.Fprintf(f, "host-%04d,owner-%d,production\n", i, i)
+		require.NoError(t, err)
+	}
+	require.NoError(t, f.Sync())
+
+	return path
+}
+
+// TestReloadDoesNotBlockLookups holds a reload in flight and asserts that a
+// lookup completes against the still-published old index rather than waiting for
+// the reload to finish.
+//
+// The index is published through an atomic pointer, so a reload builds the new
+// map off to the side and swaps it in with one Store. readHook pauses the reload
+// after it has built the new index but before that Store, which is the exact
+// window a concurrent lookup would have blocked in under a lock held across the
+// whole reload. A lookup issued during that window must still return, since it
+// reads the old index and never takes the reload's path.
+func TestReloadDoesNotBlockLookups(t *testing.T) {
+	path := writeStallCSV(t, 100)
+	csvFile := NewCSVFile(path, "host")
+	require.NoError(t, csvFile.Load())
+
+	// Confirm the key resolves off the initial index before the reload starts.
+	got, err := csvFile.Lookup(context.Background(), "host-0000")
+	require.NoError(t, err)
+	require.Equal(t, "owner-0", got["owner"])
+
+	reloading := make(chan struct{}) // closed once the reload is paused mid-flight
+	release := make(chan struct{})   // closed to let the paused reload finish
+	var hooked bool
+	csvFile.readHook = func() {
+		if hooked {
+			return
+		}
+		hooked = true
+		close(reloading)
+		<-release
+	}
+
+	reloadDone := make(chan error, 1)
+	go func() { reloadDone <- csvFile.Load() }()
+
+	<-reloading // the reload has built the new index and is parked before publishing
+
+	// The reload is provably in flight. A lookup now must not wait on it. Hand the
+	// result back to this goroutine rather than asserting in the spawned one, since
+	// a testify require outside the test goroutine only stops its own goroutine.
+	type lookupResult struct {
+		row map[string]string
+		err error
+	}
+	lookupDone := make(chan lookupResult, 1)
+	go func() {
+		row, err := csvFile.Lookup(context.Background(), "host-0001")
+		lookupDone <- lookupResult{row: row, err: err}
+	}()
+
+	select {
+	case res := <-lookupDone:
+		require.NoError(t, res.err)
+		require.Equal(t, "owner-1", res.row["owner"], "the lookup must see the old index while the reload is parked")
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "a lookup blocked while a reload was in flight")
+	}
+
+	close(release)
+	require.NoError(t, <-reloadDone)
+}


### PR DESCRIPTION
### Proposed Change

Part of PIPE-1179.

`CSVFile.Load` held a write lock across `os.Open`, `csv.ReadAll`, and the reindex. `CSVFile.Lookup` took a read lock and runs per record on the receiver handler goroutine, so every reload blocked all in-flight lookups until it finished. The reload fires on a hard-coded 60s ticker whether or not the file changed.

The index is now built into a local map and published with a single `atomic.Pointer` store. Readers observe either the complete previous index or the complete new one, never a partial rebuild, and a reload no longer blocks a lookup.

Measured through a collector using the following Claude driven harness method: blitz over OTLP gRPC into `otlp -> lookup -> batch -> nop`, a 1M-row 70.5 MB CSV, ~19,000 records/sec, 10 minutes per run, 11 reloads each.

| Metric               | Before      | After      |
|----------------------|-------------|------------|
| gRPC calls           | 127,437     | 130,735    |
| Mean latency         | 4.85 ms     | 3.50 ms    |
| Calls over 100 ms    | 120         | 2          |
| Calls over 500 ms    | 120         | 0          |
| Calls over 1000 ms   | 120         | 0          |
| Worst latency bucket | <= 5000 ms  | <= 250 ms  |

All of the slow calls from prior to the change happened during a reload with 10 reloads and blitz's 12 output workers blocking on the write lock together each time. Throughput is only 2.6% higher, since a stall that takes about 2% of the clock time can't move it much. This fixes latency, not throughput.

`batch` sits after `lookup` so the receive path stays synchronous through it. Batch first would hide the stall from request latency.

The benchmark runs `cache_enabled: false`. With the cache on and few distinct keys, hits never reach `CSVFile.Lookup` and the stall is invisible. The reporting customer has roughly 1M distinct hosts and misses constantly.

### How the reviewer can validate

> **Note:** the manual validation procedure below is an AI-generated script. Review it before running.

Manual:

1. Check out this branch in a `bindplane-otel-contrib` clone: `gh pr checkout 702`
2. In `bindplane-otel-collector`, point the manifest at that checkout by adding one line under `replaces:` in `manifests/observIQ/manifest.yaml`:
   ```
   - github.com/observiq/bindplane-otel-contrib/processor/lookupprocessor => /path/to/bindplane-otel-contrib/processor/lookupprocessor
   ```
3. `make agent`
4. Build a CSV big enough that a reload takes about a second:
   ```
   { echo "host,owner,env"; for i in $(seq 1 1000000); do echo "host-$i,owner-$((i%997)),production"; done; } > /tmp/assets.csv
   ```
5. Run the collector with a lookup over it:
   ```yaml
   receivers:
     otlp:
       protocols:
         http:
           endpoint: 127.0.0.1:4318
   processors:
     lookup:
       context: attributes
       field: host
       csv: /tmp/assets.csv
   exporters:
     debug:
       verbosity: detailed
   service:
     telemetry:
       logs:
         level: debug
     pipelines:
       logs:
         receivers: [otlp]
         processors: [lookup]
         exporters: [debug]
   ```
6. Once `source loaded/refreshed` appears, send a record every second and watch how long each request takes:
   ```
   while true; do
     /usr/bin/time -f '%e s' curl -s -o /dev/null -X POST http://127.0.0.1:4318/v1/logs \
       -H 'Content-Type: application/json' \
       -d '{"resourceLogs":[{"scopeLogs":[{"logRecords":[{"body":{"stringValue":"x"},"attributes":[{"key":"host","value":{"stringValue":"host-42"}}]}]}]}]}'
     sleep 1
   done
   ```
7. Every request should stay in the low milliseconds, including at the 60-second reload boundaries. Confirm the debug output shows `owner` and `env` added to each record throughout.
8. To see the behavior this replaces, restore the lock: add a `sync.RWMutex` to `CSVFile`, take `Lock()` at the top of `Load` and `RLock()` in `Lookup`, rebuild, and repeat. One request per minute now takes roughly a second while the reload holds the lock.

Automated: `go test -race ./...` in `processor/lookupprocessor`. The race detector matters, since this swaps a mutex for an `atomic.Pointer` on a path read by every record.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed

