### PR TITLE
fix(lookupprocessor): skip CSV reloads when the file is unchanged and make the interval configurable (PIPE-1179)

### DIFF
--- a/processor/lookupprocessor/README.md
+++ b/processor/lookupprocessor/README.md
@@ -41,6 +41,7 @@ source and adding the resulting fields to the configured `context`.
 | context        | string          | ` `     | Telemetry context to read/write. One of `attributes`, `body`, `resource.attributes`. |
 | field          | string          | ` `     | Field in `context` whose value is used as the lookup key. |
 | source_type    | string          | ` `     | Optional. One of `csv`, `redis`, `api`. When unset, the source is inferred from the source block. |
+| reload_interval | duration       | `60s`   | How often the source is re-checked for changes. An unchanged CSV is skipped without re-reading it. A negative value is rejected. |
 | cache_enabled  | bool            | `true`  | Enable TTL caching of lookup results. |
 | cache_ttl      | duration        | `5m`    | Cache entry lifetime. |
 | cache_max_entries | int          | `100000` | Maximum entries held by the in-memory cache. On overflow, expired entries are evicted first, then arbitrary entries. Ignored when `storage` is set. |
@@ -52,7 +53,7 @@ source and adding the resulting fields to the configured `context`.
 ### CSV source
 | Field | Type   | Default | Description |
 | ---   | ---    | ---     | --- |
-| csv   | string | ` `     | Filesystem path to a CSV file. The first row is the header. Reloaded every minute. |
+| csv   | string | ` `     | Filesystem path to a CSV file. The first row is the header. Re-checked on the `reload_interval` cadence (default one minute), and re-read only when it has changed. |
 
 The top-level `field` setting doubles as the CSV column name used to look up
 rows. The remaining columns of the matching row are added to the configured

--- a/processor/lookupprocessor/config.go
+++ b/processor/lookupprocessor/config.go
@@ -43,6 +43,7 @@ var (
 	errMissingRedisAddr   = errors.New("redis address is required")
 	errMissingAPIURL      = errors.New("api url is required")
 	errNegativeCacheMax   = errors.New("cache_max_entries must not be negative")
+	errNegativeInterval   = errors.New("reload_interval must not be negative")
 )
 
 // Config is the configuration for the processor.
@@ -50,6 +51,11 @@ type Config struct {
 	Context    string `mapstructure:"context"`
 	Field      string `mapstructure:"field"`
 	SourceType string `mapstructure:"source_type"`
+
+	// ReloadInterval is how often the source is re-checked. Unset uses the
+	// historical 60s cadence. Re-checking an unchanged CSV costs one stat rather
+	// than a full re-read, so the default is cheap to leave alone.
+	ReloadInterval time.Duration `mapstructure:"reload_interval"`
 
 	CacheEnabled    bool          `mapstructure:"cache_enabled"`
 	CacheTTL        time.Duration `mapstructure:"cache_ttl"`
@@ -102,6 +108,9 @@ func (cfg Config) Validate() error {
 	}
 	if cfg.Field == "" {
 		return errMissingField
+	}
+	if cfg.ReloadInterval < 0 {
+		return errNegativeInterval
 	}
 
 	switch cfg.Context {

--- a/processor/lookupprocessor/config_test.go
+++ b/processor/lookupprocessor/config_test.go
@@ -16,6 +16,7 @@ package lookupprocessor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -35,6 +36,11 @@ func TestValidate(t *testing.T) {
 			name: "missing field",
 			cfg:  Config{Context: "body"},
 			err:  errMissingField,
+		},
+		{
+			name: "negative reload_interval",
+			cfg:  Config{Context: "body", Field: "ip", ReloadInterval: -time.Second},
+			err:  errNegativeInterval,
 		},
 		{
 			name: "invalid context",

--- a/processor/lookupprocessor/csv.go
+++ b/processor/lookupprocessor/csv.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"os"
 	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
 )
 
 var (
@@ -47,39 +50,135 @@ type index map[string]map[string]string
 type CSVFile struct {
 	filepath     string
 	lookupColumn string
+	logger       *zap.Logger
 	data         atomic.Pointer[index]
 
-	// readHook runs after a reload has built the new index but before it is
-	// published, so a test can hold a reload in flight and observe that lookups
-	// proceed against the still-published old index. It is nil in production.
+	// stamp identifies the file version behind the published index, so an
+	// unchanged file can be skipped without re-reading it. stampSettled records
+	// whether that stamp was taken late enough after the file's own modification
+	// time to identify the content unambiguously. Only Load writes them, and Load
+	// runs on a single goroutine.
+	stamp        fileStamp
+	stampSettled bool
+
+	// now reports the current time, and is a seam so a test can drive the
+	// stamp-settle check off a fixed clock; it defaults to time.Now. reads and
+	// readHook exist only for tests: reads counts completed file reads, and
+	// readHook runs between a read and the re-stat that follows it. readHook is
+	// nil in production.
+	reads    atomic.Int64
 	readHook func()
+	now      func() time.Time
 }
 
-// Load reads the csv and publishes a freshly built index.
+// stampSettleWindow is how long a file's modification time must already be in the
+// past before an equal stamp is trusted to mean the content is unchanged.
+//
+// A write takes its modification time from a coarse clock, so two writes landing
+// close together carry byte-identical timestamps. When they also produce the same
+// size, the first write's stamp is indistinguishable from the second's, and
+// skipping on it would serve the earlier content for as long as the file then sat
+// still. Re-reading once while the modification time is still this fresh closes
+// that window, and costs one extra read per write rather than one per interval.
+// The window covers the coarsest timestamp granularity still in common use, FAT's
+// two seconds, so it comfortably covers the millisecond-scale granularity that
+// Linux filesystems report.
+const stampSettleWindow = 2 * time.Second
+
+// fileStamp identifies a file version cheaply. It relies on a write advancing the
+// modification time, which holds on any filesystem storing mtime at sub-second
+// resolution. Two writes can still share a timestamp when they land in the same
+// clock tick, so a stamp only identifies content once its modification time has
+// settled; see stampSettleWindow. A rewrite that deliberately restores the
+// previous timestamp and keeps the same size would read as unchanged.
+type fileStamp struct {
+	modTime time.Time
+	size    int64
+}
+
+func stampOf(fi os.FileInfo) fileStamp {
+	return fileStamp{modTime: fi.ModTime(), size: fi.Size()}
+}
+
+// equal compares two stamps. It uses time.Equal rather than ==, since == on a
+// time.Time also compares the monotonic reading and the location pointer, which
+// would report a difference for the same instant and defeat the skip.
+func (s fileStamp) equal(o fileStamp) bool {
+	return s.size == o.size && s.modTime.Equal(o.modTime)
+}
+
+// Load publishes a freshly built index, skipping the read entirely when the file
+// has not changed since the last successful load.
 func (c *CSVFile) Load() error {
+	before, err := os.Stat(c.filepath)
+	if err != nil {
+		return fmt.Errorf("stat file: %w", err)
+	}
+
+	stamp := stampOf(before)
+	if c.data.Load() != nil && c.stampSettled && stamp.equal(c.stamp) {
+		c.logger.Debug("csv unchanged, skipping reload", zap.String("path", c.filepath))
+		return nil
+	}
+
+	data, err := c.readIndex()
+	if err != nil {
+		return err
+	}
+
+	// A rewrite landing mid-read can produce a truncated file that still parses
+	// cleanly, which would publish a partial index. Re-stat and read once more
+	// when the file moved under us. Writers that rename a completed file into
+	// place avoid the window entirely, since the swap is then atomic.
+	after, err := os.Stat(c.filepath)
+	if err != nil {
+		return fmt.Errorf("re-stat file: %w", err)
+	}
+	if retryStamp := stampOf(after); !retryStamp.equal(stamp) {
+		c.logger.Debug("csv changed while being read, retrying", zap.String("path", c.filepath))
+		stamp = retryStamp
+		if data, err = c.readIndex(); err != nil {
+			return err
+		}
+	}
+
+	c.data.Store(&data)
+	c.stamp = stamp
+	// now is unset only on a CSVFile built without NewCSVFile; fall back so that
+	// path publishes rather than panics.
+	now := c.now
+	if now == nil {
+		now = time.Now
+	}
+	c.stampSettled = now().Sub(stamp.modTime) >= stampSettleWindow
+	return nil
+}
+
+// readIndex reads the file and builds an index from it, without publishing.
+func (c *CSVFile) readIndex() (index, error) {
 	file, err := os.Open(c.filepath)
 	if err != nil {
-		return fmt.Errorf("open file: %w", err)
+		return nil, fmt.Errorf("open file: %w", err)
 	}
 	defer file.Close()
 
 	reader := csv.NewReader(file)
 	records, err := reader.ReadAll()
 	if err != nil {
-		return fmt.Errorf("read all: %w", err)
+		return nil, fmt.Errorf("read all: %w", err)
 	}
 
 	data, err := indexRecords(records, c.lookupColumn)
 	if err != nil {
-		return fmt.Errorf("index records: %w", err)
+		return nil, fmt.Errorf("index records: %w", err)
 	}
 
+	c.reads.Add(1)
 	if c.readHook != nil {
 		c.readHook()
 	}
 
-	c.data.Store(&data)
-	return nil
+	return data, nil
 }
 
 // Lookup returns a row of data that matches the key in the provided column.
@@ -147,9 +246,14 @@ func (c *CSVFile) Close() error {
 }
 
 // NewCSVFile creates a new CSVFile
-func NewCSVFile(filepath string, lookupColumn string) *CSVFile {
+func NewCSVFile(filepath string, lookupColumn string, logger *zap.Logger) *CSVFile {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	return &CSVFile{
 		filepath:     filepath,
 		lookupColumn: lookupColumn,
+		logger:       logger,
+		now:          time.Now,
 	}
 }

--- a/processor/lookupprocessor/csv_reload_stall_test.go
+++ b/processor/lookupprocessor/csv_reload_stall_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 // writeStallCSV writes a small host-keyed CSV and returns its path.
@@ -57,7 +58,7 @@ func writeStallCSV(t *testing.T, rows int) string {
 // reads the old index and never takes the reload's path.
 func TestReloadDoesNotBlockLookups(t *testing.T) {
 	path := writeStallCSV(t, 100)
-	csvFile := NewCSVFile(path, "host")
+	csvFile := NewCSVFile(path, "host", zap.NewNop())
 	require.NoError(t, csvFile.Load())
 
 	// Confirm the key resolves off the initial index before the reload starts.

--- a/processor/lookupprocessor/csv_reload_test.go
+++ b/processor/lookupprocessor/csv_reload_test.go
@@ -1,0 +1,261 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lookupprocessor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// writeCSVAt writes a csv keyed by "ip" whose single data row carries env.
+func writeCSVAt(t *testing.T, path, ip, env string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf("ip,env\n%s,%s\n", ip, env)), 0o600))
+}
+
+// bumpModTime moves a file's modtime forward so a stamp comparison sees a change
+// even when the rewrite happens within the filesystem's timestamp resolution.
+func bumpModTime(t *testing.T, path string, d time.Duration) {
+	t.Helper()
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	ts := fi.ModTime().Add(d)
+	require.NoError(t, os.Chtimes(path, ts, ts))
+}
+
+func TestLoadSkipsUnchangedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lookup.csv")
+	writeCSVAt(t, path, "0.0.0.0", "prod")
+
+	c := NewCSVFile(path, "ip", zap.NewNop())
+	// Report a clock far enough past the write that the stamp settles on the first
+	// load, so this exercises the skip rather than the same-tick re-read.
+	c.now = func() time.Time { return time.Now().Add(stampSettleWindow) }
+
+	require.NoError(t, c.Load())
+	require.Equal(t, int64(1), c.reads.Load(), "first load must read the file")
+
+	first := c.data.Load()
+	require.NotNil(t, first)
+
+	require.NoError(t, c.Load())
+	require.Equal(t, int64(1), c.reads.Load(), "unchanged file must not be re-read")
+	require.Same(t, first, c.data.Load(), "unchanged file must not republish the index")
+}
+
+func TestLoadSkipsOnlyOnceTheStampHasSettled(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lookup.csv")
+	writeCSVAt(t, path, "0.0.0.0", "prod")
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	written := fi.ModTime()
+
+	c := NewCSVFile(path, "ip", zap.NewNop())
+
+	// Within the settle window another write could share this modification time,
+	// so an equal stamp proves nothing and the file is read again.
+	c.now = func() time.Time { return written.Add(stampSettleWindow - time.Millisecond) }
+	require.NoError(t, c.Load())
+	require.Equal(t, int64(1), c.reads.Load(), "first load must read the file")
+	require.NoError(t, c.Load())
+	require.Equal(t, int64(2), c.reads.Load(), "an unsettled stamp must not be skipped on")
+
+	// Once the modification time has settled, the stamp identifies the content and
+	// the read is skipped from then on.
+	c.now = func() time.Time { return written.Add(stampSettleWindow) }
+	require.NoError(t, c.Load())
+	require.Equal(t, int64(3), c.reads.Load(), "the load that settles the stamp still reads")
+	require.NoError(t, c.Load())
+	require.Equal(t, int64(3), c.reads.Load(), "a settled stamp must be skipped on")
+}
+
+func TestLoadRereadsWhenRewriteSharesTheStampedModTime(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lookup.csv")
+	writeCSVAt(t, path, "0.0.0.0", "prod")
+
+	c := NewCSVFile(path, "ip", zap.NewNop())
+	require.NoError(t, c.Load())
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	stamped := fi.ModTime()
+
+	// A rewrite of the same size landing in the same filesystem timestamp tick
+	// leaves both mtime and size identical to what the load stamped, so the stamp
+	// cannot tell that the content changed. Skipping on it strands the old index
+	// until some later write moves mtime or size.
+	writeCSVAt(t, path, "0.0.0.0", "test")
+	require.NoError(t, os.Chtimes(path, stamped, stamped))
+
+	require.NoError(t, c.Load())
+
+	got, err := c.Lookup(context.Background(), "0.0.0.0")
+	require.NoError(t, err)
+	require.Equal(t, "test", got["env"], "a rewrite sharing the stamped modtime must not be skipped")
+}
+
+func TestLoadPicksUpChangedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lookup.csv")
+	writeCSVAt(t, path, "0.0.0.0", "prod")
+
+	c := NewCSVFile(path, "ip", zap.NewNop())
+	require.NoError(t, c.Load())
+
+	got, err := c.Lookup(context.Background(), "0.0.0.0")
+	require.NoError(t, err)
+	require.Equal(t, "prod", got["env"])
+
+	// same size, different content, so the modtime is what has to carry the change
+	writeCSVAt(t, path, "0.0.0.0", "test")
+	bumpModTime(t, path, time.Second)
+
+	require.NoError(t, c.Load())
+	require.Equal(t, int64(2), c.reads.Load(), "changed file must be re-read")
+
+	got, err = c.Lookup(context.Background(), "0.0.0.0")
+	require.NoError(t, err)
+	require.Equal(t, "test", got["env"], "lookup must see the new content")
+}
+
+func TestLoadRetriesWhenFileChangesMidRead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lookup.csv")
+	writeCSVAt(t, path, "0.0.0.0", "prod")
+
+	c := NewCSVFile(path, "ip", zap.NewNop())
+
+	// Simulate a writer landing a rewrite between the read and the re-stat, which
+	// is the window where a truncated-but-parseable file would be published.
+	var rewritten bool
+	c.readHook = func() {
+		if rewritten {
+			return
+		}
+		rewritten = true
+		writeCSVAt(t, path, "0.0.0.0", "rewritten")
+		bumpModTime(t, path, time.Second)
+	}
+
+	require.NoError(t, c.Load())
+	require.Equal(t, int64(2), c.reads.Load(), "a mid-read change must trigger exactly one retry")
+
+	got, err := c.Lookup(context.Background(), "0.0.0.0")
+	require.NoError(t, err)
+	require.Equal(t, "rewritten", got["env"], "the published index must be the post-rewrite content")
+}
+
+func TestNewCSVFileToleratesNilLogger(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lookup.csv")
+	writeCSVAt(t, path, "0.0.0.0", "prod")
+
+	c := NewCSVFile(path, "ip", nil)
+	require.NotPanics(t, func() { require.NoError(t, c.Load()) })
+}
+
+func TestLoadWithoutInjectedClockDoesNotPanic(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lookup.csv")
+	writeCSVAt(t, path, "0.0.0.0", "prod")
+
+	// A CSVFile built by hand rather than through NewCSVFile has no clock, so the
+	// stamp-settle check must fall back instead of dereferencing a nil func.
+	c := &CSVFile{filepath: path, lookupColumn: "ip", logger: zap.NewNop()}
+	require.NotPanics(t, func() { require.NoError(t, c.Load()) })
+
+	got, err := c.Lookup(context.Background(), "0.0.0.0")
+	require.NoError(t, err)
+	require.Equal(t, "prod", got["env"])
+}
+
+func TestLoadSurfacesStatErrors(t *testing.T) {
+	c := NewCSVFile(filepath.Join(t.TempDir(), "missing.csv"), "ip", zap.NewNop())
+	require.Error(t, c.Load())
+	require.Nil(t, c.data.Load(), "a failed load must not publish an index")
+}
+
+func TestLoadSurfacesReadErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lookup.csv")
+	// A bare quote in an unquoted field makes csv parsing fail on the first read.
+	require.NoError(t, os.WriteFile(path, []byte("ip,env\nbad\"quote,x\n"), 0o600))
+
+	c := NewCSVFile(path, "ip", zap.NewNop())
+	require.Error(t, c.Load())
+	require.Nil(t, c.data.Load(), "a failed read must not publish an index")
+}
+
+func TestLoadSurfacesReStatErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lookup.csv")
+	writeCSVAt(t, path, "0.0.0.0", "prod")
+
+	c := NewCSVFile(path, "ip", zap.NewNop())
+	// Remove the file after the read but before the re-stat, so the re-stat fails.
+	var fired bool
+	c.readHook = func() {
+		if fired {
+			return
+		}
+		fired = true
+		require.NoError(t, os.Remove(path))
+	}
+	require.Error(t, c.Load())
+}
+
+func TestLoadSurfacesRetryReadErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lookup.csv")
+	writeCSVAt(t, path, "0.0.0.0", "prod")
+
+	c := NewCSVFile(path, "ip", zap.NewNop())
+	// Rewrite the file mid-read so the re-stat forces a retry, and make that retry
+	// read fail on a bare quote.
+	var fired bool
+	c.readHook = func() {
+		if fired {
+			return
+		}
+		fired = true
+		require.NoError(t, os.WriteFile(path, []byte("ip,env\nbad\"quote,more\n"), 0o600))
+		bumpModTime(t, path, time.Second)
+	}
+	require.Error(t, c.Load())
+}
+
+func TestLoadKeepsPreviousIndexWhenFileGoesAway(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lookup.csv")
+	writeCSVAt(t, path, "0.0.0.0", "prod")
+
+	c := NewCSVFile(path, "ip", zap.NewNop())
+	require.NoError(t, c.Load())
+	before := c.data.Load()
+
+	require.NoError(t, os.Remove(path))
+	require.Error(t, c.Load())
+	require.Same(t, before, c.data.Load(), "a failed reload must leave the last good index in place")
+
+	got, err := c.Lookup(context.Background(), "0.0.0.0")
+	require.NoError(t, err)
+	require.Equal(t, "prod", got["env"])
+}
+
+func TestResolveReloadInterval(t *testing.T) {
+	require.Equal(t, defaultReloadInterval, resolveReloadInterval(&Config{}),
+		"unset must fall back to the historical 60s cadence")
+	require.Equal(t, 5*time.Second, resolveReloadInterval(&Config{ReloadInterval: 5 * time.Second}))
+}

--- a/processor/lookupprocessor/csv_test.go
+++ b/processor/lookupprocessor/csv_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestLookup(t *testing.T) {
@@ -28,7 +29,7 @@ func TestLookup(t *testing.T) {
 		"region": "us-west",
 	}
 	csvPath := createTestCSVFile(t, csvContents)
-	csvFile := NewCSVFile(csvPath, "ip")
+	csvFile := NewCSVFile(csvPath, "ip", zap.NewNop())
 	err := csvFile.Load()
 	require.NoError(t, err)
 

--- a/processor/lookupprocessor/processor.go
+++ b/processor/lookupprocessor/processor.go
@@ -36,6 +36,17 @@ const defaultCacheTTL = 5 * time.Minute
 // memory today keep their hit rates.
 const defaultCacheMaxEntries = 100_000
 
+// defaultReloadInterval preserves the cadence the processor has always used.
+const defaultReloadInterval = time.Minute
+
+// resolveReloadInterval falls back to the default when the interval is unset.
+func resolveReloadInterval(cfg *Config) time.Duration {
+	if cfg.ReloadInterval > 0 {
+		return cfg.ReloadInterval
+	}
+	return defaultReloadInterval
+}
+
 // signal identifies the pipeline kind a processor instance is wired into. It
 // namespaces the storage extension client so concurrent processor instances
 // for the same component ID across signals do not share or close each other's
@@ -80,7 +91,7 @@ func (p *lookupProcessor) buildSource() (LookupSource, error) {
 	case p.cfg.API != nil:
 		return NewAPISource(p.cfg.API, p.logger)
 	case p.cfg.CSV != "":
-		return NewCSVFile(p.cfg.CSV, p.cfg.Field), nil
+		return NewCSVFile(p.cfg.CSV, p.cfg.Field, p.logger), nil
 	default:
 		return nil, errMissingSource
 	}
@@ -135,9 +146,10 @@ func (p *lookupProcessor) shutdown(context.Context) error {
 	return nil
 }
 
-// loadSource refreshes the source every minute until context is canceled.
+// loadSource refreshes the source on the configured interval until context is
+// canceled.
 func (p *lookupProcessor) loadSource(ctx context.Context) {
-	ticker := time.NewTicker(1 * time.Minute)
+	ticker := time.NewTicker(resolveReloadInterval(p.cfg))
 	defer ticker.Stop()
 	defer p.wg.Done()
 
@@ -145,7 +157,7 @@ func (p *lookupProcessor) loadSource(ctx context.Context) {
 		if err := p.source.Load(); err != nil {
 			p.logger.Error("failed to load source", zap.Error(err))
 		} else {
-			p.logger.Debug("source loaded/refreshed")
+			p.logger.Debug("source reload check complete")
 		}
 
 		select {

--- a/processor/lookupprocessor/processor_test.go
+++ b/processor/lookupprocessor/processor_test.go
@@ -125,7 +125,7 @@ func TestProcessLogs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			csvPath := createTestCSVFile(t, tc.csvContents)
-			csvFile := NewCSVFile(csvPath, tc.field)
+			csvFile := NewCSVFile(csvPath, tc.field, zap.NewNop())
 			err := csvFile.Load()
 			require.NoError(t, err)
 
@@ -225,7 +225,7 @@ func TestProcessTraces(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			csvPath := createTestCSVFile(t, tc.csvContents)
-			csvFile := NewCSVFile(csvPath, tc.field)
+			csvFile := NewCSVFile(csvPath, tc.field, zap.NewNop())
 			err := csvFile.Load()
 			require.NoError(t, err)
 
@@ -359,7 +359,7 @@ func TestProcessMetrics(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			csvPath := createTestCSVFile(t, tc.csvContents)
-			csvFile := NewCSVFile(csvPath, tc.field)
+			csvFile := NewCSVFile(csvPath, tc.field, zap.NewNop())
 			err := csvFile.Load()
 			require.NoError(t, err)
 
@@ -383,7 +383,7 @@ func TestAddLookupValues(t *testing.T) {
 		"region": "us-west",
 	}
 	csvPath := createTestCSVFile(t, csvContents)
-	csvFile := NewCSVFile(csvPath, "ip")
+	csvFile := NewCSVFile(csvPath, "ip", zap.NewNop())
 	err := csvFile.Load()
 	require.NoError(t, err)
 


### PR DESCRIPTION
### Proposed Change

Part of PIPE-1179.

The reload re-read and re-indexed the whole CSV every 60s even when the file had not changed. `Load` now stats first and skips the read when modification time and size both match the last successful load. A static file is therefore read once rather than once a minute.

A file rewritten in place can be read mid-write, but still parseable. `Load` re-stats after reading and reads again if the file moved.

`reload_interval` is now configurable, defaulting to the historical 60s.

Stamp comparison uses `time.Equal` rather than `==`. On a `time.Time`, `==` also compares the monotonic reading and the location pointer, so it can report a difference for the same instant and silently defeat the skip.

Measured with the same harness, 10 minutes per run, ~11.5M records each, against PR 1 as the baseline.

Static CSV:

| Metric            | Baseline | With skip |
|-------------------|----------|-----------|
| Load calls        | 11       | 11        |
| Actual file reads | 11       | 1         |
| Collector CPU     | 514.91 s | 372.59 s  |

CSV rewritten atomically every 240s, so 10 load calls meet 2 genuine changes:

| Metric            | Baseline | With skip |
|-------------------|----------|-----------|
| Load calls        | 11       | 11        |
| Actual file reads | 11       | 3         |
| Collector CPU     | 519.32 s | 369.42 s  |

27.6% less CPU on the static file and 28.9% on the rewritten one. The rewritten-file run is the one that matters for correctness: 3 reads for 1 initial load plus 2 real changes shows the skip still reloads when the file turns over. A static-only benchmark cannot distinguish a working skip from one that never reloads at all, since the broken version would post better numbers.

`loadSource` logged `source loaded/refreshed` on every successful `Load`, which would now claim a reload happened on a skip. It logs `source reload check complete` instead, and `CSVFile` logs the skip and the retry itself.

### How the reviewer can validate

> **Note:** the manual validation procedure below is an AI-generated script. Review it before running.

Manual:

1. Check out this branch in a `bindplane-otel-contrib` clone: `gh pr checkout 703`
2. In `bindplane-otel-collector`, point the manifest at that checkout by adding one line under `replaces:` in `manifests/observIQ/manifest.yaml`:
   ```
   - github.com/observiq/bindplane-otel-contrib/processor/lookupprocessor => /path/to/bindplane-otel-contrib/processor/lookupprocessor
   ```
3. `make agent`
4. A small CSV is enough here, since this is about when the file is read rather than how long a read takes:
   ```
   printf 'host,owner,env\nhost-42,alice,production\n' > /tmp/assets.csv
   ```
5. Run the collector with a short interval so cycles are quick to watch:
   ```yaml
   receivers:
     otlp:
       protocols:
         http:
           endpoint: 127.0.0.1:4318
   processors:
     lookup:
       context: attributes
       field: host
       csv: /tmp/assets.csv
       reload_interval: 10s
   exporters:
     debug:
       verbosity: detailed
   service:
     telemetry:
       logs:
         level: debug
     pipelines:
       logs:
         receivers: [otlp]
         processors: [lookup]
         exporters: [debug]
   ```
6. Watch the log for 30 seconds. The first cycle reads the file. Every cycle after it logs `csv unchanged, skipping reload` with the path, confirming the interval still fires while the read is avoided.
7. Change the file's contents: `printf 'host,owner,env\nhost-42,bob,staging\n' > /tmp/assets.csv`. Within one interval the skip line stops and the file is read again.
8. Confirm the new values reach records. Send one before and one after the change and compare the debug output:
   ```
   curl -s -X POST http://127.0.0.1:4318/v1/logs -H 'Content-Type: application/json' \
     -d '{"resourceLogs":[{"scopeLogs":[{"logRecords":[{"body":{"stringValue":"x"},"attributes":[{"key":"host","value":{"stringValue":"host-42"}}]}]}]}]}'
   ```
   `owner` should go from `alice` to `bob` and `env` from `production` to `staging`. This is the check that matters most: a skip that never reloads would keep serving `alice` forever and would otherwise look like a successful optimization.
9. Confirm the interval is validated. Set `reload_interval: -1s` and restart; the collector refuses to start with `reload_interval must not be negative`.

Automated: `go test -race ./...` in `processor/lookupprocessor`. `TestLoadSkipsUnchangedFile` asserts the file is not re-read and the published index pointer is unchanged, `TestLoadPicksUpChangedFile` asserts a changed file is re-read, and `TestLoadRetriesWhenFileChangesMidRead` drives a rewrite between the read and the re-stat to confirm the retry fires exactly once.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed

