### PR TITLE
fix(gcspubsubeventreceiver,awss3eventreceiver): terminate parse loop on read errors [PIPE-1409]

### DIFF
--- a/receiver/awss3eventreceiver/internal/worker/json_parser.go
+++ b/receiver/awss3eventreceiver/internal/worker/json_parser.go
@@ -204,8 +204,10 @@ func (p *jsonParser) yieldArray(startOffset int64) iter.Seq2[any, error] {
 				if errors.Is(err, io.EOF) {
 					return
 				}
-				// unexpected end of file, not much we can do here
+				// The object stops part way through a record. The missing bytes
+				// were never written, so a retry reads the same thing.
 				if errors.Is(err, io.ErrUnexpectedEOF) {
+					yield(nil, ErrTruncatedObject{Err: err})
 					return
 				}
 				// unexpected error, return it
@@ -221,6 +223,12 @@ func (p *jsonParser) yieldArray(startOffset int64) iter.Seq2[any, error] {
 					return
 				}
 			}
+		}
+		// The loop above also ends when the object stops part way through, because
+		// More reports no further element either way. A complete array closes with a
+		// delimiter, so anything else here means the bytes ran out early.
+		if _, err := p.decoder.Token(); err != nil {
+			yield(nil, ErrTruncatedObject{Err: err})
 		}
 	}
 }

--- a/receiver/awss3eventreceiver/internal/worker/json_truncated_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/json_truncated_test.go
@@ -1,0 +1,77 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestJSONParser_TruncatedObjectRoutesToDLQ asserts a JSON array cut short reports the
+// truncation rather than ending like a clean read. Ending quietly makes the worker ack
+// the object and drop every record after the cut.
+func TestJSONParser_TruncatedObjectRoutesToDLQ(t *testing.T) {
+	t.Parallel()
+
+	var body bytes.Buffer
+	body.WriteString("[")
+	for i := 0; i < 400; i++ {
+		if i > 0 {
+			body.WriteString(",")
+		}
+		fmt.Fprintf(&body, `{"host":"h-%04d","msg":"padding padding padding"}`, i)
+	}
+
+	raw := body.Bytes()
+	stream := LogStream{
+		Name:        "logs/object.json",
+		Body:        io.NopCloser(bytes.NewReader(raw[:len(raw)/2])),
+		MaxLogSize:  4096,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+
+	ctx := context.Background()
+	reader, err := stream.BufferedReader(ctx)
+	require.NoError(t, err)
+
+	parser, err := newParser(ctx, stream, reader)
+	require.NoError(t, err)
+
+	logs, err := parser.Parse(ctx, 0)
+	require.NoError(t, err)
+
+	var records int
+	var last error
+	for _, rerr := range logs {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		records++
+	}
+
+	require.Positive(t, records, "records before the cut are still delivered")
+	require.Error(t, last, "a truncated array must reach the caller")
+	require.True(t, IsTruncatedObject(last))
+	require.False(t, IsStreamRead(last), "truncation is not a broken connection")
+	require.NotNil(t, isDLQConditionError(last), "it must route to the dead-letter queue")
+}

--- a/receiver/awss3eventreceiver/internal/worker/line_parser.go
+++ b/receiver/awss3eventreceiver/internal/worker/line_parser.go
@@ -16,6 +16,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"iter"
@@ -51,12 +52,22 @@ func (p *lineParser) Parse(_ context.Context, startOffset int64) (logs iter.Seq2
 		for {
 			lineBytes, _, err := p.reader.ReadLine()
 			if err != nil {
-				if err == io.EOF {
+				// A decompressing reader can wrap the sentinel.
+				if errors.Is(err, io.EOF) {
 					return
 				}
-				if !yield(nil, err) {
+				// An object that stops mid-record is truncated rather than
+				// unreachable. A decompressor reports a live connection failure
+				// as that failure, so this only fires on missing bytes.
+				if errors.Is(err, io.ErrUnexpectedEOF) {
+					yield(nil, ErrTruncatedObject{Err: err})
 					return
 				}
+				// A read error is terminal. Every later ReadLine returns the same
+				// error, so continuing spins forever. It is marked so the caller
+				// fails the object instead of acking a partial read.
+				yield(nil, ErrStreamRead{Err: err})
+				return
 			}
 
 			// only yield non-empty lines

--- a/receiver/awss3eventreceiver/internal/worker/line_parser_termination_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/line_parser_termination_test.go
@@ -1,0 +1,136 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver/internal/worker"
+)
+
+// yieldBudget caps the iterations a test consumer accepts. A parser that does not
+// terminate spins until the go test timeout.
+const yieldBudget = 1000
+
+// errAfterReader serves prefix, then returns err on every later read.
+type errAfterReader struct {
+	prefix []byte
+	err    error
+}
+
+func (r *errAfterReader) Read(p []byte) (int, error) {
+	if len(r.prefix) > 0 {
+		n := copy(p, r.prefix)
+		r.prefix = r.prefix[n:]
+		return n, nil
+	}
+	return 0, r.err
+}
+
+// drain consumes the sequence and continues past errors, as processObject does.
+// exhausted reports that the sequence ran past yieldBudget.
+func drain(t *testing.T, logs func(func(any, error) bool)) (records []any, errs []error, exhausted bool) {
+	t.Helper()
+
+	iterations := 0
+	for record, err := range logs {
+		iterations++
+		if iterations > yieldBudget {
+			exhausted = true
+			break
+		}
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		records = append(records, record)
+	}
+	return records, errs, exhausted
+}
+
+func TestLineParser_TerminatesOnPersistentReadError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("connection reset by peer")
+	reader := &errAfterReader{prefix: []byte("first\nsecond\n"), err: readErr}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted, "parser did not terminate on a persistent read error")
+	require.Equal(t, []any{"first", "second"}, records, "records read before the error should still be yielded")
+	require.Len(t, errs, 1, "the terminal read error should be yielded exactly once")
+	require.ErrorIs(t, errs[0], readErr)
+	require.True(t, worker.IsStreamRead(errs[0]),
+		"a broken stream must be marked so the caller fails the object instead of acking a partial read")
+}
+
+func TestLineParser_TerminatesOnCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\n"), err: context.Canceled}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted, "parser did not terminate on a cancelled context")
+	require.Equal(t, []any{"first"}, records)
+	require.Len(t, errs, 1)
+	require.ErrorIs(t, errs[0], context.Canceled)
+}
+
+func TestLineParser_TerminatesOnExceededDeadline(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\n"), err: context.DeadlineExceeded}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	_, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted, "parser did not terminate on an exceeded deadline")
+	require.Len(t, errs, 1)
+	require.ErrorIs(t, errs[0], context.DeadlineExceeded)
+}
+
+func TestLineParser_TerminatesOnWrappedEOF(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\nsecond\n"), err: fmt.Errorf("decompress: %w", io.EOF)}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted, "parser did not terminate on a wrapped io.EOF")
+	require.Equal(t, []any{"first", "second"}, records)
+	require.Empty(t, errs, "a wrapped io.EOF is the end of the stream rather than a parse failure")
+}

--- a/receiver/awss3eventreceiver/internal/worker/stream_error.go
+++ b/receiver/awss3eventreceiver/internal/worker/stream_error.go
@@ -1,0 +1,64 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrStreamRead marks a failure to read an object to completion. The bytes after the
+// break never reached the consumer, and a later attempt can still read them.
+//
+// It separates a broken stream from a record the parser cannot use. A bad record is
+// skipped, because retrying it gives the same result. A broken stream fails the whole
+// object, so the message stays queued and resumes from the saved offset.
+type ErrStreamRead struct {
+	Err error
+}
+
+func (e ErrStreamRead) Error() string {
+	return fmt.Sprintf("read object stream: %v", e.Err)
+}
+
+func (e ErrStreamRead) Unwrap() error { return e.Err }
+
+// IsStreamRead reports that the object could not be read to completion.
+func IsStreamRead(err error) bool {
+	var streamRead ErrStreamRead
+	return errors.As(err, &streamRead)
+}
+
+// ErrTruncatedObject marks an object that ends part way through a record. The bytes
+// that are missing were never written, so a later read returns the same thing.
+//
+// It separates truncation from a broken connection. A broken connection retries. A
+// truncated object goes to the dead-letter queue, because redelivering it would only
+// fail the same way.
+type ErrTruncatedObject struct {
+	Err error
+}
+
+func (e ErrTruncatedObject) Error() string {
+	return fmt.Sprintf("object ends mid-record: %v", e.Err)
+}
+
+func (e ErrTruncatedObject) Unwrap() error { return e.Err }
+
+// IsTruncatedObject reports that the object ends part way through a record.
+func IsTruncatedObject(err error) bool {
+	var truncated ErrTruncatedObject
+	return errors.As(err, &truncated)
+}

--- a/receiver/awss3eventreceiver/internal/worker/stream_failure_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/stream_failure_test.go
@@ -1,0 +1,119 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/observiq/bindplane-otel-contrib/internal/aws/client/mocks"
+	"github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver/internal/metadata"
+	"github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver/internal/worker"
+)
+
+// brokenBody serves head and then fails, standing in for a connection dropped part way
+// through a GetObject body.
+type brokenBody struct {
+	head io.Reader
+	err  error
+}
+
+func (b *brokenBody) Read(p []byte) (int, error) {
+	n, err := b.head.Read(p)
+	if errors.Is(err, io.EOF) {
+		return n, b.err
+	}
+	return n, err
+}
+
+func (b *brokenBody) Close() error { return nil }
+
+// TestProcessMessage_PreservesMessageWhenTheObjectStreamBreaks asserts an object whose
+// body fails part way through is left in the queue for retry. Acking it would drop every
+// record after the break with no way to recover them.
+func TestProcessMessage_PreservesMessageWhenTheObjectStreamBreaks(t *testing.T) {
+	ctx := context.Background()
+	readErr := errors.New("read: connection reset by peer")
+
+	mockSQS := &mocks.MockSQSClient{}
+	mockS3 := &mocks.MockS3Client{}
+	mockClient := &mocks.MockClient{}
+	mockClient.EXPECT().SQS().Return(mockSQS)
+	mockClient.EXPECT().S3().Return(mockS3)
+
+	validS3Event := `{"Records":[{"eventName":"s3:ObjectCreated:Put","s3":{"bucket":{"name":"mybucket"},"object":{"key":"mykey1","size":15}}}]}`
+	mockSQS.EXPECT().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput)).Return(&sqs.ReceiveMessageOutput{
+		Messages: []types.Message{{
+			Body:          aws.String(validS3Event),
+			MessageId:     aws.String("123"),
+			ReceiptHandle: aws.String("receipt-handle"),
+		}},
+	}, nil)
+
+	mockS3.EXPECT().GetObject(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			return &s3.GetObjectOutput{
+				Body: &brokenBody{head: strings.NewReader("line1\nline2\nline3\n"), err: readErr},
+			}, nil
+		})
+
+	core, recorded := observer.New(zap.DebugLevel)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zap.New(core)
+
+	sink := new(consumertest.LogsSink)
+	tb, err := metadata.NewTelemetryBuilder(set)
+	require.NoError(t, err)
+
+	params := receivertest.NewNopSettings(metadata.Type)
+	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		ReceiverID:             params.ID,
+		Transport:              "http",
+		ReceiverCreateSettings: params,
+	})
+	require.NoError(t, err)
+
+	w := worker.New(set, sink, mockClient, obsrecv, 4096, 1000,
+		1*time.Hour, 300*time.Second, 6*time.Hour, worker.WithTelemetryBuilder(tb))
+
+	msg, err := mockClient.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
+	require.NoError(t, err)
+	require.Len(t, msg.Messages, 1)
+
+	done := make(chan struct{})
+	go func() { w.ProcessMessage(ctx, msg.Messages[0], "myqueue", func() { close(done) }) }()
+	<-done
+
+	require.True(t, containsLogMessage(recorded, "preserving message in SQS for retry"),
+		"a broken object stream must keep the message for retry")
+	mockSQS.AssertNotCalled(t, "DeleteMessage", mock.Anything, mock.Anything)
+}

--- a/receiver/awss3eventreceiver/internal/worker/truncated_dlq_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/truncated_dlq_test.go
@@ -1,0 +1,34 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTruncatedObjectRoutesToDLQ asserts a truncated object is a dead-letter condition.
+// Redelivering it reads the same bytes, so retrying never drains the queue.
+func TestTruncatedObjectRoutesToDLQ(t *testing.T) {
+	t.Parallel()
+
+	err := error(ErrTruncatedObject{Err: io.ErrUnexpectedEOF})
+	require.NotNil(t, isDLQConditionError(err), "a truncated object must be a DLQ condition")
+	require.NotNil(t, isDLQConditionError(fmt.Errorf("parse logs: %w", err)),
+		"the condition must survive wrapping")
+}

--- a/receiver/awss3eventreceiver/internal/worker/truncated_object_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/truncated_object_test.go
@@ -1,0 +1,49 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver/internal/worker"
+)
+
+// TestLineParser_TruncatedObjectIsNotRetryable asserts a stream cut short mid-record is
+// reported as content the receiver cannot use, rather than as a broken connection.
+// Retrying reads the same truncated bytes, so a retryable answer redelivers forever.
+func TestLineParser_TruncatedObjectIsNotRetryable(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\nsecond\n"), err: io.ErrUnexpectedEOF}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted, "the parser must stop rather than spin")
+	require.Equal(t, []any{"first", "second"}, records, "records read before the cut are still delivered")
+	require.Len(t, errs, 1)
+
+	require.False(t, worker.IsStreamRead(errs[0]),
+		"a truncated object is not a broken connection, so it must not be retried")
+	require.True(t, worker.IsTruncatedObject(errs[0]),
+		"a truncated object must be marked so the caller can route it")
+}

--- a/receiver/awss3eventreceiver/internal/worker/worker.go
+++ b/receiver/awss3eventreceiver/internal/worker/worker.go
@@ -112,7 +112,9 @@ func isNoSuchKeyError(err error) bool {
 
 // isUnsupportedFileTypeError checks if the error indicates an unsupported file type
 func isUnsupportedFileTypeError(err error) bool {
-	return errors.Is(err, ErrNotArrayOrKnownObject)
+	// A truncated object is unusable for the same reason: reading it again returns
+	// the same bytes.
+	return errors.Is(err, ErrNotArrayOrKnownObject) || IsTruncatedObject(err)
 }
 
 // DLQError represents an error that should trigger DLQ behavior
@@ -406,6 +408,12 @@ func (w *Worker) consumeLogsFromS3Object(ctx context.Context, record events.S3Ev
 
 	for log, err := range logs {
 		if err != nil {
+			// A broken stream is fatal for the whole object. Acking here would drop
+			// every record after the break with no way to recover them, so fail and
+			// let the message redeliver and resume from the saved offset.
+			if IsStreamRead(err) {
+				return err
+			}
 			recordLogger.Error("parse log", zap.Error(err))
 			continue
 		}

--- a/receiver/awss3eventreceiver/internal/worker/worker_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/worker_test.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -523,398 +524,353 @@ func TestEventTypeFiltering(t *testing.T) {
 }
 
 func TestMessageVisibilityExtension(t *testing.T) {
-	defer fake.SetFakeConstructorForTest(t)()
+	synctest.Test(t, func(t *testing.T) {
+		defer fake.SetFakeConstructorForTest(t)()
 
-	ctx := context.Background()
-	fakeAWS := client.NewClient(aws.Config{}).(*fake.AWS)
+		ctx := context.Background()
+		fakeAWS := client.NewClient(aws.Config{}).(*fake.AWS)
 
-	// Create a test object
-	objectSet := map[string]map[string]string{
-		"mybucket": {
-			"mykey1": "line1\nline2\nline3",
-		},
-	}
-	fakeAWS.CreateObjects(t, objectSet)
+		// Create a test object
+		objectSet := map[string]map[string]string{
+			"mybucket": {
+				"mykey1": "line1\nline2\nline3",
+			},
+		}
+		fakeAWS.CreateObjects(t, objectSet)
 
-	set := componenttest.NewNopTelemetrySettings()
-	sink := new(consumertest.LogsSink)
+		set := componenttest.NewNopTelemetrySettings()
+		sink := new(consumertest.LogsSink)
 
-	// Use a short extension interval for faster testing
-	visibilityExtensionInterval := 50 * time.Millisecond
-	visibilityTimeout := 300 * time.Second
+		// Use a short extension interval for faster testing
+		visibilityExtensionInterval := 50 * time.Millisecond
+		visibilityTimeout := 300 * time.Second
 
-	b, err := metadata.NewTelemetryBuilder(set)
-	require.NoError(t, err)
-	params := receivertest.NewNopSettings(metadata.Type)
-	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
-		ReceiverID:             params.ID,
-		Transport:              "http",
-		ReceiverCreateSettings: params,
-	})
-	require.NoError(t, err)
-	w := worker.New(set, sink, fakeAWS, obsrecv, 4096, 1000, visibilityExtensionInterval, visibilityTimeout, 6*time.Hour, worker.WithTelemetryBuilder(b))
-
-	// Get a message from the queue
-	msg, err := fakeAWS.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
-	require.NoError(t, err)
-	require.Len(t, msg.Messages, 1)
-
-	// Start processing the message
-	done := make(chan struct{})
-	go func() {
-		w.ProcessMessage(ctx, msg.Messages[0], "myqueue", func() {
-			close(done)
+		b, err := metadata.NewTelemetryBuilder(set)
+		require.NoError(t, err)
+		params := receivertest.NewNopSettings(metadata.Type)
+		obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+			ReceiverID:             params.ID,
+			Transport:              "http",
+			ReceiverCreateSettings: params,
 		})
-	}()
+		require.NoError(t, err)
+		w := worker.New(set, sink, fakeAWS, obsrecv, 4096, 1000, visibilityExtensionInterval, visibilityTimeout, 6*time.Hour, worker.WithTelemetryBuilder(b))
 
-	// The message is invisible for the visibility timeout from the moment it was
-	// received, so it is not re-deliverable while processing is in flight. Assert that
-	// directly instead of sleeping to "let extension happen".
-	_, err2 := fakeAWS.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
-	require.ErrorIs(t, err2, fake.ErrEmptyQueue, "Message should still be invisible due to visibility extension")
+		// Get a message from the queue
+		msg, err := fakeAWS.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
+		require.NoError(t, err)
+		require.Len(t, msg.Messages, 1)
 
-	// Wait for processing to complete
-	<-done
+		// Start processing the message
+		done := make(chan struct{})
+		go func() {
+			w.ProcessMessage(ctx, msg.Messages[0], "myqueue", func() {
+				close(done)
+			})
+		}()
 
-	// Now the message should be deleted and not available
-	_, err3 := fakeAWS.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
-	require.ErrorIs(t, err3, fake.ErrEmptyQueue, "Message should be deleted after processing")
+		// The message is invisible from the moment it was received, so it is not
+		// re-deliverable while processing is in flight. Nothing has advanced the bubble's
+		// clock yet, so no extension has run and this reads the same way every time.
+		_, err2 := fakeAWS.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
+		require.ErrorIs(t, err2, fake.ErrEmptyQueue, "Message should still be invisible due to visibility extension")
+
+		// Wait for processing to complete
+		<-done
+
+		// Now the message should be deleted and not available
+		_, err3 := fakeAWS.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
+		require.ErrorIs(t, err3, fake.ErrEmptyQueue, "Message should be deleted after processing")
+	})
 }
 
 func TestVisibilityExtensionLogs(t *testing.T) {
-	ctx := context.Background()
-	mockSQS := &mocks.MockSQSClient{}
-	mockS3 := &mocks.MockS3Client{}
-	mockClient := &mocks.MockClient{}
-	mockClient.EXPECT().SQS().Return(mockSQS)
-	mockClient.EXPECT().S3().Return(mockS3)
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		mockSQS := &mocks.MockSQSClient{}
+		mockS3 := &mocks.MockS3Client{}
+		mockClient := &mocks.MockClient{}
+		mockClient.EXPECT().SQS().Return(mockSQS)
+		mockClient.EXPECT().S3().Return(mockS3)
 
-	// Provide a valid S3 event message
-	validS3Event := `{"Records":[{"eventName":"s3:ObjectCreated:Put","s3":{"bucket":{"name":"mybucket"},"object":{"key":"mykey1","size":15}}}]}`
+		// Provide a valid S3 event message
+		validS3Event := `{"Records":[{"eventName":"s3:ObjectCreated:Put","s3":{"bucket":{"name":"mybucket"},"object":{"key":"mykey1","size":15}}}]}`
 
-	mockSQS.EXPECT().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput)).Return(&sqs.ReceiveMessageOutput{
-		Messages: []types.Message{
-			{
-				Body:          aws.String(validS3Event),
-				MessageId:     aws.String("123"),
-				ReceiptHandle: aws.String("receipt-handle"),
+		mockSQS.EXPECT().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput)).Return(&sqs.ReceiveMessageOutput{
+			Messages: []types.Message{
+				{
+					Body:          aws.String(validS3Event),
+					MessageId:     aws.String("123"),
+					ReceiptHandle: aws.String("receipt-handle"),
+				},
 			},
-		},
-	}, nil)
+		}, nil)
 
-	// Mock S3 GetObject to return content after a delay to trigger visibility extension
-	mockS3.EXPECT().GetObject(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-		// Add a delay to simulate processing time and trigger visibility extension
-		time.Sleep(10 * time.Millisecond)
-		return &s3.GetObjectOutput{
-			Body: io.NopCloser(strings.NewReader("line1\nline2\nline3")),
-		}, nil
-	})
+		// Hold the object open so the monitor gets a chance to extend.
+		release := make(chan struct{})
+		mockS3.EXPECT().GetObject(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			<-release
+			return &s3.GetObjectOutput{
+				Body: io.NopCloser(strings.NewReader("line1\nline2\nline3")),
+			}, nil
+		})
 
-	mockSQS.EXPECT().DeleteMessage(mock.Anything, mock.Anything).Return(&sqs.DeleteMessageOutput{}, nil)
-	mockSQS.EXPECT().ChangeMessageVisibility(mock.Anything, mock.Anything).Return(&sqs.ChangeMessageVisibilityOutput{}, nil)
+		mockSQS.EXPECT().DeleteMessage(mock.Anything, mock.Anything).Return(&sqs.DeleteMessageOutput{}, nil)
+		mockSQS.EXPECT().ChangeMessageVisibility(mock.Anything, mock.Anything).Return(&sqs.ChangeMessageVisibilityOutput{}, nil)
 
-	// Set up zap observer
-	core, recorded := observer.New(zap.DebugLevel)
-	logger := zap.New(core)
-	set := componenttest.NewNopTelemetrySettings()
-	set.Logger = logger
+		// Set up zap observer
+		core, recorded := observer.New(zap.DebugLevel)
+		logger := zap.New(core)
+		set := componenttest.NewNopTelemetrySettings()
+		set.Logger = logger
 
-	sink := new(consumertest.LogsSink)
-	visibilityExtensionInterval := 1 * time.Millisecond
-	visibilityTimeout := 300 * time.Second
-	b, err := metadata.NewTelemetryBuilder(set)
-	require.NoError(t, err)
-	params := receivertest.NewNopSettings(metadata.Type)
-	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
-		ReceiverID:             params.ID,
-		Transport:              "http",
-		ReceiverCreateSettings: params,
-	})
-	require.NoError(t, err)
-	w := worker.New(set, sink, mockClient, obsrecv, 4096, 1000, visibilityExtensionInterval, visibilityTimeout, 6*time.Hour, worker.WithTelemetryBuilder(b))
+		sink := new(consumertest.LogsSink)
+		visibilityExtensionInterval := 1 * time.Millisecond
+		visibilityTimeout := 300 * time.Second
+		b, err := metadata.NewTelemetryBuilder(set)
+		require.NoError(t, err)
+		params := receivertest.NewNopSettings(metadata.Type)
+		obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+			ReceiverID:             params.ID,
+			Transport:              "http",
+			ReceiverCreateSettings: params,
+		})
+		require.NoError(t, err)
+		w := worker.New(set, sink, mockClient, obsrecv, 4096, 1000, visibilityExtensionInterval, visibilityTimeout, 6*time.Hour, worker.WithTelemetryBuilder(b))
 
-	msg, err := mockClient.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
-	require.NoError(t, err)
-	require.Len(t, msg.Messages, 1)
+		msg, err := mockClient.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
+		require.NoError(t, err)
+		require.Len(t, msg.Messages, 1)
 
-	done := make(chan struct{})
-	go func() {
-		w.ProcessMessage(ctx, msg.Messages[0], "myqueue", func() { close(done) })
-	}()
-	// Wait for processing to complete
-	<-done
+		done := make(chan struct{})
+		go func() {
+			w.ProcessMessage(ctx, msg.Messages[0], "myqueue", func() { close(done) })
+		}()
 
-	// Wait for the visibility-extension goroutine to emit its startup and extension logs.
-	require.Eventually(t, func() bool {
-		return containsLogMessage(recorded, "starting visibility extension monitoring") &&
-			containsLogMessage(recorded, "extending message visibility")
-	}, 5*time.Second, 10*time.Millisecond)
+		// Move past one extension interval so the monitor extends at least once.
+		advanceFakeTime(10 * time.Millisecond)
+		synctest.Wait()
 
-	t.Logf("recorded logs:")
-	for i, entry := range recorded.All() {
-		t.Logf("  [%d] %s: %s", i, entry.Level, entry.Message)
-	}
-
-	// Check for all expected log messages
-	expectedMessages := []string{
-		"starting visibility extension monitoring",
-		"extending message visibility",
-	}
-
-	for _, expectedMsg := range expectedMessages {
-		found := false
-		for _, entry := range recorded.All() {
-			if entry.Message == expectedMsg {
-				found = true
-				break
-			}
+		for _, expected := range []string{
+			"starting visibility extension monitoring",
+			"extending message visibility",
+		} {
+			assert.True(t, containsLogMessage(recorded, expected),
+				"expected '%s' log message to be present", expected)
 		}
-		assert.True(t, found, "expected '%s' log message to be present", expectedMsg)
-	}
+
+		close(release)
+		<-done
+	})
 }
 
+// TestExtendToMaxAndStop asserts the monitor extends to the maximum window and stops.
+// It runs inside a synctest bubble, so the extension schedule plays out on a fake clock
+// and the test waits for no real time.
 func TestExtendToMaxAndStop(t *testing.T) {
-	ctx := context.Background()
-	mockSQS := &mocks.MockSQSClient{}
-	mockS3 := &mocks.MockS3Client{}
-	mockClient := &mocks.MockClient{}
-	mockClient.EXPECT().SQS().Return(mockSQS)
-	mockClient.EXPECT().S3().Return(mockS3)
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		mockSQS := &mocks.MockSQSClient{}
+		mockS3 := &mocks.MockS3Client{}
+		mockClient := &mocks.MockClient{}
+		mockClient.EXPECT().SQS().Return(mockSQS)
+		mockClient.EXPECT().S3().Return(mockS3)
 
-	// Provide a valid S3 event message
-	validS3Event := `{"Records":[{"eventName":"s3:ObjectCreated:Put","s3":{"bucket":{"name":"mybucket"},"object":{"key":"mykey1","size":15}}}]}`
-
-	mockSQS.EXPECT().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput)).Return(&sqs.ReceiveMessageOutput{
-		Messages: []types.Message{
-			{
+		validS3Event := `{"Records":[{"eventName":"s3:ObjectCreated:Put","s3":{"bucket":{"name":"mybucket"},"object":{"key":"mykey1","size":15}}}]}`
+		mockSQS.EXPECT().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput)).Return(&sqs.ReceiveMessageOutput{
+			Messages: []types.Message{{
 				Body:          aws.String(validS3Event),
 				MessageId:     aws.String("123"),
 				ReceiptHandle: aws.String("receipt-handle"),
-			},
-		},
-	}, nil)
+			}},
+		}, nil)
 
-	// Mock S3 GetObject to return content after a delay to trigger visibility extension
-	mockS3.EXPECT().GetObject(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-		// Add a delay to simulate processing time and trigger visibility extension
-		time.Sleep(100 * time.Millisecond)
-		return &s3.GetObjectOutput{
-			Body: io.NopCloser(strings.NewReader("line1\nline2\nline3")),
-		}, nil
+		// Hold the object open so the monitor keeps running. The read blocks, the
+		// monitor waits on its timer, and the bubble moves the clock to each
+		// extension in turn.
+		release := make(chan struct{})
+		mockS3.EXPECT().GetObject(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+			func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+				<-release
+				return &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader("line1\nline2\nline3"))}, nil
+			})
+
+		mockSQS.EXPECT().DeleteMessage(mock.Anything, mock.Anything).Return(&sqs.DeleteMessageOutput{}, nil)
+		mockSQS.EXPECT().ChangeMessageVisibility(mock.Anything, mock.Anything).Return(&sqs.ChangeMessageVisibilityOutput{}, nil)
+
+		core, recorded := observer.New(zap.InfoLevel)
+		set := componenttest.NewNopTelemetrySettings()
+		set.Logger = zap.New(core)
+
+		sink := new(consumertest.LogsSink)
+		visibilityExtensionInterval := 1 * time.Millisecond
+		visibilityTimeout := 5 * time.Millisecond
+		maxVisibilityWindow := 100 * time.Millisecond
+
+		b, err := metadata.NewTelemetryBuilder(set)
+		require.NoError(t, err)
+		params := receivertest.NewNopSettings(metadata.Type)
+		obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+			ReceiverID:             params.ID,
+			Transport:              "http",
+			ReceiverCreateSettings: params,
+		})
+		require.NoError(t, err)
+		w := worker.New(set, sink, mockClient, obsrecv, 4096, 1000,
+			visibilityExtensionInterval, visibilityTimeout, maxVisibilityWindow,
+			worker.WithTelemetryBuilder(b))
+
+		msg, err := mockClient.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
+		require.NoError(t, err)
+		require.Len(t, msg.Messages, 1)
+
+		done := make(chan struct{})
+		go func() {
+			w.ProcessMessage(ctx, msg.Messages[0], "myqueue", func() { close(done) })
+		}()
+
+		// Move past the max window so the monitor runs its whole schedule.
+		advanceFakeTime(150 * time.Millisecond)
+		synctest.Wait()
+
+		assert.True(t, containsLogMessage(recorded, "reaching maximum visibility window, extending to max and stopping"),
+			"expected 'reaching maximum visibility window' log message to be present")
+
+		close(release)
+		<-done
 	})
-
-	mockSQS.EXPECT().DeleteMessage(mock.Anything, mock.Anything).Return(&sqs.DeleteMessageOutput{}, nil)
-	mockSQS.EXPECT().ChangeMessageVisibility(mock.Anything, mock.Anything).Return(&sqs.ChangeMessageVisibilityOutput{}, nil)
-
-	// Set up zap observer
-	core, recorded := observer.New(zap.InfoLevel)
-	logger := zap.New(core)
-	set := componenttest.NewNopTelemetrySettings()
-	set.Logger = logger
-
-	sink := new(consumertest.LogsSink)
-	visibilityExtensionInterval := 1 * time.Millisecond
-	visibilityTimeout := 5 * time.Millisecond
-	maxVisibilityWindow := 100 * time.Millisecond // Short window to trigger max extension
-
-	b, err := metadata.NewTelemetryBuilder(set)
-	require.NoError(t, err)
-	params := receivertest.NewNopSettings(metadata.Type)
-	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
-		ReceiverID:             params.ID,
-		Transport:              "http",
-		ReceiverCreateSettings: params,
-	})
-	require.NoError(t, err)
-	w := worker.New(set, sink, mockClient, obsrecv, 4096, 1000, visibilityExtensionInterval, visibilityTimeout, maxVisibilityWindow, worker.WithTelemetryBuilder(b))
-
-	msg, err := mockClient.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
-	require.NoError(t, err)
-	require.Len(t, msg.Messages, 1)
-
-	done := make(chan struct{})
-	go func() {
-		w.ProcessMessage(ctx, msg.Messages[0], "myqueue", func() { close(done) })
-	}()
-
-	// Wait for processing to complete
-	<-done
-
-	// Wait for the visibility-extension goroutine to log that it hit the max window.
-	require.Eventually(t, func() bool {
-		return containsLogMessage(recorded, "reaching maximum visibility window, extending to max and stopping")
-	}, 5*time.Second, 10*time.Millisecond)
-
-	t.Logf("recorded logs:")
-	for i, entry := range recorded.All() {
-		t.Logf("  [%d] %s: %s", i, entry.Level, entry.Message)
-	}
-
-	// Check for the "reaching maximum visibility window" log message
-	found := false
-	for _, entry := range recorded.All() {
-		if strings.Contains(entry.Message, "reaching maximum visibility window, extending to max and stopping") {
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "expected 'reaching maximum visibility window' log message to be present")
 }
 
 func TestVisibilityExtensionContextCancellation(t *testing.T) {
-	defer fake.SetFakeConstructorForTest(t)()
+	synctest.Test(t, func(t *testing.T) {
+		defer fake.SetFakeConstructorForTest(t)()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	fakeAWS := client.NewClient(aws.Config{}).(*fake.AWS)
+		ctx, cancel := context.WithCancel(context.Background())
+		fakeAWS := client.NewClient(aws.Config{}).(*fake.AWS)
 
-	objectSet := map[string]map[string]string{
-		"mybucket": {
-			"mykey1": "line1\nline2\nline3",
-		},
-	}
-	fakeAWS.CreateObjects(t, objectSet)
-
-	// Set up zap observer
-	core, recorded := observer.New(zap.DebugLevel)
-	logger := zap.New(core)
-	set := componenttest.NewNopTelemetrySettings()
-	set.Logger = logger
-
-	sink := new(consumertest.LogsSink)
-	visibilityExtensionInterval := 1 * time.Millisecond
-	visibilityTimeout := 300 * time.Second
-	b, err := metadata.NewTelemetryBuilder(set)
-	require.NoError(t, err)
-	params := receivertest.NewNopSettings(metadata.Type)
-	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
-		ReceiverID:             params.ID,
-		Transport:              "http",
-		ReceiverCreateSettings: params,
-	})
-	require.NoError(t, err)
-	w := worker.New(set, sink, fakeAWS, obsrecv, 4096, 1000, visibilityExtensionInterval, visibilityTimeout, 6*time.Hour, worker.WithTelemetryBuilder(b))
-
-	msg, err := fakeAWS.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
-	require.NoError(t, err)
-	require.Len(t, msg.Messages, 1)
-
-	done := make(chan struct{})
-	go func() {
-		w.ProcessMessage(ctx, msg.Messages[0], "myqueue", func() { close(done) })
-	}()
-
-	// Cancel once the visibility-extension goroutine has started, so the cancellation
-	// reliably interrupts monitoring instead of racing its startup.
-	require.Eventually(t, func() bool {
-		return containsLogMessage(recorded, "starting visibility extension monitoring")
-	}, 5*time.Second, 10*time.Millisecond)
-	cancel()
-
-	// Wait for processing to complete
-	<-done
-
-	// Check for context cancellation log message
-	found := false
-	for _, entry := range recorded.All() {
-		if entry.Message == "visibility extension stopped due to context cancellation" {
-			found = true
-			break
+		objectSet := map[string]map[string]string{
+			"mybucket": {
+				"mykey1": "line1\nline2\nline3",
+			},
 		}
-	}
-	assert.True(t, found, "expected 'visibility extension stopped due to context cancellation' log message to be present")
+		fakeAWS.CreateObjects(t, objectSet)
+
+		// Set up zap observer
+		core, recorded := observer.New(zap.DebugLevel)
+		logger := zap.New(core)
+		set := componenttest.NewNopTelemetrySettings()
+		set.Logger = logger
+
+		sink := new(consumertest.LogsSink)
+		visibilityExtensionInterval := 1 * time.Millisecond
+		visibilityTimeout := 300 * time.Second
+		b, err := metadata.NewTelemetryBuilder(set)
+		require.NoError(t, err)
+		params := receivertest.NewNopSettings(metadata.Type)
+		obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+			ReceiverID:             params.ID,
+			Transport:              "http",
+			ReceiverCreateSettings: params,
+		})
+		require.NoError(t, err)
+		w := worker.New(set, sink, fakeAWS, obsrecv, 4096, 1000, visibilityExtensionInterval, visibilityTimeout, 6*time.Hour, worker.WithTelemetryBuilder(b))
+
+		msg, err := fakeAWS.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
+		require.NoError(t, err)
+		require.Len(t, msg.Messages, 1)
+
+		done := make(chan struct{})
+		go func() {
+			w.ProcessMessage(ctx, msg.Messages[0], "myqueue", func() { close(done) })
+		}()
+
+		// Let the monitor start, then cancel while it is still running. Inside the bubble
+		// the ordering is fixed, so the cancellation always interrupts monitoring.
+		synctest.Wait()
+		require.True(t, containsLogMessage(recorded, "starting visibility extension monitoring"))
+
+		cancel()
+		<-done
+		synctest.Wait()
+
+		assert.True(t, containsLogMessage(recorded, "visibility extension stopped due to context cancellation"),
+			"expected 'visibility extension stopped due to context cancellation' log message to be present")
+	})
 }
 
 func TestVisibilityExtensionErrorHandling(t *testing.T) {
-	ctx := context.Background()
-	mockSQS := &mocks.MockSQSClient{}
-	mockS3 := &mocks.MockS3Client{}
-	mockClient := &mocks.MockClient{}
-	mockClient.EXPECT().SQS().Return(mockSQS)
-	mockClient.EXPECT().S3().Return(mockS3)
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		mockSQS := &mocks.MockSQSClient{}
+		mockS3 := &mocks.MockS3Client{}
+		mockClient := &mocks.MockClient{}
+		mockClient.EXPECT().SQS().Return(mockSQS)
+		mockClient.EXPECT().S3().Return(mockS3)
 
-	// Provide a valid S3 event message
-	validS3Event := `{"Records":[{"eventName":"s3:ObjectCreated:Put","s3":{"bucket":{"name":"mybucket"},"object":{"key":"mykey1","size":15}}}]}`
+		// Provide a valid S3 event message
+		validS3Event := `{"Records":[{"eventName":"s3:ObjectCreated:Put","s3":{"bucket":{"name":"mybucket"},"object":{"key":"mykey1","size":15}}}]}`
 
-	mockSQS.EXPECT().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput)).Return(&sqs.ReceiveMessageOutput{
-		Messages: []types.Message{
-			{
-				Body:          aws.String(validS3Event),
-				MessageId:     aws.String("123"),
-				ReceiptHandle: aws.String("receipt-handle"),
+		mockSQS.EXPECT().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput)).Return(&sqs.ReceiveMessageOutput{
+			Messages: []types.Message{
+				{
+					Body:          aws.String(validS3Event),
+					MessageId:     aws.String("123"),
+					ReceiptHandle: aws.String("receipt-handle"),
+				},
 			},
-		},
-	}, nil)
+		}, nil)
 
-	// Mock S3 GetObject to return content after a delay
-	mockS3.EXPECT().GetObject(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-		// Add a delay to simulate processing time and trigger visibility extension
-		time.Sleep(10 * time.Millisecond)
-		return &s3.GetObjectOutput{
-			Body: io.NopCloser(strings.NewReader("line1\nline2\nline3")),
-		}, nil
+		// Hold the object open so the monitor attempts an extension.
+		release := make(chan struct{})
+		mockS3.EXPECT().GetObject(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			<-release
+			return &s3.GetObjectOutput{
+				Body: io.NopCloser(strings.NewReader("line1\nline2\nline3")),
+			}, nil
+		})
+
+		mockSQS.EXPECT().DeleteMessage(mock.Anything, mock.Anything).Return(&sqs.DeleteMessageOutput{}, nil)
+		mockSQS.EXPECT().ChangeMessageVisibility(mock.Anything, mock.Anything).Return(&sqs.ChangeMessageVisibilityOutput{}, errors.New("visibility extension error"))
+
+		// Set up zap observer
+		core, recorded := observer.New(zap.ErrorLevel)
+		logger := zap.New(core)
+		set := componenttest.NewNopTelemetrySettings()
+		set.Logger = logger
+
+		sink := new(consumertest.LogsSink)
+		visibilityExtensionInterval := 1 * time.Millisecond
+		visibilityTimeout := 300 * time.Second
+		b, err := metadata.NewTelemetryBuilder(set)
+		require.NoError(t, err)
+		params := receivertest.NewNopSettings(metadata.Type)
+		obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+			ReceiverID:             params.ID,
+			Transport:              "http",
+			ReceiverCreateSettings: params,
+		})
+		require.NoError(t, err)
+		w := worker.New(set, sink, mockClient, obsrecv, 4096, 1000, visibilityExtensionInterval, visibilityTimeout, 6*time.Hour, worker.WithTelemetryBuilder(b))
+
+		msg, err := mockClient.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
+		require.NoError(t, err)
+		require.Len(t, msg.Messages, 1)
+
+		// Process the message - this will take time due to S3 operations
+		done := make(chan struct{})
+		go func() {
+			w.ProcessMessage(ctx, msg.Messages[0], "myqueue", func() { close(done) })
+		}()
+		// Move past one extension interval so the monitor tries, and fails, to extend.
+		advanceFakeTime(10 * time.Millisecond)
+		synctest.Wait()
+
+		assert.True(t, containsLogMessage(recorded, "failed to extend message visibility"),
+			"expected the extension failure to be logged")
+
+		close(release)
+		<-done
 	})
-
-	mockSQS.EXPECT().DeleteMessage(mock.Anything, mock.Anything).Return(&sqs.DeleteMessageOutput{}, nil)
-	mockSQS.EXPECT().ChangeMessageVisibility(mock.Anything, mock.Anything).Return(&sqs.ChangeMessageVisibilityOutput{}, errors.New("visibility extension error"))
-
-	// Set up zap observer
-	core, recorded := observer.New(zap.ErrorLevel)
-	logger := zap.New(core)
-	set := componenttest.NewNopTelemetrySettings()
-	set.Logger = logger
-
-	sink := new(consumertest.LogsSink)
-	visibilityExtensionInterval := 1 * time.Millisecond
-	visibilityTimeout := 300 * time.Second
-	b, err := metadata.NewTelemetryBuilder(set)
-	require.NoError(t, err)
-	params := receivertest.NewNopSettings(metadata.Type)
-	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
-		ReceiverID:             params.ID,
-		Transport:              "http",
-		ReceiverCreateSettings: params,
-	})
-	require.NoError(t, err)
-	w := worker.New(set, sink, mockClient, obsrecv, 4096, 1000, visibilityExtensionInterval, visibilityTimeout, 6*time.Hour, worker.WithTelemetryBuilder(b))
-
-	msg, err := mockClient.SQS().ReceiveMessage(ctx, new(sqs.ReceiveMessageInput))
-	require.NoError(t, err)
-	require.Len(t, msg.Messages, 1)
-
-	// Process the message - this will take time due to S3 operations
-	done := make(chan struct{})
-	go func() {
-		w.ProcessMessage(ctx, msg.Messages[0], "myqueue", func() { close(done) })
-	}()
-	// Wait for processing to complete
-	<-done
-
-	// Wait for the visibility-extension goroutine to log the extension failure.
-	require.Eventually(t, func() bool {
-		return containsLogMessage(recorded, "failed to extend message visibility")
-	}, 5*time.Second, 10*time.Millisecond)
-
-	t.Logf("recorded logs:")
-	for i, entry := range recorded.All() {
-		t.Logf("  [%d] %s: %s", i, entry.Level, entry.Message)
-	}
-
-	// Check for error log messages
-	errorMessages := []string{
-		"failed to extend message visibility",
-	}
-
-	for _, expectedMsg := range errorMessages {
-		found := false
-		for _, entry := range recorded.All() {
-			if strings.Contains(entry.Message, expectedMsg) {
-				found = true
-				break
-			}
-		}
-		assert.True(t, found, "expected error message containing '%s' to be present", expectedMsg)
-	}
 }
 
 func TestProcessMessageWithFilters(t *testing.T) {
@@ -1132,6 +1088,13 @@ func TestProcessMessageWithFilters(t *testing.T) {
 // containsLogMessage reports whether any recorded log entry's message contains
 // substr. It is used as an Eventually condition to wait for a background goroutine
 // to emit an expected log line instead of sleeping a fixed duration.
+// advanceFakeTime moves a synctest bubble's clock forward. It is not a wait: inside a
+// bubble time only moves while every goroutine is blocked, so this returns straight
+// away in real time and always resolves timers in the same order.
+func advanceFakeTime(d time.Duration) {
+	time.Sleep(d)
+}
+
 func containsLogMessage(recorded *observer.ObservedLogs, substr string) bool {
 	for _, entry := range recorded.All() {
 		if strings.Contains(entry.Message, substr) {

--- a/receiver/awss3eventreceiver/receiver.go
+++ b/receiver/awss3eventreceiver/receiver.go
@@ -49,7 +49,7 @@ type logsReceiver struct {
 	startOnce sync.Once
 	stopOnce  sync.Once
 
-	pollCancel context.CancelFunc
+	cancel     context.CancelFunc
 	pollDone   chan struct{}
 	workerPool sync.Pool
 	workerWg   sync.WaitGroup
@@ -156,16 +156,20 @@ func (r *logsReceiver) Start(_ context.Context, host component.Host) error {
 		// Create message channel
 		r.msgChan = make(chan workerMessage, r.cfg.Workers*2)
 
+		// A single cancellable context governs the workers and the poller, so Shutdown
+		// can interrupt an in-flight ProcessMessage (a stalled read or a downstream
+		// consume) rather than blocking on workerWg.Wait until it returns on its own.
+		runCtx, cancel := context.WithCancel(ctx)
+		r.cancel = cancel
+
 		// Start fixed number of workers
 		for i := 0; i < r.cfg.Workers; i++ {
 			r.workerWg.Add(1)
-			go r.runWorker(ctx)
+			go r.runWorker(runCtx)
 		}
 
-		pollCtx, pollCancel := context.WithCancel(ctx)
-		r.pollCancel = pollCancel
 		r.pollDone = make(chan struct{})
-		go r.poll(pollCtx, func() {
+		go r.poll(runCtx, func() {
 			close(r.pollDone)
 		})
 	})
@@ -203,8 +207,8 @@ func (r *logsReceiver) runWorker(ctx context.Context) {
 
 func (r *logsReceiver) Shutdown(ctx context.Context) error {
 	r.stopOnce.Do(func() {
-		if r.pollCancel != nil {
-			r.pollCancel()
+		if r.cancel != nil {
+			r.cancel()
 		}
 		if r.pollDone != nil {
 			<-r.pollDone

--- a/receiver/awss3eventreceiver/receiver_cancel_test.go
+++ b/receiver/awss3eventreceiver/receiver_cancel_test.go
@@ -1,0 +1,86 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awss3eventreceiver_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+
+	"github.com/observiq/bindplane-otel-contrib/internal/aws/client"
+	"github.com/observiq/bindplane-otel-contrib/internal/aws/fake"
+	rcvr "github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver"
+	"github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver/internal/metadata"
+)
+
+// TestShutdownCancelsInflightConsume asserts that Shutdown cancels a worker that is
+// blocked inside ConsumeLogs. The worker context must be cancellable; if workers run on
+// context.Background(), an in-flight consume never unblocks and Shutdown hangs on
+// workerWg.Wait().
+func TestShutdownCancelsInflightConsume(t *testing.T) {
+	defer fake.SetFakeConstructorForTest(t)()
+
+	ctx := context.Background()
+	fakeAWS := client.NewClient(aws.Config{}).(*fake.AWS)
+	fakeAWS.CreateObjects(t, map[string]map[string]string{
+		"mybucket": {"mykey1": "line1\nline2\n"},
+	})
+
+	f := rcvr.NewFactory()
+	cfg := f.CreateDefaultConfig().(*rcvr.Config)
+	cfg.SQSQueueURL = "https://sqs.us-west-2.amazonaws.com/123456789012/test-queue"
+	cfg.StandardPollInterval = 10 * time.Millisecond
+
+	entered := make(chan struct{})
+	var once sync.Once
+	blocking, err := consumer.NewLogs(func(cctx context.Context, _ plog.Logs) error {
+		once.Do(func() { close(entered) })
+		<-cctx.Done() // block until the worker context is cancelled by Shutdown
+		// Return success so the object acks and the shared fake queue drains, rather
+		// than leaking a nacked message into other tests' cleanup assertions.
+		return nil
+	})
+	require.NoError(t, err)
+
+	set := receivertest.NewNopSettings(metadata.Type)
+	receiver, err := f.CreateLogs(ctx, set, cfg, blocking)
+	require.NoError(t, err)
+
+	host := componenttest.NewNopHost()
+	require.NoError(t, receiver.Start(ctx, host))
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker never reached ConsumeLogs")
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- receiver.Shutdown(ctx) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Shutdown hung: the worker context was never cancelled")
+	}
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/archive.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/archive.go
@@ -332,6 +332,13 @@ func (a *archiveProducer) consumeEntry(ctx context.Context, entry archiveEntry, 
 				yield(nil, limitErr)
 				return true
 			}
+			// Content this entry cannot use stops the entry, not the object. The
+			// other entries still read, so failing here would send them to the
+			// dead-letter queue alongside the bad one.
+			if isUnusableEntry(rerr) {
+				a.skipEntry(ctx, entry.Name(), rerr)
+				return false
+			}
 			// A per-record decode error: forward it so the worker skips just this
 			// record, consistent with the non-archive path.
 			if !yield(nil, rerr) {
@@ -401,4 +408,18 @@ func (c *cappingReader) Read(p []byte) (int, error) {
 		return 0, c.tripped
 	}
 	return n, err
+}
+
+// isUnusableEntry reports content that reads the same way on a retry. It ends the entry
+// rather than the object, so the remaining entries still reach the pipeline.
+func isUnusableEntry(err error) bool {
+	if IsTruncatedObject(err) || errors.Is(err, ErrNotArrayOrKnownObject) {
+		return true
+	}
+	var unsupported ErrUnsupportedContent
+	if errors.As(err, &unsupported) {
+		return true
+	}
+	var corrupt ErrCorruptArchive
+	return errors.As(err, &corrupt)
 }

--- a/receiver/gcspubsubeventreceiver/internal/worker/archive_truncated_entry_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/archive_truncated_entry_test.go
@@ -1,0 +1,77 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestArchive_TruncatedEntryIsSkipped asserts a truncated entry drops that entry alone.
+// The other entries read fine, so failing the whole object would discard good records
+// and send them to the dead-letter queue with the bad one.
+func TestArchive_TruncatedEntryIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	good := tarFile{name: "a.log", body: []byte("kept1\nkept2\n")}
+	big := tarFile{name: "b.log", body: []byte(strings.Repeat("padding-line\n", 200))}
+	full := tarBytes(t, []tarFile{good, big})
+
+	// Cut inside the second entry's data, so its header reads and its body does not.
+	firstEntryEnd := 512 + roundUp512(len(good.body))
+	cut := firstEntryEnd + 512 + 100
+	require.Less(t, cut, len(full))
+
+	core, logs := observer.New(zap.WarnLevel)
+	ap := &archiveProducer{
+		stream: LogStream{Name: "o", MaxLogSize: testMaxLogSize, Logger: zap.New(core), TryDecoding: true},
+		open:   func() (archiveBackend, error) { return newTarBackend(bytes.NewReader(full[:cut])), nil },
+		limits: defaultArchiveLimits(),
+	}
+
+	seq, err := ap.records(context.Background(), Offset{})
+	require.NoError(t, err)
+
+	var bodies []string
+	var fatal error
+	for rec, rerr := range seq {
+		if rerr != nil {
+			if isDLQConditionError(rerr) {
+				fatal = rerr
+			}
+			continue
+		}
+		bodies = append(bodies, rec.(string))
+	}
+
+	require.NoError(t, fatal, "a truncated entry must not fail the whole object")
+	require.GreaterOrEqual(t, len(bodies), 2)
+	require.Equal(t, []string{"kept1", "kept2"}, bodies[:2], "the readable entry is still delivered")
+	require.Positive(t, logs.FilterMessageSnippet("skipping unparseable archive entry").Len(),
+		"the skipped entry must be reported")
+}
+
+func roundUp512(n int) int {
+	if n%512 == 0 {
+		return n
+	}
+	return n + (512 - n%512)
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/json_parser.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/json_parser.go
@@ -236,8 +236,10 @@ func (p *jsonParser) yieldArray(startOffset int64) iter.Seq2[any, error] {
 				if errors.Is(err, io.EOF) {
 					return
 				}
-				// unexpected end of file, not much we can do here
+				// The object stops part way through a record. The missing bytes
+				// were never written, so a retry reads the same thing.
 				if errors.Is(err, io.ErrUnexpectedEOF) {
+					yield(nil, ErrTruncatedObject{Err: err})
 					return
 				}
 				// unexpected error, return it
@@ -253,6 +255,12 @@ func (p *jsonParser) yieldArray(startOffset int64) iter.Seq2[any, error] {
 					return
 				}
 			}
+		}
+		// The loop above also ends when the object stops part way through, because
+		// More reports no further element either way. A complete array closes with a
+		// delimiter, so anything else here means the bytes ran out early.
+		if _, err := p.decoder.Token(); err != nil {
+			yield(nil, ErrTruncatedObject{Err: err})
 		}
 	}
 }

--- a/receiver/gcspubsubeventreceiver/internal/worker/json_truncated_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/json_truncated_test.go
@@ -1,0 +1,77 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestJSONParser_TruncatedObjectRoutesToDLQ asserts a JSON array cut short reports the
+// truncation rather than ending like a clean read. Ending quietly makes the worker ack
+// the object and drop every record after the cut.
+func TestJSONParser_TruncatedObjectRoutesToDLQ(t *testing.T) {
+	t.Parallel()
+
+	var body bytes.Buffer
+	body.WriteString("[")
+	for i := 0; i < 400; i++ {
+		if i > 0 {
+			body.WriteString(",")
+		}
+		fmt.Fprintf(&body, `{"host":"h-%04d","msg":"padding padding padding"}`, i)
+	}
+
+	raw := body.Bytes()
+	stream := LogStream{
+		Name:        "logs/object.json",
+		Body:        io.NopCloser(bytes.NewReader(raw[:len(raw)/2])),
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+
+	ctx := context.Background()
+	reader, err := stream.BufferedReader(ctx)
+	require.NoError(t, err)
+
+	parser, err := newParser(ctx, stream, reader)
+	require.NoError(t, err)
+
+	logs, err := parser.Parse(ctx, 0)
+	require.NoError(t, err)
+
+	var records int
+	var last error
+	for _, rerr := range logs {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		records++
+	}
+
+	require.Positive(t, records, "records before the cut are still delivered")
+	require.Error(t, last, "a truncated array must reach the caller")
+	require.True(t, IsTruncatedObject(last))
+	require.False(t, IsStreamRead(last), "truncation is not a broken connection")
+	require.True(t, isDLQConditionError(last), "it must route to the dead-letter queue")
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/line_parser.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/line_parser.go
@@ -16,6 +16,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"iter"
@@ -51,12 +52,22 @@ func (p *lineParser) Parse(_ context.Context, startOffset int64) (logs iter.Seq2
 		for {
 			lineBytes, _, err := p.reader.ReadLine()
 			if err != nil {
-				if err == io.EOF {
+				// A decompressing reader can wrap the sentinel.
+				if errors.Is(err, io.EOF) {
 					return
 				}
-				if !yield(nil, err) {
+				// An object that stops mid-record is truncated rather than
+				// unreachable. A decompressor reports a live connection failure
+				// as that failure, so this only fires on missing bytes.
+				if errors.Is(err, io.ErrUnexpectedEOF) {
+					yield(nil, ErrTruncatedObject{Err: err})
 					return
 				}
+				// A read error is terminal. Every later ReadLine returns the same
+				// error, so continuing spins forever. It is marked so the caller
+				// fails the object instead of acking a partial read.
+				yield(nil, ErrStreamRead{Err: err})
+				return
 			}
 
 			// only yield non-empty lines

--- a/receiver/gcspubsubeventreceiver/internal/worker/line_parser_termination_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/line_parser_termination_test.go
@@ -1,0 +1,136 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/observiq/bindplane-otel-contrib/receiver/gcspubsubeventreceiver/internal/worker"
+)
+
+// yieldBudget caps the iterations a test consumer accepts. A parser that does not
+// terminate spins until the go test timeout.
+const yieldBudget = 1000
+
+// errAfterReader serves prefix, then returns err on every later read.
+type errAfterReader struct {
+	prefix []byte
+	err    error
+}
+
+func (r *errAfterReader) Read(p []byte) (int, error) {
+	if len(r.prefix) > 0 {
+		n := copy(p, r.prefix)
+		r.prefix = r.prefix[n:]
+		return n, nil
+	}
+	return 0, r.err
+}
+
+// drain consumes the sequence and continues past errors, as processObject does.
+// exhausted reports that the sequence ran past yieldBudget.
+func drain(t *testing.T, logs func(func(any, error) bool)) (records []any, errs []error, exhausted bool) {
+	t.Helper()
+
+	iterations := 0
+	for record, err := range logs {
+		iterations++
+		if iterations > yieldBudget {
+			exhausted = true
+			break
+		}
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		records = append(records, record)
+	}
+	return records, errs, exhausted
+}
+
+func TestLineParser_TerminatesOnPersistentReadError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("connection reset by peer")
+	reader := &errAfterReader{prefix: []byte("first\nsecond\n"), err: readErr}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted, "parser did not terminate on a persistent read error")
+	require.Equal(t, []any{"first", "second"}, records, "records read before the error should still be yielded")
+	require.Len(t, errs, 1, "the terminal read error should be yielded exactly once")
+	require.ErrorIs(t, errs[0], readErr)
+	require.True(t, worker.IsStreamRead(errs[0]),
+		"a broken stream must be marked so the caller fails the object instead of acking a partial read")
+}
+
+func TestLineParser_TerminatesOnCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\n"), err: context.Canceled}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted, "parser did not terminate on a cancelled context")
+	require.Equal(t, []any{"first"}, records)
+	require.Len(t, errs, 1)
+	require.ErrorIs(t, errs[0], context.Canceled)
+}
+
+func TestLineParser_TerminatesOnExceededDeadline(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\n"), err: context.DeadlineExceeded}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	_, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted, "parser did not terminate on an exceeded deadline")
+	require.Len(t, errs, 1)
+	require.ErrorIs(t, errs[0], context.DeadlineExceeded)
+}
+
+func TestLineParser_TerminatesOnWrappedEOF(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\nsecond\n"), err: fmt.Errorf("decompress: %w", io.EOF)}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted, "parser did not terminate on a wrapped io.EOF")
+	require.Equal(t, []any{"first", "second"}, records)
+	require.Empty(t, errs, "a wrapped io.EOF is the end of the stream rather than a parse failure")
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/stream_error.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/stream_error.go
@@ -1,0 +1,64 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrStreamRead marks a failure to read an object to completion. The bytes after the
+// break never reached the consumer, and a later attempt can still read them.
+//
+// It separates a broken stream from a record the parser cannot use. A bad record is
+// skipped, because retrying it gives the same result. A broken stream fails the whole
+// object, so the message stays queued and resumes from the saved offset.
+type ErrStreamRead struct {
+	Err error
+}
+
+func (e ErrStreamRead) Error() string {
+	return fmt.Sprintf("read object stream: %v", e.Err)
+}
+
+func (e ErrStreamRead) Unwrap() error { return e.Err }
+
+// IsStreamRead reports that the object could not be read to completion.
+func IsStreamRead(err error) bool {
+	var streamRead ErrStreamRead
+	return errors.As(err, &streamRead)
+}
+
+// ErrTruncatedObject marks an object that ends part way through a record. The bytes
+// that are missing were never written, so a later read returns the same thing.
+//
+// It separates truncation from a broken connection. A broken connection retries. A
+// truncated object goes to the dead-letter queue, because redelivering it would only
+// fail the same way.
+type ErrTruncatedObject struct {
+	Err error
+}
+
+func (e ErrTruncatedObject) Error() string {
+	return fmt.Sprintf("object ends mid-record: %v", e.Err)
+}
+
+func (e ErrTruncatedObject) Unwrap() error { return e.Err }
+
+// IsTruncatedObject reports that the object ends part way through a record.
+func IsTruncatedObject(err error) bool {
+	var truncated ErrTruncatedObject
+	return errors.As(err, &truncated)
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/truncated_dlq_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/truncated_dlq_test.go
@@ -1,0 +1,88 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestTruncatedObjectRoutesToDLQ asserts a truncated object is a dead-letter condition.
+// Redelivering it reads the same bytes, so retrying never drains the queue.
+func TestTruncatedObjectRoutesToDLQ(t *testing.T) {
+	t.Parallel()
+
+	err := error(ErrTruncatedObject{Err: io.ErrUnexpectedEOF})
+	require.True(t, isDLQConditionError(err), "a truncated object must be a DLQ condition")
+	require.True(t, isDLQConditionError(fmt.Errorf("parse logs: %w", err)),
+		"the condition must survive wrapping")
+	require.Equal(t, dlqErrorKindUnsupportedFile, dlqConditionKind(err))
+}
+
+// TestTruncatedGzipIsNotRetryable covers the reported case end to end. A gzip object cut
+// short decompresses to a partial record, and that must not requeue the message.
+func TestTruncatedGzipIsNotRetryable(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	for i := 0; i < 5000; i++ {
+		_, err := zw.Write([]byte("line-of-text-padding-padding-padding\n"))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+
+	full := buf.Bytes()
+	stream := LogStream{
+		Name:        "logs/object.gz",
+		Body:        io.NopCloser(bytes.NewReader(full[:len(full)/2])),
+		MaxLogSize:  4096,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+
+	ctx := context.Background()
+	reader, err := stream.BufferedReader(ctx)
+	require.NoError(t, err)
+
+	parser, err := newParser(ctx, stream, reader)
+	require.NoError(t, err)
+
+	logs, err := parser.Parse(ctx, 0)
+	require.NoError(t, err)
+
+	var records int
+	var last error
+	for _, rerr := range logs {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		records++
+	}
+
+	require.Positive(t, records, "records before the cut are still delivered")
+	require.Error(t, last)
+	require.False(t, IsStreamRead(last), "a truncated gzip must not be retried")
+	require.True(t, IsTruncatedObject(last))
+	require.True(t, isDLQConditionError(last), "it must route to the dead-letter queue")
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/truncated_object_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/truncated_object_test.go
@@ -1,0 +1,49 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/observiq/bindplane-otel-contrib/receiver/gcspubsubeventreceiver/internal/worker"
+)
+
+// TestLineParser_TruncatedObjectIsNotRetryable asserts a stream cut short mid-record is
+// reported as content the receiver cannot use, rather than as a broken connection.
+// Retrying reads the same truncated bytes, so a retryable answer redelivers forever.
+func TestLineParser_TruncatedObjectIsNotRetryable(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\nsecond\n"), err: io.ErrUnexpectedEOF}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted, "the parser must stop rather than spin")
+	require.Equal(t, []any{"first", "second"}, records, "records read before the cut are still delivered")
+	require.Len(t, errs, 1)
+
+	require.False(t, worker.IsStreamRead(errs[0]),
+		"a truncated object is not a broken connection, so it must not be retried")
+	require.True(t, worker.IsTruncatedObject(errs[0]),
+		"a truncated object must be marked so the caller can route it")
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/worker.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/worker.go
@@ -383,6 +383,12 @@ func (w *Worker) consumeLogsFromGCSObject(ctx context.Context, bucket, object st
 			if isDLQConditionError(err) {
 				return err
 			}
+			// A broken stream is fatal for the whole object. Acking here would drop
+			// every record after the break with no way to recover them, so fail and
+			// let the message redeliver and resume from the saved offset.
+			if IsStreamRead(err) {
+				return err
+			}
 			// Skipping the individual record rather than nacking the whole message, since
 			// retrying a malformed record would produce the same error.  The remaining
 			// records in the object can still be ingested successfully.
@@ -481,6 +487,11 @@ func dlqConditionKind(err error) dlqErrorKind {
 	}
 	// Unsupported file type detected during parsing.
 	if errors.Is(err, ErrNotArrayOrKnownObject) {
+		return dlqErrorKindUnsupportedFile
+	}
+	// A truncated object is unusable for the same reason: reading it again returns
+	// the same bytes.
+	if IsTruncatedObject(err) {
 		return dlqErrorKindUnsupportedFile
 	}
 	// Recognized but unsupported content (image, PDF, unknown binary).


### PR DESCRIPTION
### Proposed Change

Currently `line_parser.go` yields a read error and then falls through without a `continue`. The bare `for {}` loop has no safe exit for the circumstance. Once a context is cancelled, every subsequent `ReadLine` returns `context.Canceled` and the loop spins on it infinitely until systemd sends a SIGKILL.

A customer support bundle shows this as 1.1 million identical error lines from six Pub/Sub messages, around 10k per second. The reload from a rollout never finishes, so systemd kills the collector. The unacked messages then redeliver and the same objects reprocess from the start.

A read error is now terminal: the parser surfaces it once and stops.

A terminal read used to ack the message and delete the saved offset, because the worker logs a yielded error and keeps going. Every record after the break was lost. The parser now marks a terminal read, and the worker fails the object. The message stays queued and resumes from its offset.

`io.ErrUnexpectedEOF` means bytes are missing rather than unreachable, so a retry reads the same object. A truncated object goes to the dead-letter queue instead of the retry path. Inside an archive, the parser drops only that entry.

The visibility tests now run in `testing/synctest` bubbles on a fake clock, replacing the real-time sleeps.

Both receivers carry the identical loop, so both are fixed here. A refactor will happen later to combine shared code.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
