### PR TITLE
fix(gcspubsubeventreceiver,awss3eventreceiver): drop records truncated by a broken stream [PIPE-1415]

### DIFF
--- a/receiver/awss3eventreceiver/internal/worker/buffered_reader.go
+++ b/receiver/awss3eventreceiver/internal/worker/buffered_reader.go
@@ -23,6 +23,10 @@ import (
 type BufferedReader interface {
 	Offset() int64
 	ReadLine() (line []byte, isPrefix bool, err error)
+	// ReadSlice reads up to and including delim. It reports the read error with any
+	// bytes already held. ReadLine does not.
+	ReadSlice(delim byte) (line []byte, err error)
+	UnreadByte() error
 	Peek(n int) ([]byte, error)
 	io.Reader
 }
@@ -56,6 +60,16 @@ func (r *bufferedReader) Offset() int64 {
 // ReadLine reads a line from the reader.
 func (r *bufferedReader) ReadLine() (line []byte, isPrefix bool, err error) {
 	return r.reader.ReadLine()
+}
+
+// ReadSlice reads from the reader up to and including delim.
+func (r *bufferedReader) ReadSlice(delim byte) (line []byte, err error) {
+	return r.reader.ReadSlice(delim)
+}
+
+// UnreadByte returns the most recently read byte to the buffer.
+func (r *bufferedReader) UnreadByte() error {
+	return r.reader.UnreadByte()
 }
 
 // Read reads the given number of bytes.

--- a/receiver/awss3eventreceiver/internal/worker/line_parser.go
+++ b/receiver/awss3eventreceiver/internal/worker/line_parser.go
@@ -15,6 +15,7 @@
 package worker
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -26,6 +27,10 @@ import (
 
 type lineParser struct {
 	reader BufferedReader
+
+	// offset is the position after the last record sent to the consumer. It differs
+	// from the reader position. A truncated record is read but never emitted.
+	offset int64
 }
 
 // NewLineParser creates a new line parser.
@@ -36,7 +41,7 @@ func NewLineParser(reader BufferedReader) LogParser {
 }
 
 func (p *lineParser) Offset() int64 {
-	return p.reader.Offset()
+	return p.offset
 }
 
 // Parse parses the log records from the reader using ReadLine.
@@ -46,11 +51,12 @@ func (p *lineParser) Parse(_ context.Context, startOffset int64) (logs iter.Seq2
 	if err != nil {
 		return nil, fmt.Errorf("discard to offset: %w", err)
 	}
+	p.offset = p.reader.Offset()
 
 	// logs is a sequence of log records that can be used with the provided appender
 	return func(yield func(any, error) bool) {
 		for {
-			lineBytes, _, err := p.reader.ReadLine()
+			lineBytes, _, err := readLine(p.reader)
 			if err != nil {
 				// A decompressing reader can wrap the sentinel.
 				if errors.Is(err, io.EOF) {
@@ -70,6 +76,9 @@ func (p *lineParser) Parse(_ context.Context, startOffset int64) (logs iter.Seq2
 				return
 			}
 
+			// Advance past consumed bytes, even for an empty line.
+			p.offset = p.reader.Offset()
+
 			// only yield non-empty lines
 			if len(lineBytes) > 0 {
 				if !yield(string(lineBytes), nil) {
@@ -78,6 +87,49 @@ func (p *lineParser) Parse(_ context.Context, startOffset int64) (logs iter.Seq2
 			}
 		}
 	}, nil
+}
+
+// readLine is bufio.Reader.ReadLine with the read error preserved.
+//
+// ReadLine returns (line, nil) when it holds bytes, even after a failed read. A
+// truncated record then looks like a final record with no newline.
+func readLine(r BufferedReader) (line []byte, isPrefix bool, err error) {
+	line, err = r.ReadSlice('\n')
+
+	if errors.Is(err, bufio.ErrBufferFull) {
+		// A record longer than the buffer, split at max_log_size. Return a trailing
+		// '\r' to the buffer, so the next chunk can find a split "\r\n".
+		if len(line) > 0 && line[len(line)-1] == '\r' {
+			if unreadErr := r.UnreadByte(); unreadErr != nil {
+				return nil, false, unreadErr
+			}
+			line = line[:len(line)-1]
+		}
+		return line, true, nil
+	}
+
+	if err != nil {
+		// Bytes with no terminator. At end of stream they are the final record. Under
+		// any other error they are a fragment, so drop them.
+		if errors.Is(err, io.EOF) && len(line) > 0 {
+			return line, false, nil
+		}
+		return nil, false, err
+	}
+
+	return trimLineEnding(line), false, nil
+}
+
+// trimLineEnding drops the trailing newline, and a "\r" before it.
+func trimLineEnding(line []byte) []byte {
+	if len(line) > 0 && line[len(line)-1] == '\n' {
+		drop := 1
+		if len(line) > 1 && line[len(line)-2] == '\r' {
+			drop = 2
+		}
+		line = line[:len(line)-drop]
+	}
+	return line
 }
 
 // AppendLogBody appends the log record to the log record body using SetStr.

--- a/receiver/awss3eventreceiver/internal/worker/line_parser_termination_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/line_parser_termination_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -133,4 +134,121 @@ func TestLineParser_TerminatesOnWrappedEOF(t *testing.T) {
 	require.False(t, exhausted, "parser did not terminate on a wrapped io.EOF")
 	require.Equal(t, []any{"first", "second"}, records)
 	require.Empty(t, errs, "a wrapped io.EOF is the end of the stream rather than a parse failure")
+}
+
+// TestLineParser_DropsRecordTruncatedByAReadError asserts the parser drops bytes left
+// over when the stream breaks mid-record. Emitting them splits one record in two.
+func TestLineParser_DropsRecordTruncatedByAReadError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("connection reset by peer")
+	reader := &errAfterReader{prefix: []byte("complete\ntrunca"), err: readErr}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted)
+	require.Equal(t, []any{"complete"}, records,
+		"the fragment left by the broken stream must not be emitted as a record")
+	require.Len(t, errs, 1)
+	require.ErrorIs(t, errs[0], readErr)
+}
+
+// TestLineParser_KeepsFinalLineWithoutTrailingNewline asserts the parser emits the
+// trailing bytes at end of stream. io.EOF separates this case from a truncated read.
+func TestLineParser_KeepsFinalLineWithoutTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("complete\nfinal"), err: io.EOF}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted)
+	require.Equal(t, []any{"complete", "final"}, records,
+		"an unterminated final line is a whole record at end of stream")
+	require.Empty(t, errs)
+}
+
+// TestLineParser_KeepsFinalLineOnWrappedEOF covers a wrapped io.EOF.
+func TestLineParser_KeepsFinalLineOnWrappedEOF(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("complete\nfinal"), err: fmt.Errorf("decompress: %w", io.EOF)}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted)
+	require.Equal(t, []any{"complete", "final"}, records)
+	require.Empty(t, errs)
+}
+
+// TestLineParser_TrimsCRLF covers line-ending handling under ReadSlice.
+func TestLineParser_TrimsCRLF(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\r\nsecond\r\n"), err: io.EOF}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, _ := drain(t, logs)
+	require.Equal(t, []any{"first", "second"}, records)
+	require.Empty(t, errs)
+}
+
+// TestLineParser_SplitsOversizedLine asserts chunks of an oversized record reassemble
+// to the original, including a "\r\n" on the buffer boundary.
+func TestLineParser_SplitsOversizedLine(t *testing.T) {
+	t.Parallel()
+
+	const bufSize = 16
+	for _, ending := range []string{"\n", "\r\n"} {
+		body := strings.Repeat("x", bufSize*3-1) + ending
+		reader := &errAfterReader{prefix: []byte(body), err: io.EOF}
+		parser := worker.NewLineParser(worker.NewBufferedReader(reader, bufSize))
+
+		logs, err := parser.Parse(context.Background(), 0)
+		require.NoError(t, err)
+
+		records, errs, _ := drain(t, logs)
+		require.Empty(t, errs)
+
+		var joined string
+		for _, r := range records {
+			joined += r.(string)
+		}
+		require.Equal(t, strings.Repeat("x", bufSize*3-1), joined,
+			"chunks of an oversized record should reassemble without the line ending")
+	}
+}
+
+// TestLineParser_OffsetStopsAtTheLastDeliveredRecord asserts the resume position stops
+// at the last emitted record. Otherwise redelivery replays the record tail.
+func TestLineParser_OffsetStopsAtTheLastDeliveredRecord(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\ntrunca"), err: errors.New("connection reset by peer")}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, _ := drain(t, logs)
+	require.Equal(t, []any{"first"}, records)
+	require.Len(t, errs, 1)
+
+	require.Equal(t, int64(len("first\n")), parser.Offset(),
+		"the resume position should sit at the end of the last delivered record")
 }

--- a/receiver/gcspubsubeventreceiver/internal/worker/buffered_reader.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/buffered_reader.go
@@ -23,6 +23,10 @@ import (
 type BufferedReader interface {
 	Offset() int64
 	ReadLine() (line []byte, isPrefix bool, err error)
+	// ReadSlice reads up to and including delim. It reports the read error with any
+	// bytes already held. ReadLine does not.
+	ReadSlice(delim byte) (line []byte, err error)
+	UnreadByte() error
 	Peek(n int) ([]byte, error)
 	io.Reader
 }
@@ -56,6 +60,16 @@ func (r *bufferedReader) Offset() int64 {
 // ReadLine reads a line from the reader.
 func (r *bufferedReader) ReadLine() (line []byte, isPrefix bool, err error) {
 	return r.reader.ReadLine()
+}
+
+// ReadSlice reads from the reader up to and including delim.
+func (r *bufferedReader) ReadSlice(delim byte) (line []byte, err error) {
+	return r.reader.ReadSlice(delim)
+}
+
+// UnreadByte returns the most recently read byte to the buffer.
+func (r *bufferedReader) UnreadByte() error {
+	return r.reader.UnreadByte()
 }
 
 // Read reads the given number of bytes.

--- a/receiver/gcspubsubeventreceiver/internal/worker/line_parser.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/line_parser.go
@@ -15,6 +15,7 @@
 package worker
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -26,6 +27,10 @@ import (
 
 type lineParser struct {
 	reader BufferedReader
+
+	// offset is the position after the last record sent to the consumer. It differs
+	// from the reader position. A truncated record is read but never emitted.
+	offset int64
 }
 
 // NewLineParser creates a new line parser.
@@ -36,7 +41,7 @@ func NewLineParser(reader BufferedReader) LogParser {
 }
 
 func (p *lineParser) Offset() int64 {
-	return p.reader.Offset()
+	return p.offset
 }
 
 // Parse parses the log records from the reader using ReadLine.
@@ -46,11 +51,12 @@ func (p *lineParser) Parse(_ context.Context, startOffset int64) (logs iter.Seq2
 	if err != nil {
 		return nil, fmt.Errorf("discard to offset: %w", err)
 	}
+	p.offset = p.reader.Offset()
 
 	// logs is a sequence of log records that can be used with the provided appender
 	return func(yield func(any, error) bool) {
 		for {
-			lineBytes, _, err := p.reader.ReadLine()
+			lineBytes, _, err := readLine(p.reader)
 			if err != nil {
 				// A decompressing reader can wrap the sentinel.
 				if errors.Is(err, io.EOF) {
@@ -70,6 +76,9 @@ func (p *lineParser) Parse(_ context.Context, startOffset int64) (logs iter.Seq2
 				return
 			}
 
+			// Advance past consumed bytes, even for an empty line.
+			p.offset = p.reader.Offset()
+
 			// only yield non-empty lines
 			if len(lineBytes) > 0 {
 				if !yield(string(lineBytes), nil) {
@@ -78,6 +87,49 @@ func (p *lineParser) Parse(_ context.Context, startOffset int64) (logs iter.Seq2
 			}
 		}
 	}, nil
+}
+
+// readLine is bufio.Reader.ReadLine with the read error preserved.
+//
+// ReadLine returns (line, nil) when it holds bytes, even after a failed read. A
+// truncated record then looks like a final record with no newline.
+func readLine(r BufferedReader) (line []byte, isPrefix bool, err error) {
+	line, err = r.ReadSlice('\n')
+
+	if errors.Is(err, bufio.ErrBufferFull) {
+		// A record longer than the buffer, split at max_log_size. Return a trailing
+		// '\r' to the buffer, so the next chunk can find a split "\r\n".
+		if len(line) > 0 && line[len(line)-1] == '\r' {
+			if unreadErr := r.UnreadByte(); unreadErr != nil {
+				return nil, false, unreadErr
+			}
+			line = line[:len(line)-1]
+		}
+		return line, true, nil
+	}
+
+	if err != nil {
+		// Bytes with no terminator. At end of stream they are the final record. Under
+		// any other error they are a fragment, so drop them.
+		if errors.Is(err, io.EOF) && len(line) > 0 {
+			return line, false, nil
+		}
+		return nil, false, err
+	}
+
+	return trimLineEnding(line), false, nil
+}
+
+// trimLineEnding drops the trailing newline, and a "\r" before it.
+func trimLineEnding(line []byte) []byte {
+	if len(line) > 0 && line[len(line)-1] == '\n' {
+		drop := 1
+		if len(line) > 1 && line[len(line)-2] == '\r' {
+			drop = 2
+		}
+		line = line[:len(line)-drop]
+	}
+	return line
 }
 
 // AppendLogBody appends the log record to the log record body using SetStr.

--- a/receiver/gcspubsubeventreceiver/internal/worker/line_parser_termination_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/line_parser_termination_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -133,4 +134,121 @@ func TestLineParser_TerminatesOnWrappedEOF(t *testing.T) {
 	require.False(t, exhausted, "parser did not terminate on a wrapped io.EOF")
 	require.Equal(t, []any{"first", "second"}, records)
 	require.Empty(t, errs, "a wrapped io.EOF is the end of the stream rather than a parse failure")
+}
+
+// TestLineParser_DropsRecordTruncatedByAReadError asserts the parser drops bytes left
+// over when the stream breaks mid-record. Emitting them splits one record in two.
+func TestLineParser_DropsRecordTruncatedByAReadError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("connection reset by peer")
+	reader := &errAfterReader{prefix: []byte("complete\ntrunca"), err: readErr}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted)
+	require.Equal(t, []any{"complete"}, records,
+		"the fragment left by the broken stream must not be emitted as a record")
+	require.Len(t, errs, 1)
+	require.ErrorIs(t, errs[0], readErr)
+}
+
+// TestLineParser_KeepsFinalLineWithoutTrailingNewline asserts the parser emits the
+// trailing bytes at end of stream. io.EOF separates this case from a truncated read.
+func TestLineParser_KeepsFinalLineWithoutTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("complete\nfinal"), err: io.EOF}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted)
+	require.Equal(t, []any{"complete", "final"}, records,
+		"an unterminated final line is a whole record at end of stream")
+	require.Empty(t, errs)
+}
+
+// TestLineParser_KeepsFinalLineOnWrappedEOF covers a wrapped io.EOF.
+func TestLineParser_KeepsFinalLineOnWrappedEOF(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("complete\nfinal"), err: fmt.Errorf("decompress: %w", io.EOF)}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, exhausted := drain(t, logs)
+
+	require.False(t, exhausted)
+	require.Equal(t, []any{"complete", "final"}, records)
+	require.Empty(t, errs)
+}
+
+// TestLineParser_TrimsCRLF covers line-ending handling under ReadSlice.
+func TestLineParser_TrimsCRLF(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\r\nsecond\r\n"), err: io.EOF}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, _ := drain(t, logs)
+	require.Equal(t, []any{"first", "second"}, records)
+	require.Empty(t, errs)
+}
+
+// TestLineParser_SplitsOversizedLine asserts chunks of an oversized record reassemble
+// to the original, including a "\r\n" on the buffer boundary.
+func TestLineParser_SplitsOversizedLine(t *testing.T) {
+	t.Parallel()
+
+	const bufSize = 16
+	for _, ending := range []string{"\n", "\r\n"} {
+		body := strings.Repeat("x", bufSize*3-1) + ending
+		reader := &errAfterReader{prefix: []byte(body), err: io.EOF}
+		parser := worker.NewLineParser(worker.NewBufferedReader(reader, bufSize))
+
+		logs, err := parser.Parse(context.Background(), 0)
+		require.NoError(t, err)
+
+		records, errs, _ := drain(t, logs)
+		require.Empty(t, errs)
+
+		var joined string
+		for _, r := range records {
+			joined += r.(string)
+		}
+		require.Equal(t, strings.Repeat("x", bufSize*3-1), joined,
+			"chunks of an oversized record should reassemble without the line ending")
+	}
+}
+
+// TestLineParser_OffsetStopsAtTheLastDeliveredRecord asserts the resume position stops
+// at the last emitted record. Otherwise redelivery replays the record tail.
+func TestLineParser_OffsetStopsAtTheLastDeliveredRecord(t *testing.T) {
+	t.Parallel()
+
+	reader := &errAfterReader{prefix: []byte("first\ntrunca"), err: errors.New("connection reset by peer")}
+	parser := worker.NewLineParser(worker.NewBufferedReader(reader, 4096))
+
+	logs, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	records, errs, _ := drain(t, logs)
+	require.Equal(t, []any{"first"}, records)
+	require.Len(t, errs, 1)
+
+	require.Equal(t, int64(len("first\n")), parser.Offset(),
+		"the resume position should sit at the end of the last delivered record")
 }


### PR DESCRIPTION
### Proposed Change

`bufio.Reader.ReadLine` clears the read error when it already holds bytes. A stream that breaks mid-record then resembles an unterminated final record, so the parser emits it whole.

The resume position also advances past those bytes. Redelivery starts mid-record and emits the tail as a second record. In testing, one line arrived as `"lin"` and then as `"e-000145-padding..."` across two collector lifetimes. No error appears in the logs.

`io.EOF` separates the two cases. At end of stream the trailing bytes are a complete record, so the parser emits them. Under any other error they are a fragment, so the parser drops them. `ReadLine` discards that signal, so the parser now reads through `ReadSlice`.

The parser also tracks the position of the last emitted record. The reader position moves past dropped bytes, and the checkpoint must not follow it.

Both receivers carry the same loop.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
