### PR TITLE
fix(gcspubsubeventreceiver,awss3eventreceiver): run checkpoint, ack, and nack on a detached context [PIPE-1410]

### DIFF
--- a/receiver/awss3eventreceiver/README.md
+++ b/receiver/awss3eventreceiver/README.md
@@ -55,6 +55,7 @@ This approach ensures that:
 | max_log_size                     | int      | 1048576    | `false`  | The maximum size of a log record in bytes. Logs exceeding this size will be split |
 | max_logs_emitted                 | int      | 1000       | `false`  | The maximum number of log records to emit in a single batch. A higher number will result in fewer batches, but more memory |
 | notification_type                | enum     | s3         | `false`  | The Notification Type that the receiver expects.  Valid values are `s3` or `sns` |
+| error_backoff                    | object   | disabled   | `false`  | Exponential backoff retried in-process when a downstream consumer returns a non-permanent error, so a struggling downstream is retried with backoff instead of being hit by immediate redelivery. Standard collector fields: `enabled` (default `false`), `initial_interval`, `randomization_factor`, `multiplier`, `max_interval`, `max_elapsed_time`. When disabled, a failed message is left for the `visibility_timeout` to redeliver |
 
 ## AWS Setup
 

--- a/receiver/awss3eventreceiver/config.go
+++ b/receiver/awss3eventreceiver/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/observiq/bindplane-otel-contrib/internal/aws/client"
 	"github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver/internal/constants"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configretry"
 )
 
 // Config defines the configuration for the AWS S3 Event receiver.
@@ -87,6 +88,12 @@ type Config struct {
 	// Valid values: "s3" (direct S3 events), "sns" (S3 events wrapped in SNS notifications).
 	// Default is "s3".
 	NotificationType string `mapstructure:"notification_type"`
+
+	// ErrorBackOff is the exponential backoff applied when a downstream consumer returns a
+	// (non-permanent) error, so a struggling downstream is retried with backoff rather than
+	// hammered by immediate redelivery. Disabled by default; when disabled the message is
+	// left for the SQS visibility timeout to redeliver, as before.
+	ErrorBackOff configretry.BackOffConfig `mapstructure:"error_backoff"`
 }
 
 // Validate checks if all required fields are present and valid.
@@ -143,6 +150,10 @@ func (c *Config) Validate() error {
 
 	if c.MaxLogSize <= 0 {
 		return errors.New("'max_log_size' must be greater than 0")
+	}
+
+	if err := c.ErrorBackOff.Validate(); err != nil {
+		return fmt.Errorf("'error_backoff' is invalid: %w", err)
 	}
 
 	if _, err := client.ParseRegionFromSQSURL(c.SQSQueueURL); err != nil {

--- a/receiver/awss3eventreceiver/config_test.go
+++ b/receiver/awss3eventreceiver/config_test.go
@@ -44,6 +44,10 @@ func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "test_config.yaml"))
 	require.NoError(t, err)
 
+	// The default (disabled) error backoff is present on every loaded config unless the
+	// file overrides it; the testdata does not, so expect the factory default.
+	defaultBackOff := awss3eventreceiver.NewFactory().CreateDefaultConfig().(*awss3eventreceiver.Config).ErrorBackOff
+
 	tests := []struct {
 		id          component.ID
 		expected    component.Config
@@ -68,6 +72,7 @@ func TestLoadConfig(t *testing.T) {
 				MaxLogSize:                  4096,
 				MaxLogsEmitted:              1000,
 				NotificationType:            "s3",
+				ErrorBackOff:                defaultBackOff,
 			},
 			expectError: false,
 		},
@@ -85,6 +90,7 @@ func TestLoadConfig(t *testing.T) {
 				MaxLogSize:                  4096,
 				MaxLogsEmitted:              1000,
 				NotificationType:            "sns",
+				ErrorBackOff:                defaultBackOff,
 			},
 			expectError: false,
 		},

--- a/receiver/awss3eventreceiver/factory.go
+++ b/receiver/awss3eventreceiver/factory.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
@@ -52,7 +53,16 @@ func createDefaultConfig() component.Config {
 		MaxLogSize:                  1024 * 1024,
 		MaxLogsEmitted:              1000,
 		NotificationType:            "s3", // Default to direct S3 events for backward compatibility
+		ErrorBackOff:                defaultErrorBackOff(),
 	}
+}
+
+// defaultErrorBackOff returns the standard collector backoff defaults, disabled, so
+// downstream-error retry backoff is opt-in and behavior is unchanged out of the box.
+func defaultErrorBackOff() configretry.BackOffConfig {
+	b := configretry.NewDefaultBackOffConfig()
+	b.Enabled = false
+	return b
 }
 
 // createLogsReceiver creates a logs receiver

--- a/receiver/awss3eventreceiver/go.mod
+++ b/receiver/awss3eventreceiver/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.46.4
 	github.com/aws/smithy-go v1.27.7
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/linkedin/goavro/v2 v2.15.0
 	github.com/observiq/bindplane-otel-contrib/internal/aws v1.12.0
@@ -16,8 +17,10 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.64.0
 	go.opentelemetry.io/collector/component/componenttest v0.158.0
+	go.opentelemetry.io/collector/config/configretry v1.64.0
 	go.opentelemetry.io/collector/confmap v1.64.0
 	go.opentelemetry.io/collector/consumer v1.64.0
+	go.opentelemetry.io/collector/consumer/consumererror v0.158.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.158.0
 	go.opentelemetry.io/collector/pdata v1.64.0
 	go.opentelemetry.io/collector/pipeline v1.64.0
@@ -46,6 +49,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.4 // indirect
+	github.com/cenkalti/backoff/v7 v7.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -66,7 +70,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.158.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.158.0 // indirect
 	go.opentelemetry.io/collector/extension v1.64.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.158.0 // indirect

--- a/receiver/awss3eventreceiver/go.sum
+++ b/receiver/awss3eventreceiver/go.sum
@@ -38,6 +38,10 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.45.4 h1:w/AryDYMjSUANSQ2uoZxJovUsMTw
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.4/go.mod h1:WeBiAa67azG7Su9Vf+ChGDBLiAozJCXzdjXiPBUwtbc=
 github.com/aws/smithy-go v1.27.7 h1:Zgj5z4LfcDYoQIVk+n/yGdTkP/2y6ZT5vYxe0fp7bqE=
 github.com/aws/smithy-go v1.27.7/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v7 v7.0.0 h1:ZP+QAaaOnVUHo+ufFpZ835hbT3x2fy+h2lecVEosZ6A=
+github.com/cenkalti/backoff/v7 v7.0.0/go.mod h1:qcKBGwsu4hpxHtQ8tWYsQ+ifzx2+sS+Xx/3jfe30lI8=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -113,6 +117,8 @@ go.opentelemetry.io/collector/component v1.64.0 h1:c8663Y++GIsnRDn4itl2q1i7aGgCX
 go.opentelemetry.io/collector/component v1.64.0/go.mod h1:2QhrPI89ZJL8FyTcwIutWPSDbWziM04PG0DvnM8GQ4M=
 go.opentelemetry.io/collector/component/componenttest v0.158.0 h1:9Kf4Ki8wxqx7MVT6CMspedMKCzSFD4ehFOWLXpeUEck=
 go.opentelemetry.io/collector/component/componenttest v0.158.0/go.mod h1:HqJMtBI6Kaoz6tZpjHxndDntPjWud5ZSWQuLarxP8RE=
+go.opentelemetry.io/collector/config/configretry v1.64.0 h1:2e+RwSGP6Y/X7kC4tkY7nEcytSgrLVJ8jgKHUIpFkt8=
+go.opentelemetry.io/collector/config/configretry v1.64.0/go.mod h1:W6bJYhzZ3FQ2Tg0K5SWprF3l7MotMqD1uQbgYm00SU8=
 go.opentelemetry.io/collector/confmap v1.64.0 h1:0iORRU/KHd3T1FMV3r3ywLAPk7VpZGg/GmORRzsUthk=
 go.opentelemetry.io/collector/confmap v1.64.0/go.mod h1:Bv2VrpUOCcDJwNMsRHSKQovK5naW63RzQFoNiSeCfq4=
 go.opentelemetry.io/collector/consumer v1.64.0 h1:6ou2lspkcCmv7IjOEnYTZz6pYLEGfrEqvbfxMVPInug=

--- a/receiver/awss3eventreceiver/internal/worker/backoff.go
+++ b/receiver/awss3eventreceiver/internal/worker/backoff.go
@@ -1,0 +1,67 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.uber.org/zap"
+)
+
+// newExponentialBackOff builds a cenkalti ExponentialBackOff from cfg. The caller is
+// responsible for checking cfg.Enabled.
+func newExponentialBackOff(cfg configretry.BackOffConfig) *backoff.ExponentialBackOff {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = cfg.InitialInterval
+	bo.RandomizationFactor = cfg.RandomizationFactor
+	bo.Multiplier = cfg.Multiplier
+	bo.MaxInterval = cfg.MaxInterval
+	bo.MaxElapsedTime = cfg.MaxElapsedTime
+	bo.Reset()
+	return bo
+}
+
+// consumeWithRetry calls consume, retrying a transient failure with exponential backoff
+// until it succeeds, returns a permanent error, exhausts the backoff, or ctx is cancelled.
+// When cfg.Enabled is false it calls consume exactly once, preserving the prior behavior
+// where redelivery is left to the broker's visibility timeout / ack deadline.
+func consumeWithRetry(ctx context.Context, cfg configretry.BackOffConfig, logger *zap.Logger, consume func() error) error {
+	err := consume()
+	if err == nil || !cfg.Enabled || consumererror.IsPermanent(err) {
+		return err
+	}
+
+	bo := newExponentialBackOff(cfg)
+	for {
+		delay := bo.NextBackOff()
+		if delay == backoff.Stop {
+			return err
+		}
+		logger.Debug("downstream consume failed; backing off before retry",
+			zap.Duration("delay", delay), zap.Error(err))
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(delay):
+		}
+		if err = consume(); err == nil || consumererror.IsPermanent(err) {
+			return err
+		}
+	}
+}

--- a/receiver/awss3eventreceiver/internal/worker/backoff_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/backoff_test.go
@@ -1,0 +1,106 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.uber.org/zap"
+)
+
+func fastBackOff(enabled bool) configretry.BackOffConfig {
+	return configretry.BackOffConfig{
+		Enabled:             enabled,
+		InitialInterval:     time.Millisecond,
+		RandomizationFactor: 0,
+		Multiplier:          1,
+		MaxInterval:         time.Millisecond,
+		MaxElapsedTime:      50 * time.Millisecond,
+	}
+}
+
+// TestConsumeWithRetry_DisabledCallsOnce asserts that with backoff disabled the consume
+// runs exactly once and the error is returned unchanged (prior behavior).
+func TestConsumeWithRetry_DisabledCallsOnce(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := consumeWithRetry(context.Background(), fastBackOff(false), zap.NewNop(), func() error {
+		calls++
+		return errors.New("boom")
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+}
+
+// TestConsumeWithRetry_RetriesThenSucceeds asserts a transient failure is retried with
+// backoff until it succeeds.
+func TestConsumeWithRetry_RetriesThenSucceeds(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := consumeWithRetry(context.Background(), fastBackOff(true), zap.NewNop(), func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, calls)
+}
+
+// TestConsumeWithRetry_PermanentNotRetried asserts a permanent error bypasses backoff.
+func TestConsumeWithRetry_PermanentNotRetried(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := consumeWithRetry(context.Background(), fastBackOff(true), zap.NewNop(), func() error {
+		calls++
+		return consumererror.NewPermanent(errors.New("permanent"))
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+}
+
+// TestConsumeWithRetry_StopsOnContextCancel asserts a cancelled context ends the retry loop.
+func TestConsumeWithRetry_StopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	err := consumeWithRetry(ctx, fastBackOff(true), zap.NewNop(), func() error {
+		calls++
+		return errors.New("transient")
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, calls, "a cancelled context must not drive further attempts")
+}
+
+// TestConsumeWithRetry_GivesUpAfterMaxElapsed asserts the loop eventually returns the last
+// error once the backoff is exhausted rather than retrying forever.
+func TestConsumeWithRetry_GivesUpAfterMaxElapsed(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := consumeWithRetry(context.Background(), fastBackOff(true), zap.NewNop(), func() error {
+		calls++
+		return errors.New("always fails")
+	})
+	require.Error(t, err)
+	require.Greater(t, calls, 1, "an exhausted backoff should have retried at least once")
+}

--- a/receiver/awss3eventreceiver/internal/worker/cleanup_context.go
+++ b/receiver/awss3eventreceiver/internal/worker/cleanup_context.go
@@ -1,0 +1,45 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// cleanupTimeout bounds each wind-down call, so a shutdown cannot block forever.
+const cleanupTimeout = 30 * time.Second
+
+// isCancellation reports a cancelled context or an expired deadline. A config push
+// or a shutdown causes it. It is routine, and never a DLQ condition.
+func isCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// cleanupContext detaches ctx from its cancellation and applies cleanupTimeout. The
+// checkpoint, ack, and nack then run after the cancellation that stopped processing.
+func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+}
+
+// drainContext returns ctx while it is live, and a cleanupContext after cancellation.
+// Records already read are then delivered and checkpointed, not re-read.
+func drainContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx.Err() == nil {
+		return context.WithCancel(ctx)
+	}
+	return cleanupContext(ctx)
+}

--- a/receiver/awss3eventreceiver/internal/worker/cleanup_context_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/cleanup_context_test.go
@@ -1,0 +1,104 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal test file — uses package worker to access unexported symbols.
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsCancellation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "context.Canceled", err: context.Canceled, want: true},
+		{name: "wrapped context.Canceled", err: fmt.Errorf("read object: %w", context.Canceled), want: true},
+		{name: "context.DeadlineExceeded", err: context.DeadlineExceeded, want: true},
+		{name: "wrapped context.DeadlineExceeded", err: fmt.Errorf("read object: %w", context.DeadlineExceeded), want: true},
+		{name: "unrelated error", err: errors.New("connection reset by peer"), want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isCancellation(tc.err))
+		})
+	}
+}
+
+func TestCleanupContext_OutlivesParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	parent, cancelParent := context.WithCancel(context.Background())
+	cancelParent()
+
+	cleanup, cancel := cleanupContext(parent)
+	defer cancel()
+
+	require.NoError(t, cleanup.Err(), "wind-down work must not inherit the parent's cancellation")
+
+	deadline, ok := cleanup.Deadline()
+	require.True(t, ok, "wind-down work must be bounded by a deadline")
+	require.WithinDuration(t, time.Now().Add(cleanupTimeout), deadline, time.Second)
+
+	cancel()
+	require.ErrorIs(t, cleanup.Err(), context.Canceled, "the returned cancel must still release the context")
+}
+
+func TestDrainContext_FollowsLiveParentAndDetachesFromCancelledOne(t *testing.T) {
+	t.Parallel()
+
+	live, cancelLive := context.WithCancel(context.Background())
+	defer cancelLive()
+
+	drain, cancelDrain := drainContext(live)
+	require.NoError(t, drain.Err())
+	cancelLive()
+	require.ErrorIs(t, drain.Err(), context.Canceled, "a live parent still governs the drain")
+	cancelDrain()
+
+	dead, cancelDead := context.WithCancel(context.Background())
+	cancelDead()
+
+	detached, cancelDetached := drainContext(dead)
+	defer cancelDetached()
+	require.NoError(t, detached.Err(), "an already-cancelled parent must not cancel the drain")
+}
+
+func TestIsDLQConditionError_CancellationIsNeverDLQ(t *testing.T) {
+	t.Parallel()
+
+	// A config push cancels the context mid-object. Routing that to the dead-letter
+	// queue would send good data to the DLQ on every config change.
+	for _, err := range []error{
+		context.Canceled,
+		context.DeadlineExceeded,
+		fmt.Errorf("read object: %w", context.Canceled),
+		fmt.Errorf("read object: %w", context.DeadlineExceeded),
+	} {
+		require.Nil(t, isDLQConditionError(err), "err: %v", err)
+	}
+}

--- a/receiver/awss3eventreceiver/internal/worker/drain_failure_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/drain_failure_test.go
@@ -1,0 +1,90 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/observiq/bindplane-otel-contrib/internal/storageclient"
+	"github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver/internal/metadata"
+)
+
+// errStorage fails every save, so the checkpoint error path runs.
+type errStorage struct{ err error }
+
+func (s errStorage) SaveStorageData(context.Context, string, storageclient.StorageData) error {
+	return s.err
+}
+func (s errStorage) LoadStorageData(context.Context, string, storageclient.StorageData) error {
+	return nil
+}
+func (s errStorage) DeleteStorageData(context.Context, string) error { return nil }
+func (s errStorage) Close(context.Context) error                     { return nil }
+
+func newTestObsReport(t *testing.T) *receiverhelper.ObsReport {
+	t.Helper()
+	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		ReceiverID:             component.NewID(metadata.Type),
+		Transport:              "sqs",
+		ReceiverCreateSettings: receivertest.NewNopSettings(metadata.Type),
+	})
+	require.NoError(t, err)
+	return obsrecv
+}
+
+// TestFlush_ReportsConsumerFailure asserts a rejected batch surfaces as an error and a
+// log line. The caller nacks the message, so the object is redelivered.
+func TestFlush_ReportsConsumerFailure(t *testing.T) {
+	t.Parallel()
+
+	consumeErr := errors.New("pipeline backpressure")
+	core, logs := observer.New(zap.ErrorLevel)
+
+	w := &Worker{
+		nextConsumer: consumertest.NewErr(consumeErr),
+		obsrecv:      newTestObsReport(t),
+	}
+
+	err := w.flush(context.Background(), plog.NewLogs(), 3, zap.New(core))
+	require.ErrorIs(t, err, consumeErr)
+	require.ErrorContains(t, err, "consume logs")
+	require.Equal(t, 1, logs.FilterMessage("consume logs").Len())
+}
+
+// TestCheckpoint_LogsSaveFailure asserts a failed save is logged rather than dropped.
+// The offset stays where it was, so the object resumes from the last saved position.
+func TestCheckpoint_LogsSaveFailure(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zap.ErrorLevel)
+	w := &Worker{offsetStorage: errStorage{err: errors.New("storage extension unavailable")}}
+
+	w.checkpoint(context.Background(), "_aws_s3_event_offset_key", 512, zap.New(core))
+
+	entries := logs.FilterMessage("Failed to save offset").All()
+	require.Len(t, entries, 1)
+	require.Equal(t, int64(512), entries[0].ContextMap()["offset"])
+}

--- a/receiver/awss3eventreceiver/internal/worker/flush_failure_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/flush_failure_test.go
@@ -1,0 +1,96 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.uber.org/zap"
+
+	"github.com/observiq/bindplane-otel-contrib/internal/aws/client/mocks"
+)
+
+// newFlushFailWorker builds a Worker whose S3 object serves body and whose next consumer
+// rejects every batch, so a flush inside consumeLogsFromS3Object fails.
+func newFlushFailWorker(t *testing.T, body string, maxLogsEmitted int, consumeErr error) (*Worker, events.S3EventRecord) {
+	t.Helper()
+
+	mockS3 := &mocks.MockS3Client{}
+	mockClient := &mocks.MockClient{}
+	mockClient.EXPECT().S3().Return(mockS3)
+	mockS3.EXPECT().GetObject(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			return &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(body))}, nil
+		})
+
+	w := &Worker{
+		client:         mockClient,
+		nextConsumer:   consumertest.NewErr(consumeErr),
+		offsetStorage:  errStorage{},
+		obsrecv:        newTestObsReport(t),
+		maxLogSize:     4096,
+		maxLogsEmitted: maxLogsEmitted,
+	}
+
+	record := events.S3EventRecord{
+		AWSRegion: "us-east-1",
+		EventTime: time.Now(),
+		S3: events.S3Entity{
+			Bucket: events.S3Bucket{Name: "mybucket"},
+			Object: events.S3Object{Key: "mykey", Size: int64(len(body))},
+		},
+	}
+	return w, record
+}
+
+// TestConsume_TrailingFlushFailureFailsObject asserts that when the final batch is
+// rejected by the next consumer, consumeLogsFromS3Object returns the error so the object
+// is not acked (the message nacks and redelivers).
+func TestConsume_TrailingFlushFailureFailsObject(t *testing.T) {
+	t.Parallel()
+
+	consumeErr := errors.New("pipeline backpressure")
+	// Fewer records than maxLogsEmitted, so only the trailing flush runs.
+	w, record := newFlushFailWorker(t, "line1\nline2\n", 1000, consumeErr)
+
+	err := w.consumeLogsFromS3Object(context.Background(), record, "mykey", false, zap.NewNop())
+	require.ErrorIs(t, err, consumeErr)
+	require.ErrorContains(t, err, "consume logs")
+}
+
+// TestConsume_MidLoopFlushFailureFailsObject asserts that when a mid-object batch (the
+// one emitted once maxLogsEmitted is reached) is rejected, consumeLogsFromS3Object
+// returns the error immediately rather than continuing to read.
+func TestConsume_MidLoopFlushFailureFailsObject(t *testing.T) {
+	t.Parallel()
+
+	consumeErr := errors.New("pipeline backpressure")
+	// maxLogsEmitted of 1 forces a flush after the first record, mid-loop.
+	w, record := newFlushFailWorker(t, "line1\nline2\nline3\n", 1, consumeErr)
+
+	err := w.consumeLogsFromS3Object(context.Background(), record, "mykey", false, zap.NewNop())
+	require.ErrorIs(t, err, consumeErr)
+	require.ErrorContains(t, err, "consume logs")
+}

--- a/receiver/awss3eventreceiver/internal/worker/handle_processing_error_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/handle_processing_error_test.go
@@ -1,0 +1,80 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap"
+
+	"github.com/observiq/bindplane-otel-contrib/internal/aws/client/mocks"
+	"github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver/internal/metadata"
+)
+
+func newTestMetrics(t *testing.T) *metadata.TelemetryBuilder {
+	t.Helper()
+	tb, err := metadata.NewTelemetryBuilder(componenttest.NewNopTelemetrySettings())
+	require.NoError(t, err)
+	return tb
+}
+
+// TestHandleProcessingError_DeadlineExceededDoesNotHotRedeliver asserts that a downstream
+// timeout (context.DeadlineExceeded) with a live context is treated as a transient failure
+// and left for the visibility timeout to redeliver, NOT nacked for immediate redelivery.
+// Immediate redelivery would hammer a downstream that is already struggling under backpressure.
+func TestHandleProcessingError_DeadlineExceededDoesNotHotRedeliver(t *testing.T) {
+	t.Parallel()
+
+	mockSQS := &mocks.MockSQSClient{}
+	mockClient := &mocks.MockClient{}
+	mockClient.EXPECT().SQS().Return(mockSQS).Maybe()
+
+	w := &Worker{client: mockClient, metrics: newTestMetrics(t)}
+
+	// Live context: the downstream timed out, we are not shutting down.
+	w.handleProcessingError(context.Background(), types.Message{ReceiptHandle: aws.String("rh")},
+		"https://sqs.example/q", context.DeadlineExceeded, zap.NewNop())
+
+	mockSQS.AssertNotCalled(t, "ChangeMessageVisibility", mock.Anything, mock.Anything)
+}
+
+// TestHandleProcessingError_ShutdownNacksImmediately asserts that when our own context is
+// cancelled (a shutdown / config push), the message is nacked for immediate redelivery so it
+// resumes promptly from the checkpoint — the DeadlineExceeded there is our own wind-down.
+func TestHandleProcessingError_ShutdownNacksImmediately(t *testing.T) {
+	t.Parallel()
+
+	mockSQS := &mocks.MockSQSClient{}
+	mockClient := &mocks.MockClient{}
+	mockClient.EXPECT().SQS().Return(mockSQS)
+	mockSQS.EXPECT().ChangeMessageVisibility(mock.Anything, mock.Anything).
+		Return(&sqs.ChangeMessageVisibilityOutput{}, nil).Once()
+
+	w := &Worker{client: mockClient, metrics: newTestMetrics(t)}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	w.handleProcessingError(ctx, types.Message{ReceiptHandle: aws.String("rh")},
+		"https://sqs.example/q", context.DeadlineExceeded, zap.NewNop())
+
+	mockSQS.AssertExpectations(t)
+}

--- a/receiver/awss3eventreceiver/internal/worker/worker.go
+++ b/receiver/awss3eventreceiver/internal/worker/worker.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/aws/smithy-go"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -76,6 +77,11 @@ func parseS3Event(messageBody string) (*events.S3Event, error) {
 
 // isDLQConditionError checks if an error should trigger DLQ behavior and returns the specific error type
 func isDLQConditionError(err error) error {
+	// Cancellation is never a DLQ condition. The check is explicit because the
+	// classifiers below match on the error text.
+	if err == nil || isCancellation(err) {
+		return nil
+	}
 	if isAccessDeniedError(err) {
 		return &DLQError{Type: "iam_permission_denied", Err: err}
 	}
@@ -152,6 +158,7 @@ type Worker struct {
 	notificationType            string
 	parseFunc                   parseFunc
 	obsrecv                     *receiverhelper.ObsReport
+	errorBackOff                configretry.BackOffConfig
 }
 
 // Option is a functional option for configuring the Worker
@@ -177,6 +184,13 @@ func WithTelemetryBuilder(tb *metadata.TelemetryBuilder) Option {
 		if tb != nil {
 			w.metrics = tb
 		}
+	}
+}
+
+// WithErrorBackOff sets the retry backoff applied when a downstream consume fails.
+func WithErrorBackOff(cfg configretry.BackOffConfig) Option {
+	return func(w *Worker) {
+		w.errorBackOff = cfg
 	}
 }
 
@@ -406,8 +420,18 @@ func (w *Worker) consumeLogsFromS3Object(ctx context.Context, record events.S3Ev
 		return fmt.Errorf("parse logs: %w", err)
 	}
 
+	// parseErr records a cancellation that stopped the read. The records already read
+	// are delivered below. The error is returned, so the message nacks.
+	var parseErr error
+
 	for log, err := range logs {
 		if err != nil {
+			// Cancellation is checked first. A cancelled read is also a broken
+			// stream, and shutdown has its own wind-down path.
+			if isCancellation(err) {
+				parseErr = err
+				break
+			}
 			// A broken stream is fatal for the whole object. Acking here would drop
 			// every record after the break with no way to recover them, so fail and
 			// let the message redeliver and resume from the saved offset.
@@ -430,22 +454,15 @@ func (w *Worker) consumeLogsFromS3Object(ctx context.Context, record events.S3Ev
 		}
 
 		if ld.LogRecordCount() >= w.maxLogsEmitted {
-			obsCtx := w.obsrecv.StartLogsOp(ctx)
-			if err := w.nextConsumer.ConsumeLogs(ctx, ld); err != nil {
-				w.obsrecv.EndLogsOp(obsCtx, metadata.Type.String(), ld.LogRecordCount(), err)
-				recordLogger.Error("consume logs", zap.Error(err), zap.Int("batches_consumed_count", batchesConsumedCount))
-				return fmt.Errorf("consume logs: %w", err)
+			if err := w.flush(ctx, ld, batchesConsumedCount, recordLogger); err != nil {
+				return err
 			}
-			w.metrics.S3eventBatchSize.Record(ctx, int64(ld.LogRecordCount()))
-			w.obsrecv.EndLogsOp(obsCtx, metadata.Type.String(), ld.LogRecordCount(), nil)
 
 			batchesConsumedCount++
 			recordLogger.Debug("Reached max logs for single batch, starting new batch", zap.Int("batches_consumed_count", batchesConsumedCount))
 
 			// Save the offset to storage
-			if err := w.offsetStorage.SaveStorageData(ctx, offsetStorageKey, NewOffset(parser.Offset())); err != nil {
-				recordLogger.Error("Failed to save offset", zap.Error(err), zap.String("offset_storage_key", offsetStorageKey), zap.Int64("offset", parser.Offset()))
-			}
+			w.checkpoint(ctx, offsetStorageKey, parser.Offset(), recordLogger)
 
 			ld = plog.NewLogs()
 			rls = ld.ResourceLogs().AppendEmpty()
@@ -455,34 +472,71 @@ func (w *Worker) consumeLogsFromS3Object(ctx context.Context, record events.S3Ev
 		}
 	}
 
-	if ld.LogRecordCount() == 0 {
-		return nil
-	}
-	w.metrics.S3eventBatchSize.Record(ctx, int64(ld.LogRecordCount()))
+	if ld.LogRecordCount() > 0 {
+		if err := w.flush(ctx, ld, batchesConsumedCount, recordLogger); err != nil {
+			return err
+		}
+		if parseErr == nil {
+			recordLogger.Debug("processed S3 object", zap.Int("batches_consumed_count", batchesConsumedCount+1))
+		}
 
-	obsCtx := w.obsrecv.StartLogsOp(ctx)
-	if err := w.nextConsumer.ConsumeLogs(ctx, ld); err != nil {
-		w.obsrecv.EndLogsOp(obsCtx, metadata.Type.String(), ld.LogRecordCount(), err)
-		recordLogger.Error("consume logs", zap.Error(err), zap.Int("batches_consumed_count", batchesConsumedCount))
-		return fmt.Errorf("consume logs: %w", err)
+		// Save the offset to storage
+		w.checkpoint(ctx, offsetStorageKey, parser.Offset(), recordLogger)
 	}
-	w.obsrecv.EndLogsOp(obsCtx, metadata.Type.String(), ld.LogRecordCount(), nil)
-	recordLogger.Debug("processed S3 object", zap.Int("batches_consumed_count", batchesConsumedCount+1))
 
-	// Save the offset to storage
-	if err := w.offsetStorage.SaveStorageData(ctx, offsetStorageKey, NewOffset(parser.Offset())); err != nil {
-		recordLogger.Error("Failed to save offset", zap.Error(err), zap.String("offset_storage_key", offsetStorageKey), zap.Int64("offset", parser.Offset()))
+	if parseErr != nil {
+		// The read stopped partway. Everything read is delivered and checkpointed
+		// above, so redelivery resumes at the first unread record.
+		return fmt.Errorf("read object: %w", parseErr)
 	}
 
 	return nil
 }
 
+// flush sends a batch to the next consumer on a drain context. Records already read
+// are delivered during wind-down.
+//
+// The line parser drops a truncated record, so a batch always ends on a record
+// boundary and the checkpoint stays accurate. Reading stops at the next failed refill.
+func (w *Worker) flush(ctx context.Context, ld plog.Logs, batchesConsumedCount int, recordLogger *zap.Logger) error {
+	flushCtx, cancel := drainContext(ctx)
+	defer cancel()
+
+	obsCtx := w.obsrecv.StartLogsOp(flushCtx)
+	err := consumeWithRetry(flushCtx, w.errorBackOff, recordLogger, func() error {
+		return w.nextConsumer.ConsumeLogs(flushCtx, ld)
+	})
+	w.obsrecv.EndLogsOp(obsCtx, metadata.Type.String(), ld.LogRecordCount(), err)
+	if err != nil {
+		recordLogger.Error("consume logs", zap.Error(err), zap.Int("batches_consumed_count", batchesConsumedCount))
+		return fmt.Errorf("consume logs: %w", err)
+	}
+	w.metrics.S3eventBatchSize.Record(flushCtx, int64(ld.LogRecordCount()))
+	return nil
+}
+
+// checkpoint saves the parse position on a drain context. A late cancellation then
+// cannot lose the offset.
+func (w *Worker) checkpoint(ctx context.Context, offsetStorageKey string, offset int64, recordLogger *zap.Logger) {
+	saveCtx, cancel := drainContext(ctx)
+	defer cancel()
+
+	if err := w.offsetStorage.SaveStorageData(saveCtx, offsetStorageKey, NewOffset(offset)); err != nil {
+		recordLogger.Error("Failed to save offset", zap.Error(err), zap.String("offset_storage_key", offsetStorageKey), zap.Int64("offset", offset))
+	}
+}
+
 func (w *Worker) deleteMessage(ctx context.Context, msg types.Message, queueURL string, keys []string, recordLogger *zap.Logger) {
+	// Ack on a detached context. A cancellation must not leave a consumed object in
+	// the queue.
+	deleteCtx, cancel := cleanupContext(ctx)
+	defer cancel()
+
 	deleteParams := &sqs.DeleteMessageInput{
 		QueueUrl:      aws.String(queueURL),
 		ReceiptHandle: msg.ReceiptHandle,
 	}
-	_, err := w.client.SQS().DeleteMessage(ctx, deleteParams)
+	_, err := w.client.SQS().DeleteMessage(deleteCtx, deleteParams)
 	if err != nil {
 		recordLogger.Error("delete message", zap.Error(err))
 		return
@@ -492,7 +546,7 @@ func (w *Worker) deleteMessage(ctx context.Context, msg types.Message, queueURL 
 	// Delete the offsets for the keys that were processed
 	for _, key := range keys {
 		offsetStorageKey := fmt.Sprintf("%s_%s", OffsetStorageKey, key)
-		if err := w.offsetStorage.DeleteStorageData(ctx, offsetStorageKey); err != nil {
+		if err := w.offsetStorage.DeleteStorageData(deleteCtx, offsetStorageKey); err != nil {
 			recordLogger.Error("Failed to delete offset", zap.Error(err), zap.String("offset_storage_key", offsetStorageKey))
 		}
 	}
@@ -654,6 +708,19 @@ func (w *Worker) handleDLQCondition(ctx context.Context, msg types.Message, queu
 
 // handleProcessingError handles errors from processing records, determining if they should trigger DLQ behavior
 func (w *Worker) handleProcessingError(ctx context.Context, msg types.Message, queueURL string, err error, logger *zap.Logger) {
+	// Only a genuine shutdown/config-push counts as a cancellation: our own context is
+	// cancelled, or the error is context.Canceled. A bare DeadlineExceeded with a live
+	// context is a downstream timeout (backpressure), not a shutdown, so it must fall
+	// through to the retry path below rather than nacking for immediate redelivery.
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		// A config push or a shutdown cancelled the context. Nack the message, so it
+		// redelivers at once and resumes from the checkpoint. This is not a failure.
+		logger.Info("processing cancelled, nacking message for redelivery", zap.Error(err))
+		if nackErr := w.resetVisibilityTimeout(ctx, msg, queueURL, logger); nackErr != nil {
+			logger.Error("failed to nack message after cancellation", zap.Error(nackErr))
+		}
+		return
+	}
 	if dlqErr := isDLQConditionError(err); dlqErr != nil {
 		w.handleDLQCondition(ctx, msg, queueURL, dlqErr, logger)
 		return
@@ -664,12 +731,17 @@ func (w *Worker) handleProcessingError(ctx context.Context, msg types.Message, q
 
 // resetVisibilityTimeout resets the message visibility timeout to 0, making it immediately available for DLQ processing
 func (w *Worker) resetVisibilityTimeout(ctx context.Context, msg types.Message, queueURL string, logger *zap.Logger) error {
+	// Nack on a detached context. The message then redelivers without waiting for the
+	// full visibility timeout.
+	nackCtx, cancel := cleanupContext(ctx)
+	defer cancel()
+
 	changeParams := &sqs.ChangeMessageVisibilityInput{
 		QueueUrl:          aws.String(queueURL),
 		ReceiptHandle:     msg.ReceiptHandle,
 		VisibilityTimeout: 0, // Reset to 0 to make message immediately available
 	}
 	logger.Debug("resetting message visibility timeout for DLQ processing")
-	_, err := w.client.SQS().ChangeMessageVisibility(ctx, changeParams)
+	_, err := w.client.SQS().ChangeMessageVisibility(nackCtx, changeParams)
 	return err
 }

--- a/receiver/awss3eventreceiver/internal/worker/worker_cancellation_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/worker_cancellation_test.go
@@ -1,0 +1,310 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/observiq/bindplane-otel-contrib/internal/aws/client/mocks"
+	"github.com/observiq/bindplane-otel-contrib/internal/storageclient"
+	"github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver/internal/metadata"
+	"github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver/internal/worker"
+)
+
+// memStorage is an in-memory StorageClient that obeys context cancellation. A test can
+// then tell whether a checkpoint ran on a live context.
+type memStorage struct {
+	mu   sync.Mutex
+	data map[string][]byte
+}
+
+func newMemStorage() *memStorage {
+	return &memStorage{data: map[string][]byte{}}
+}
+
+func (m *memStorage) SaveStorageData(ctx context.Context, key string, data storageclient.StorageData) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	b, err := data.Marshal()
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[key] = b
+	return nil
+}
+
+func (m *memStorage) LoadStorageData(ctx context.Context, key string, data storageclient.StorageData) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	b, ok := m.data[key]
+	if !ok {
+		return nil
+	}
+	return data.Unmarshal(b)
+}
+
+func (m *memStorage) DeleteStorageData(ctx context.Context, key string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.data, key)
+	return nil
+}
+
+func (m *memStorage) Close(context.Context) error { return nil }
+
+func (m *memStorage) has(key string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.data[key]
+	return ok
+}
+
+// cancelOnExhaustReader serves body and then cancels the context and reports the
+// cancellation, modelling a config push that lands while an object is being streamed.
+type cancelOnExhaustReader struct {
+	body   *strings.Reader
+	cancel context.CancelFunc
+}
+
+func (r *cancelOnExhaustReader) Read(p []byte) (int, error) {
+	if r.body.Len() > 0 {
+		return r.body.Read(p)
+	}
+	if r.cancel != nil {
+		r.cancel()
+		r.cancel = nil
+	}
+	return 0, context.Canceled
+}
+
+func (r *cancelOnExhaustReader) Close() error { return nil }
+
+const cancelTestEvent = `{"Records":[{"eventName":"s3:ObjectCreated:Put","s3":{"bucket":{"name":"mybucket"},"object":{"key":"mykey","size":9}}}]}`
+
+type cancelTestHarness struct {
+	worker      *worker.Worker
+	message     types.Message
+	sink        *consumertest.LogsSink
+	storage     *memStorage
+	logs        *observer.ObservedLogs
+	visibility  *[]int32
+	deleteCalls *int
+}
+
+// newCancelTestHarness builds a worker whose S3 object body is served by bodyFn and whose
+// SQS calls are recorded rather than performed.
+func newCancelTestHarness(t *testing.T, maxLogsEmitted int, store *memStorage, bodyFn func() io.ReadCloser) *cancelTestHarness {
+	t.Helper()
+
+	mockSQS := &mocks.MockSQSClient{}
+	mockS3 := &mocks.MockS3Client{}
+	mockClient := &mocks.MockClient{}
+	mockClient.EXPECT().SQS().Return(mockSQS)
+	mockClient.EXPECT().S3().Return(mockS3)
+
+	visibility := &[]int32{}
+	deleteCalls := new(int)
+	var mu sync.Mutex
+
+	mockS3.EXPECT().GetObject(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			return &s3.GetObjectOutput{Body: bodyFn()}, nil
+		})
+	mockSQS.EXPECT().ChangeMessageVisibility(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, in *sqs.ChangeMessageVisibilityInput, _ ...func(*sqs.Options)) (*sqs.ChangeMessageVisibilityOutput, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			*visibility = append(*visibility, in.VisibilityTimeout)
+			return &sqs.ChangeMessageVisibilityOutput{}, nil
+		})
+	mockSQS.EXPECT().DeleteMessage(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, _ *sqs.DeleteMessageInput, _ ...func(*sqs.Options)) (*sqs.DeleteMessageOutput, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			*deleteCalls++
+			return &sqs.DeleteMessageOutput{}, nil
+		})
+
+	core, recorded := observer.New(zap.DebugLevel)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zap.New(core)
+
+	tb, err := metadata.NewTelemetryBuilder(set)
+	require.NoError(t, err)
+
+	params := receivertest.NewNopSettings(metadata.Type)
+	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		ReceiverID:             params.ID,
+		Transport:              "http",
+		ReceiverCreateSettings: params,
+	})
+	require.NoError(t, err)
+
+	sink := new(consumertest.LogsSink)
+	// Downstream consumers reject a cancelled context, so the sink must also reject it.
+	next, err := consumer.NewLogs(func(ctx context.Context, ld plog.Logs) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return sink.ConsumeLogs(ctx, ld)
+	})
+	require.NoError(t, err)
+
+	// A long visibility timeout keeps the extension goroutine out of the way.
+	w := worker.New(set, next, mockClient, obsrecv, 4096, maxLogsEmitted,
+		300*time.Second, 300*time.Second, 6*time.Hour, worker.WithTelemetryBuilder(tb))
+	w.SetOffsetStorage(store)
+
+	return &cancelTestHarness{
+		worker: w,
+		message: types.Message{
+			Body:          aws.String(cancelTestEvent),
+			MessageId:     aws.String("cancel-test"),
+			ReceiptHandle: aws.String("receipt-handle"),
+		},
+		sink:        sink,
+		storage:     store,
+		logs:        recorded,
+		visibility:  visibility,
+		deleteCalls: deleteCalls,
+	}
+}
+
+func (h *cancelTestHarness) bodyStrings(t *testing.T) []string {
+	t.Helper()
+
+	var got []string
+	for _, ld := range h.sink.AllLogs() {
+		for i := 0; i < ld.ResourceLogs().Len(); i++ {
+			sls := ld.ResourceLogs().At(i).ScopeLogs()
+			for j := 0; j < sls.Len(); j++ {
+				lrs := sls.At(j).LogRecords()
+				for k := 0; k < lrs.Len(); k++ {
+					got = append(got, lrs.At(k).Body().Str())
+				}
+			}
+		}
+	}
+	return got
+}
+
+func (h *cancelTestHarness) logged(msg string) bool {
+	for _, e := range h.logs.All() {
+		if e.Message == msg {
+			return true
+		}
+	}
+	return false
+}
+
+// TestProcessMessage_CancelledMidObject asserts the wind-down contract: batches completed
+// before the stream was cut are delivered and checkpointed, the message is nacked for
+// redelivery rather than deleted, and the cancellation is not treated as a DLQ condition.
+func TestProcessMessage_CancelledMidObject(t *testing.T) {
+	store := newMemStorage()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newCancelTestHarness(t, 2, store, func() io.ReadCloser {
+		return &cancelOnExhaustReader{body: strings.NewReader("l1\nl2\nl3\n"), cancel: cancel}
+	})
+
+	done := make(chan struct{})
+	go h.worker.ProcessMessage(ctx, h.message, "myqueue", func() { close(done) })
+	<-done
+
+	require.Equal(t, []string{"l1", "l2", "l3"}, h.bodyStrings(t),
+		"the partial batch left in hand is drained rather than dropped for redelivery")
+
+	require.True(t, store.has(worker.OffsetStorageKey+"_mykey"),
+		"a cancelled object should leave a checkpoint behind")
+
+	require.Contains(t, *h.visibility, int32(0),
+		"a cancelled message should be nacked so it redelivers immediately")
+
+	require.Zero(t, *h.deleteCalls, "a partially read object must not be deleted from the queue")
+
+	require.False(t, h.logged("DLQ condition triggered, resetting visibility for DLQ processing"),
+		"cancellation must never route an object to the DLQ")
+}
+
+// TestProcessMessage_ResumesFromCheckpointAfterCancellation asserts that the checkpoint
+// written before the cancellation is what redelivery resumes from, so the two runs
+// together cover the object exactly once.
+func TestProcessMessage_ResumesFromCheckpointAfterCancellation(t *testing.T) {
+	store := newMemStorage()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	first := newCancelTestHarness(t, 2, store, func() io.ReadCloser {
+		return &cancelOnExhaustReader{body: strings.NewReader("l1\nl2\nl3\n"), cancel: cancel}
+	})
+
+	done := make(chan struct{})
+	go first.worker.ProcessMessage(ctx, first.message, "myqueue", func() { close(done) })
+	<-done
+	delivered := first.bodyStrings(t)
+	require.NotEmpty(t, delivered)
+
+	// Redelivery: the same object, now complete, processed on a live context.
+	second := newCancelTestHarness(t, 2, store, func() io.ReadCloser {
+		return io.NopCloser(strings.NewReader("l1\nl2\nl3\nl4\nl5\n"))
+	})
+
+	done2 := make(chan struct{})
+	go second.worker.ProcessMessage(context.Background(), second.message, "myqueue", func() { close(done2) })
+	<-done2
+
+	require.Equal(t, []string{"l1", "l2", "l3", "l4", "l5"}, append(delivered, second.bodyStrings(t)...),
+		"the two runs together should cover the object exactly once")
+	require.Equal(t, 1, *second.deleteCalls, "a fully read object should be deleted from the queue")
+}

--- a/receiver/awss3eventreceiver/internal/worker/worker_cleanup_error_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/worker_cleanup_error_test.go
@@ -1,0 +1,92 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/observiq/bindplane-otel-contrib/internal/aws/client/mocks"
+	"github.com/observiq/bindplane-otel-contrib/internal/storageclient"
+)
+
+// deleteErrStorage fails every offset delete, so the delete-error path in deleteMessage runs.
+type deleteErrStorage struct{ err error }
+
+func (s deleteErrStorage) SaveStorageData(context.Context, string, storageclient.StorageData) error {
+	return nil
+}
+func (s deleteErrStorage) LoadStorageData(context.Context, string, storageclient.StorageData) error {
+	return nil
+}
+func (s deleteErrStorage) DeleteStorageData(context.Context, string) error { return s.err }
+func (s deleteErrStorage) Close(context.Context) error                     { return nil }
+
+// TestDeleteMessage_LogsOffsetDeleteFailure asserts that when the ack succeeds but deleting
+// a processed key's offset fails, the failure is logged rather than dropped. The stale
+// offset is harmless (the object is already acked), so the delete error must not escalate.
+func TestDeleteMessage_LogsOffsetDeleteFailure(t *testing.T) {
+	t.Parallel()
+
+	mockSQS := &mocks.MockSQSClient{}
+	mockClient := &mocks.MockClient{}
+	mockClient.EXPECT().SQS().Return(mockSQS)
+	mockSQS.EXPECT().DeleteMessage(mock.Anything, mock.Anything).Return(&sqs.DeleteMessageOutput{}, nil)
+
+	core, logs := observer.New(zap.ErrorLevel)
+	w := &Worker{
+		client:        mockClient,
+		offsetStorage: deleteErrStorage{err: errors.New("storage extension unavailable")},
+	}
+
+	w.deleteMessage(context.Background(), types.Message{ReceiptHandle: aws.String("rh")},
+		"https://sqs.example/q", []string{"mykey"}, zap.New(core))
+
+	entries := logs.FilterMessage("Failed to delete offset").All()
+	require.Len(t, entries, 1, "a failed offset delete is logged once")
+	require.Equal(t, OffsetStorageKey+"_mykey", entries[0].ContextMap()["offset_storage_key"])
+}
+
+// TestHandleProcessingError_LogsNackFailureOnCancellation asserts that when processing is
+// cancelled and the follow-up nack (visibility reset) also fails, the nack failure is
+// logged. The message stays invisible until its timeout lapses, then redelivers.
+func TestHandleProcessingError_LogsNackFailureOnCancellation(t *testing.T) {
+	t.Parallel()
+
+	nackErr := errors.New("visibility reset failed")
+	mockSQS := &mocks.MockSQSClient{}
+	mockClient := &mocks.MockClient{}
+	mockClient.EXPECT().SQS().Return(mockSQS)
+	mockSQS.EXPECT().ChangeMessageVisibility(mock.Anything, mock.Anything).
+		Return(&sqs.ChangeMessageVisibilityOutput{}, nackErr)
+
+	core, logs := observer.New(zap.ErrorLevel)
+	w := &Worker{client: mockClient}
+
+	w.handleProcessingError(context.Background(), types.Message{ReceiptHandle: aws.String("rh")},
+		"https://sqs.example/q", context.Canceled, zap.New(core))
+
+	require.Equal(t, 1, logs.FilterMessage("failed to nack message after cancellation").Len(),
+		"a nack failure after cancellation is logged")
+}

--- a/receiver/awss3eventreceiver/receiver.go
+++ b/receiver/awss3eventreceiver/receiver.go
@@ -130,6 +130,7 @@ func newLogsReceiver(params receiver.Settings, cfg *Config, next consumer.Logs, 
 
 				// Set notification type
 				opts = append(opts, worker.WithNotificationType(cfg.NotificationType))
+				opts = append(opts, worker.WithErrorBackOff(cfg.ErrorBackOff))
 				return worker.New(tel, next, client.NewClient(awsConfig), obsrecv, cfg.MaxLogSize, cfg.MaxLogsEmitted, cfg.VisibilityTimeout, cfg.VisibilityExtensionInterval, cfg.MaxVisibilityWindow, opts...)
 			},
 		},

--- a/receiver/gcspubsubeventreceiver/README.md
+++ b/receiver/gcspubsubeventreceiver/README.md
@@ -106,6 +106,7 @@ Content that is not text, Avro, or JSON (for example an image or a PDF) is not p
 | `storage` | component.ID | | `false` | The ID of a storage extension to use for tracking per-object byte offsets, enabling resumption of interrupted object reads |
 | `bucket_name_filter` | string | | `false` | A Go regular expression to filter GCS events by bucket name. Only events from matching buckets are processed |
 | `object_key_filter` | string | | `false` | A Go regular expression to filter GCS events by object name. Only objects with matching names are processed |
+| `error_backoff` | object | disabled | `false` | Exponential backoff retried in-process when a downstream consumer returns a non-permanent error, so a struggling downstream is retried with backoff instead of being hit by immediate redelivery. Standard collector fields: `enabled` (default `false`), `initial_interval`, `randomization_factor`, `multiplier`, `max_interval`, `max_elapsed_time`. When disabled, a failed message is left for the ack deadline to lapse and redeliver |
 
 ## GCP Setup
 

--- a/receiver/gcspubsubeventreceiver/config.go
+++ b/receiver/gcspubsubeventreceiver/config.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configretry"
 )
 
 // Config defines the configuration for the GCS Pub/Sub Event receiver.
@@ -75,6 +76,12 @@ type Config struct {
 
 	// ObjectKeyFilter is a regex filter to apply to the GCS object name.
 	ObjectKeyFilter string `mapstructure:"object_key_filter"`
+
+	// ErrorBackOff is the exponential backoff applied when a downstream consumer returns a
+	// (non-permanent) error, so a struggling downstream is retried with backoff rather than
+	// hammered by immediate redelivery. Disabled by default; when disabled the message is
+	// left for the ack deadline to lapse and redeliver, as before.
+	ErrorBackOff configretry.BackOffConfig `mapstructure:"error_backoff"`
 }
 
 // Validate checks if all required fields are present and valid.
@@ -123,6 +130,10 @@ func (c *Config) Validate() error {
 		if err != nil {
 			return fmt.Errorf("'object_key_filter' %q is invalid: %w", c.ObjectKeyFilter, err)
 		}
+	}
+
+	if err := c.ErrorBackOff.Validate(); err != nil {
+		return fmt.Errorf("'error_backoff' is invalid: %w", err)
 	}
 
 	return nil

--- a/receiver/gcspubsubeventreceiver/config_test.go
+++ b/receiver/gcspubsubeventreceiver/config_test.go
@@ -45,6 +45,10 @@ func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "test_config.yaml"))
 	require.NoError(t, err)
 
+	// The default (disabled) error backoff is present on every loaded config unless the
+	// file overrides it; the testdata does not, so expect the factory default.
+	defaultBackOff := gcspubsubeventreceiver.NewFactory().CreateDefaultConfig().(*gcspubsubeventreceiver.Config).ErrorBackOff
+
 	tests := []struct {
 		id          component.ID
 		expected    component.Config
@@ -66,6 +70,7 @@ func TestLoadConfig(t *testing.T) {
 				DedupTTL:       10 * time.Minute,
 				MaxLogSize:     4096,
 				MaxLogsEmitted: 500,
+				ErrorBackOff:   defaultBackOff,
 			},
 			expectError: false,
 		},

--- a/receiver/gcspubsubeventreceiver/factory.go
+++ b/receiver/gcspubsubeventreceiver/factory.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
@@ -48,7 +49,16 @@ func createDefaultConfig() component.Config {
 		DedupTTL:       5 * time.Minute,
 		MaxLogSize:     1024 * 1024,
 		MaxLogsEmitted: 1000,
+		ErrorBackOff:   defaultErrorBackOff(),
 	}
+}
+
+// defaultErrorBackOff returns the standard collector backoff defaults, disabled, so
+// downstream-error retry backoff is opt-in and behavior is unchanged out of the box.
+func defaultErrorBackOff() configretry.BackOffConfig {
+	b := configretry.NewDefaultBackOffConfig()
+	b.Enabled = false
+	return b
 }
 
 // createLogsReceiver creates a logs receiver

--- a/receiver/gcspubsubeventreceiver/go.mod
+++ b/receiver/gcspubsubeventreceiver/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/pubsub v1.51.0
 	cloud.google.com/go/storage v1.64.0
 	github.com/bodgit/sevenzip v1.6.5
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/gabriel-vasile/mimetype v1.4.15
 	github.com/google/go-cmp v0.7.0
 	github.com/jonboulle/clockwork v0.5.0
@@ -19,8 +20,10 @@ require (
 	github.com/ulikunitz/xz v0.5.16
 	go.opentelemetry.io/collector/component v1.64.0
 	go.opentelemetry.io/collector/component/componenttest v0.158.0
+	go.opentelemetry.io/collector/config/configretry v1.64.0
 	go.opentelemetry.io/collector/confmap v1.64.0
 	go.opentelemetry.io/collector/consumer v1.64.0
+	go.opentelemetry.io/collector/consumer/consumererror v0.158.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.158.0
 	go.opentelemetry.io/collector/pdata v1.64.0
 	go.opentelemetry.io/collector/pipeline v1.64.0
@@ -51,6 +54,7 @@ require (
 	github.com/andybalholm/brotli v1.2.2 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
+	github.com/cenkalti/backoff/v7 v7.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -84,7 +88,6 @@ require (
 	github.com/stangelandcl/ppmd v0.1.1 // indirect
 	go.einride.tech/aip v0.83.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.158.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.158.0 // indirect
 	go.opentelemetry.io/collector/extension v1.64.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.158.0 // indirect

--- a/receiver/gcspubsubeventreceiver/go.sum
+++ b/receiver/gcspubsubeventreceiver/go.sum
@@ -40,6 +40,10 @@ github.com/bodgit/sevenzip v1.6.5 h1:7H7BxgmeX0j6UX42lH+KXQ92WgMQJ49DoocFdfHbCng
 github.com/bodgit/sevenzip v1.6.5/go.mod h1:GhuB6Lq1xCpP1sps+horjZ8lgiKPJcy2zUX3prla9wc=
 github.com/bodgit/windows v1.0.1 h1:tF7K6KOluPYygXa3Z2594zxlkbKPAOvqr97etrGNIz4=
 github.com/bodgit/windows v1.0.1/go.mod h1:a6JLwrB4KrTR5hBpp8FI9/9W9jJfeQ2h4XDXU74ZCdM=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v7 v7.0.0 h1:ZP+QAaaOnVUHo+ufFpZ835hbT3x2fy+h2lecVEosZ6A=
+github.com/cenkalti/backoff/v7 v7.0.0/go.mod h1:qcKBGwsu4hpxHtQ8tWYsQ+ifzx2+sS+Xx/3jfe30lI8=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
@@ -170,6 +174,8 @@ go.opentelemetry.io/collector/component v1.64.0 h1:c8663Y++GIsnRDn4itl2q1i7aGgCX
 go.opentelemetry.io/collector/component v1.64.0/go.mod h1:2QhrPI89ZJL8FyTcwIutWPSDbWziM04PG0DvnM8GQ4M=
 go.opentelemetry.io/collector/component/componenttest v0.158.0 h1:9Kf4Ki8wxqx7MVT6CMspedMKCzSFD4ehFOWLXpeUEck=
 go.opentelemetry.io/collector/component/componenttest v0.158.0/go.mod h1:HqJMtBI6Kaoz6tZpjHxndDntPjWud5ZSWQuLarxP8RE=
+go.opentelemetry.io/collector/config/configretry v1.64.0 h1:2e+RwSGP6Y/X7kC4tkY7nEcytSgrLVJ8jgKHUIpFkt8=
+go.opentelemetry.io/collector/config/configretry v1.64.0/go.mod h1:W6bJYhzZ3FQ2Tg0K5SWprF3l7MotMqD1uQbgYm00SU8=
 go.opentelemetry.io/collector/confmap v1.64.0 h1:0iORRU/KHd3T1FMV3r3ywLAPk7VpZGg/GmORRzsUthk=
 go.opentelemetry.io/collector/confmap v1.64.0/go.mod h1:Bv2VrpUOCcDJwNMsRHSKQovK5naW63RzQFoNiSeCfq4=
 go.opentelemetry.io/collector/consumer v1.64.0 h1:6ou2lspkcCmv7IjOEnYTZz6pYLEGfrEqvbfxMVPInug=

--- a/receiver/gcspubsubeventreceiver/internal/worker/backoff.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/backoff.go
@@ -1,0 +1,67 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.uber.org/zap"
+)
+
+// newExponentialBackOff builds a cenkalti ExponentialBackOff from cfg. The caller is
+// responsible for checking cfg.Enabled.
+func newExponentialBackOff(cfg configretry.BackOffConfig) *backoff.ExponentialBackOff {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = cfg.InitialInterval
+	bo.RandomizationFactor = cfg.RandomizationFactor
+	bo.Multiplier = cfg.Multiplier
+	bo.MaxInterval = cfg.MaxInterval
+	bo.MaxElapsedTime = cfg.MaxElapsedTime
+	bo.Reset()
+	return bo
+}
+
+// consumeWithRetry calls consume, retrying a transient failure with exponential backoff
+// until it succeeds, returns a permanent error, exhausts the backoff, or ctx is cancelled.
+// When cfg.Enabled is false it calls consume exactly once, preserving the prior behavior
+// where redelivery is left to the broker's visibility timeout / ack deadline.
+func consumeWithRetry(ctx context.Context, cfg configretry.BackOffConfig, logger *zap.Logger, consume func() error) error {
+	err := consume()
+	if err == nil || !cfg.Enabled || consumererror.IsPermanent(err) {
+		return err
+	}
+
+	bo := newExponentialBackOff(cfg)
+	for {
+		delay := bo.NextBackOff()
+		if delay == backoff.Stop {
+			return err
+		}
+		logger.Debug("downstream consume failed; backing off before retry",
+			zap.Duration("delay", delay), zap.Error(err))
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(delay):
+		}
+		if err = consume(); err == nil || consumererror.IsPermanent(err) {
+			return err
+		}
+	}
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/backoff_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/backoff_test.go
@@ -1,0 +1,106 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.uber.org/zap"
+)
+
+func fastBackOff(enabled bool) configretry.BackOffConfig {
+	return configretry.BackOffConfig{
+		Enabled:             enabled,
+		InitialInterval:     time.Millisecond,
+		RandomizationFactor: 0,
+		Multiplier:          1,
+		MaxInterval:         time.Millisecond,
+		MaxElapsedTime:      50 * time.Millisecond,
+	}
+}
+
+// TestConsumeWithRetry_DisabledCallsOnce asserts that with backoff disabled the consume
+// runs exactly once and the error is returned unchanged (prior behavior).
+func TestConsumeWithRetry_DisabledCallsOnce(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := consumeWithRetry(context.Background(), fastBackOff(false), zap.NewNop(), func() error {
+		calls++
+		return errors.New("boom")
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+}
+
+// TestConsumeWithRetry_RetriesThenSucceeds asserts a transient failure is retried with
+// backoff until it succeeds.
+func TestConsumeWithRetry_RetriesThenSucceeds(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := consumeWithRetry(context.Background(), fastBackOff(true), zap.NewNop(), func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, calls)
+}
+
+// TestConsumeWithRetry_PermanentNotRetried asserts a permanent error bypasses backoff.
+func TestConsumeWithRetry_PermanentNotRetried(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := consumeWithRetry(context.Background(), fastBackOff(true), zap.NewNop(), func() error {
+		calls++
+		return consumererror.NewPermanent(errors.New("permanent"))
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+}
+
+// TestConsumeWithRetry_StopsOnContextCancel asserts a cancelled context ends the retry loop.
+func TestConsumeWithRetry_StopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	err := consumeWithRetry(ctx, fastBackOff(true), zap.NewNop(), func() error {
+		calls++
+		return errors.New("transient")
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, calls, "a cancelled context must not drive further attempts")
+}
+
+// TestConsumeWithRetry_GivesUpAfterMaxElapsed asserts the loop eventually returns the last
+// error once the backoff is exhausted rather than retrying forever.
+func TestConsumeWithRetry_GivesUpAfterMaxElapsed(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := consumeWithRetry(context.Background(), fastBackOff(true), zap.NewNop(), func() error {
+		calls++
+		return errors.New("always fails")
+	})
+	require.Error(t, err)
+	require.Greater(t, calls, 1, "an exhausted backoff should have retried at least once")
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/cleanup_context.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/cleanup_context.go
@@ -1,0 +1,45 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// cleanupTimeout bounds each wind-down call, so a shutdown cannot block forever.
+const cleanupTimeout = 30 * time.Second
+
+// isCancellation reports a cancelled context or an expired deadline. A config push
+// or a shutdown causes it. It is routine, and never a DLQ condition.
+func isCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// cleanupContext detaches ctx from its cancellation and applies cleanupTimeout. The
+// checkpoint, ack, and nack then run after the cancellation that stopped processing.
+func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+}
+
+// drainContext returns ctx while it is live, and a cleanupContext after cancellation.
+// Records already read are then delivered and checkpointed, not re-read.
+func drainContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx.Err() == nil {
+		return context.WithCancel(ctx)
+	}
+	return cleanupContext(ctx)
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/cleanup_context_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/cleanup_context_test.go
@@ -1,0 +1,105 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal test file — uses package worker to access unexported symbols.
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsCancellation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "context.Canceled", err: context.Canceled, want: true},
+		{name: "wrapped context.Canceled", err: fmt.Errorf("read object: %w", context.Canceled), want: true},
+		{name: "context.DeadlineExceeded", err: context.DeadlineExceeded, want: true},
+		{name: "wrapped context.DeadlineExceeded", err: fmt.Errorf("read object: %w", context.DeadlineExceeded), want: true},
+		{name: "unrelated error", err: errors.New("connection reset by peer"), want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isCancellation(tc.err))
+		})
+	}
+}
+
+func TestCleanupContext_OutlivesParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	parent, cancelParent := context.WithCancel(context.Background())
+	cancelParent()
+
+	cleanup, cancel := cleanupContext(parent)
+	defer cancel()
+
+	require.NoError(t, cleanup.Err(), "wind-down work must not inherit the parent's cancellation")
+
+	deadline, ok := cleanup.Deadline()
+	require.True(t, ok, "wind-down work must be bounded by a deadline")
+	require.WithinDuration(t, time.Now().Add(cleanupTimeout), deadline, time.Second)
+
+	cancel()
+	require.ErrorIs(t, cleanup.Err(), context.Canceled, "the returned cancel must still release the context")
+}
+
+func TestDrainContext_FollowsLiveParentAndDetachesFromCancelledOne(t *testing.T) {
+	t.Parallel()
+
+	live, cancelLive := context.WithCancel(context.Background())
+	defer cancelLive()
+
+	drain, cancelDrain := drainContext(live)
+	require.NoError(t, drain.Err())
+	cancelLive()
+	require.ErrorIs(t, drain.Err(), context.Canceled, "a live parent still governs the drain")
+	cancelDrain()
+
+	dead, cancelDead := context.WithCancel(context.Background())
+	cancelDead()
+
+	detached, cancelDetached := drainContext(dead)
+	defer cancelDetached()
+	require.NoError(t, detached.Err(), "an already-cancelled parent must not cancel the drain")
+}
+
+func TestDLQConditionKind_CancellationIsNeverDLQ(t *testing.T) {
+	t.Parallel()
+
+	// A config push cancels the context mid-object. Routing that to the dead-letter
+	// queue would send good data to the DLQ on every config change.
+	for _, err := range []error{
+		context.Canceled,
+		context.DeadlineExceeded,
+		fmt.Errorf("read object: %w", context.Canceled),
+		fmt.Errorf("read object: %w", context.DeadlineExceeded),
+	} {
+		require.Equal(t, dlqErrorKindNone, dlqConditionKind(err), "err: %v", err)
+		require.False(t, isDLQConditionError(err), "err: %v", err)
+	}
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/drain_failure_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/drain_failure_test.go
@@ -1,0 +1,90 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/observiq/bindplane-otel-contrib/internal/storageclient"
+	"github.com/observiq/bindplane-otel-contrib/receiver/gcspubsubeventreceiver/internal/metadata"
+)
+
+// errStorage fails every save, so the checkpoint error path runs.
+type errStorage struct{ err error }
+
+func (s errStorage) SaveStorageData(context.Context, string, storageclient.StorageData) error {
+	return s.err
+}
+func (s errStorage) LoadStorageData(context.Context, string, storageclient.StorageData) error {
+	return nil
+}
+func (s errStorage) DeleteStorageData(context.Context, string) error { return nil }
+func (s errStorage) Close(context.Context) error                     { return nil }
+
+func newTestObsReport(t *testing.T) *receiverhelper.ObsReport {
+	t.Helper()
+	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		ReceiverID:             component.NewID(metadata.Type),
+		Transport:              "pubsub",
+		ReceiverCreateSettings: receivertest.NewNopSettings(metadata.Type),
+	})
+	require.NoError(t, err)
+	return obsrecv
+}
+
+// TestFlush_ReportsConsumerFailure asserts a rejected batch surfaces as an error and a
+// log line. The caller nacks the message, so the object is redelivered.
+func TestFlush_ReportsConsumerFailure(t *testing.T) {
+	t.Parallel()
+
+	consumeErr := errors.New("pipeline backpressure")
+	core, logs := observer.New(zap.ErrorLevel)
+
+	w := &Worker{
+		nextConsumer: consumertest.NewErr(consumeErr),
+		obsrecv:      newTestObsReport(t),
+	}
+
+	err := w.flush(context.Background(), plog.NewLogs(), 3, zap.New(core))
+	require.ErrorIs(t, err, consumeErr)
+	require.ErrorContains(t, err, "consume logs")
+	require.Equal(t, 1, logs.FilterMessage("consume logs").Len())
+}
+
+// TestCheckpoint_LogsSaveFailure asserts a failed save is logged rather than dropped.
+// The offset stays where it was, so the object resumes from the last saved position.
+func TestCheckpoint_LogsSaveFailure(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zap.ErrorLevel)
+	w := &Worker{offsetStorage: errStorage{err: errors.New("storage extension unavailable")}}
+
+	w.checkpoint(context.Background(), "_gcs_pub_event_offset_key", Offset{EntryIndex: 2, Offset: 512}, zap.New(core))
+
+	entries := logs.FilterMessage("Failed to save offset").All()
+	require.Len(t, entries, 1)
+	require.Equal(t, int64(512), entries[0].ContextMap()["offset"])
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/flush_failure_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/flush_failure_test.go
@@ -1,0 +1,100 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.uber.org/zap"
+	"google.golang.org/api/option"
+)
+
+// fakeGCSCompleteBody serves object metadata and then the full object body, so the worker
+// reads the object cleanly. It is the success-path counterpart to fakeGCSBrokenStream.
+func fakeGCSCompleteBody(t *testing.T, body string) *storage.Client {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("alt") != "media" && strings.Contains(r.URL.Path, "/storage/v1/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"myobject","bucket":"mybucket","contentType":"text/plain"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := storage.NewClient(context.Background(),
+		option.WithEndpoint(srv.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func newGCSFlushFailWorker(t *testing.T, body string, maxLogsEmitted int, consumeErr error) *Worker {
+	t.Helper()
+	return &Worker{
+		storageClient:  fakeGCSCompleteBody(t, body),
+		nextConsumer:   consumertest.NewErr(consumeErr),
+		offsetStorage:  errStorage{},
+		obsrecv:        newTestObsReport(t),
+		maxLogSize:     4096,
+		maxLogsEmitted: maxLogsEmitted,
+	}
+}
+
+// TestConsumeGCS_TrailingFlushFailureFailsObject asserts that when the final batch is
+// rejected by the next consumer, consumeLogsFromGCSObject returns the error so the object
+// is not acked (the message is preserved for retry).
+func TestConsumeGCS_TrailingFlushFailureFailsObject(t *testing.T) {
+	t.Parallel()
+
+	consumeErr := errors.New("pipeline backpressure")
+	// Fewer records than maxLogsEmitted, so only the trailing flush runs.
+	w := newGCSFlushFailWorker(t, "line1\nline2\n", 1000, consumeErr)
+
+	err := w.consumeLogsFromGCSObject(context.Background(), "mybucket", "myobject", false, zap.NewNop())
+	require.ErrorIs(t, err, consumeErr)
+	require.ErrorContains(t, err, "consume logs")
+}
+
+// TestConsumeGCS_MidLoopFlushFailureFailsObject asserts that when a mid-object batch (the
+// one emitted once maxLogsEmitted is reached) is rejected, consumeLogsFromGCSObject
+// returns the error immediately rather than continuing to read.
+func TestConsumeGCS_MidLoopFlushFailureFailsObject(t *testing.T) {
+	t.Parallel()
+
+	consumeErr := errors.New("pipeline backpressure")
+	// maxLogsEmitted of 1 forces a flush after the first record, mid-loop.
+	w := newGCSFlushFailWorker(t, "line1\nline2\nline3\n", 1, consumeErr)
+
+	err := w.consumeLogsFromGCSObject(context.Background(), "mybucket", "myobject", false, zap.NewNop())
+	require.ErrorIs(t, err, consumeErr)
+	require.ErrorContains(t, err, "consume logs")
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/handle_processing_error_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/handle_processing_error_test.go
@@ -1,0 +1,67 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/observiq/bindplane-otel-contrib/receiver/gcspubsubeventreceiver/internal/metadata"
+)
+
+func newTestMetrics(t *testing.T) *metadata.TelemetryBuilder {
+	t.Helper()
+	tb, err := metadata.NewTelemetryBuilder(componenttest.NewNopTelemetrySettings())
+	require.NoError(t, err)
+	return tb
+}
+
+// TestHandleProcessingError_DeadlineExceededDoesNotHotRedeliver asserts that a downstream
+// timeout (context.DeadlineExceeded) with a live context is treated as a transient failure
+// (preserve for the ack deadline to lapse), not a cancellation nacked for immediate redelivery.
+func TestHandleProcessingError_DeadlineExceededDoesNotHotRedeliver(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zap.DebugLevel)
+	w := &Worker{metrics: newTestMetrics(t)} // subClient nil: nack is a no-op
+
+	w.handleProcessingError(context.Background(), "ack-id", "sub", context.DeadlineExceeded, zap.New(core))
+
+	require.Equal(t, 1, logs.FilterMessage("error processing record, preserving message for retry").Len(),
+		"a live-context downstream timeout must take the preserve-for-retry path")
+	require.Zero(t, logs.FilterMessage("processing cancelled, nacking message for redelivery").Len(),
+		"a downstream timeout must not be treated as a cancellation")
+}
+
+// TestHandleProcessingError_ShutdownNacksImmediately asserts that a cancelled context (a
+// shutdown / config push) is nacked for immediate redelivery so it resumes from the checkpoint.
+func TestHandleProcessingError_ShutdownNacksImmediately(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zap.DebugLevel)
+	w := &Worker{metrics: newTestMetrics(t)}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	w.handleProcessingError(ctx, "ack-id", "sub", context.DeadlineExceeded, zap.New(core))
+
+	require.Equal(t, 1, logs.FilterMessage("processing cancelled, nacking message for redelivery").Len(),
+		"a cancelled context is a shutdown and must nack for immediate redelivery")
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/offset_ack_ordering_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/offset_ack_ordering_test.go
@@ -1,0 +1,52 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/observiq/bindplane-otel-contrib/receiver/gcspubsubeventreceiver/internal/worker"
+)
+
+// TestProcessMessage_OffsetKeptWhenAckFails asserts the object's saved offset is not
+// deleted when the ack fails. Deleting it before a successful ack means a redelivery
+// (the message was never acked) reprocesses the whole object from the start, duplicating
+// every record. The offset must survive an ack failure as the resume point.
+func TestProcessMessage_OffsetKeptWhenAckFails(t *testing.T) {
+	store := newMemStorage()
+	// A complete object: the head exceeds the content-detection window, then a final line.
+	client := fakeGCS(t, strings.Repeat("x", 4000)+"\n", "line\n", false)
+	h := newGCSHarness(t, finalizeAttrs(), 1000, store, client, func() {}, 0)
+
+	msg := &worker.PullMessage{
+		AckID:      h.pubsub.ackID,
+		MessageID:  h.pubsub.messageID,
+		Attributes: h.pubsub.srv.Message(h.pubsub.messageID).Attributes,
+	}
+	// A subscription that does not exist makes Acknowledge fail fast with NotFound (a
+	// non-retryable error), while the GCS read uses a separate httptest server and still
+	// succeeds, so processing completes and only the ack fails.
+	badSub := "projects/test/subscriptions/does-not-exist"
+	h.worker.ProcessMessage(context.Background(), msg, badSub, func() {})
+
+	offsetKey := fmt.Sprintf("%s_%s", worker.OffsetStorageKey, "myobject")
+	require.NotContains(t, store.deleted, offsetKey,
+		"offset must be preserved when the ack fails, so a redelivery resumes rather than reprocessing")
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/stream_failure_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/stream_failure_test.go
@@ -1,0 +1,89 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+)
+
+// fakeGCSBrokenStream serves an object's metadata normally, then on the media read
+// declares more bytes than it sends and drops the connection part way through. The
+// client's read of the body fails rather than ending cleanly, which surfaces a raw
+// read error the worker classifies as a broken source stream (a transient failure).
+func fakeGCSBrokenStream(t *testing.T, head string) *storage.Client {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("alt") != "media" && strings.Contains(r.URL.Path, "/storage/v1/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"myobject","bucket":"mybucket","contentType":"text/plain"}`)
+			return
+		}
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Errorf("test ResponseWriter does not support hijacking")
+			return
+		}
+		conn, buf, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		// Promise 64 more bytes than we deliver, then drop the connection, so the
+		// client sees a read error mid-body rather than a clean short read.
+		fmt.Fprintf(buf, "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n", len(head)+64)
+		_, _ = buf.WriteString(head)
+		_ = buf.Flush()
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := storage.NewClient(context.Background(),
+		option.WithEndpoint(srv.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+// TestProcessMessage_BacksOffWhenObjectStreamBreaks asserts that an interrupted
+// download (a broken source stream) preserves the message for retry by letting the
+// ack deadline lapse, rather than nacking it for immediate redelivery. Immediate
+// redelivery would spin against a persistently broken stream; the awss3 receiver
+// backs off via its visibility timeout, and this receiver must match. Cancellation
+// and DLQ conditions still nack for immediate redelivery.
+func TestProcessMessage_BacksOffWhenObjectStreamBreaks(t *testing.T) {
+	head, _ := objectLines(0, 250) // exceeds the content-detection window
+	client := fakeGCSBrokenStream(t, head)
+	h := newGCSHarness(t, finalizeAttrs(), 1000, newMemStorage(), client, func() {}, 0)
+
+	h.process(context.Background())
+
+	require.False(t, h.pubsub.nacked(),
+		"a broken object stream must let the ack deadline lapse for backoff, not nack for immediate redelivery")
+	require.Zero(t, h.pubsub.acks(),
+		"a broken object stream must not ack the message")
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/worker.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/worker.go
@@ -184,28 +184,28 @@ func (w *Worker) ProcessMessage(ctx context.Context, msg *PullMessage, subscript
 	// Filter for OBJECT_FINALIZE events only
 	if eventType != EventTypeObjectFinalize {
 		logger.Debug("skipping non-OBJECT_FINALIZE event")
-		w.ackMessage(ctx, msg.AckID, subscriptionPath)
+		_ = w.ackMessage(ctx, msg.AckID, subscriptionPath)
 		return false
 	}
 
 	// Validate required attributes
 	if bucketID == "" || objectID == "" {
 		logger.Warn("message missing required attributes (bucketId, objectId)")
-		w.ackMessage(ctx, msg.AckID, subscriptionPath)
+		_ = w.ackMessage(ctx, msg.AckID, subscriptionPath)
 		return false
 	}
 
 	// Apply bucket name filter
 	if w.bucketNameFilter != nil && !w.bucketNameFilter.MatchString(bucketID) {
 		logger.Debug("skipping message due to bucket name filter")
-		w.ackMessage(ctx, msg.AckID, subscriptionPath)
+		_ = w.ackMessage(ctx, msg.AckID, subscriptionPath)
 		return false
 	}
 
 	// Apply object key filter
 	if w.objectKeyFilter != nil && !w.objectKeyFilter.MatchString(objectID) {
 		logger.Debug("skipping message due to object key filter")
-		w.ackMessage(ctx, msg.AckID, subscriptionPath)
+		_ = w.ackMessage(ctx, msg.AckID, subscriptionPath)
 		return false
 	}
 

--- a/receiver/gcspubsubeventreceiver/internal/worker/worker.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/worker.go
@@ -26,6 +26,7 @@ import (
 	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
 	"cloud.google.com/go/storage"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -73,6 +74,7 @@ type Worker struct {
 	obsrecv          *receiverhelper.ObsReport
 	subClient        *subscriber.SubscriberClient
 	maxExtension     time.Duration
+	errorBackOff     configretry.BackOffConfig
 }
 
 // Option is a functional option for configuring the Worker
@@ -102,6 +104,13 @@ func WithTelemetryBuilder(tb *metadata.TelemetryBuilder) Option {
 		if tb != nil {
 			w.metrics = tb
 		}
+	}
+}
+
+// WithErrorBackOff sets the retry backoff applied when a downstream consume fails.
+func WithErrorBackOff(cfg configretry.BackOffConfig) Option {
+	return func(w *Worker) {
+		w.errorBackOff = cfg
 	}
 }
 
@@ -211,28 +220,45 @@ func (w *Worker) ProcessMessage(ctx context.Context, msg *PullMessage, subscript
 
 	w.metrics.GcseventObjectsHandled.Add(ctx, 1)
 
-	// Clean up offset storage for the processed object
+	// Ack first, then delete the offset only once the ack succeeds. If the ack fails the
+	// message redelivers, so the offset must remain as the resume point; deleting it
+	// first would reprocess the whole object from the start on that redelivery.
+	if err := w.ackMessage(ctx, msg.AckID, subscriptionPath); err != nil {
+		return false
+	}
+	logger.Debug("message acked")
+
+	// Delete the offset on a detached context. A cancellation would otherwise leave a
+	// stale offset for an acked object.
+	deleteCtx, cancelDelete := cleanupContext(ctx)
 	offsetStorageKey := fmt.Sprintf("%s_%s", OffsetStorageKey, objectID)
-	if err := w.offsetStorage.DeleteStorageData(ctx, offsetStorageKey); err != nil {
+	if err := w.offsetStorage.DeleteStorageData(deleteCtx, offsetStorageKey); err != nil {
 		logger.Error("failed to delete offset", zap.Error(err), zap.String("offset_storage_key", offsetStorageKey))
 	}
+	cancelDelete()
 
-	w.ackMessage(ctx, msg.AckID, subscriptionPath)
-	logger.Debug("message acked")
 	return true
 }
 
-// ackMessage acknowledges a message so Pub/Sub does not redeliver it.
-func (w *Worker) ackMessage(ctx context.Context, ackID, subscriptionPath string) {
+// ackMessage acknowledges a message so Pub/Sub does not redeliver it. It returns the
+// acknowledge error so the caller can keep the offset when the ack does not land.
+func (w *Worker) ackMessage(ctx context.Context, ackID, subscriptionPath string) error {
 	if w.subClient == nil {
-		return
+		return nil
 	}
-	if err := w.subClient.Acknowledge(ctx, &pubsubpb.AcknowledgeRequest{
+	// Ack on a detached context. A cancellation must not leave a processed object in
+	// the subscription.
+	ackCtx, cancel := cleanupContext(ctx)
+	defer cancel()
+
+	if err := w.subClient.Acknowledge(ackCtx, &pubsubpb.AcknowledgeRequest{
 		Subscription: subscriptionPath,
 		AckIds:       []string{ackID},
 	}); err != nil {
 		w.logger.Error("failed to ack message", zap.Error(err), zap.String("ack_id", ackID))
+		return err
 	}
+	return nil
 }
 
 // nackMessage makes a message immediately available for redelivery by setting
@@ -241,7 +267,12 @@ func (w *Worker) nackMessage(ctx context.Context, ackID, subscriptionPath string
 	if w.subClient == nil {
 		return
 	}
-	if err := w.subClient.ModifyAckDeadline(ctx, &pubsubpb.ModifyAckDeadlineRequest{
+	// Nack on a detached context. The message then redelivers without waiting for the
+	// full ack deadline.
+	nackCtx, cancel := cleanupContext(ctx)
+	defer cancel()
+
+	if err := w.subClient.ModifyAckDeadline(nackCtx, &pubsubpb.ModifyAckDeadlineRequest{
 		Subscription:       subscriptionPath,
 		AckIds:             []string{ackID},
 		AckDeadlineSeconds: 0,
@@ -375,8 +406,16 @@ func (w *Worker) consumeLogsFromGCSObject(ctx context.Context, bucket, object st
 		return fmt.Errorf("parse logs: %w", err)
 	}
 
+	// parseErr records a cancellation that stopped the read. The records already read
+	// are delivered below. The error is returned, so the message nacks.
+	var parseErr error
+
 	for log, err := range logs {
 		if err != nil {
+			if isCancellation(err) {
+				parseErr = err
+				break
+			}
 			// A DLQ-condition error (for example an archive-bomb limit) is fatal for
 			// the whole object: fail so the message is routed to the DLQ rather than
 			// silently skipped.
@@ -411,23 +450,15 @@ func (w *Worker) consumeLogsFromGCSObject(ctx context.Context, bucket, object st
 		}
 
 		if ld.LogRecordCount() >= w.maxLogsEmitted {
-			obsCtx := w.obsrecv.StartLogsOp(ctx)
-			if err := w.nextConsumer.ConsumeLogs(ctx, ld); err != nil {
-				w.obsrecv.EndLogsOp(obsCtx, metadata.Type.String(), ld.LogRecordCount(), err)
-				recordLogger.Error("consume logs", zap.Error(err), zap.Int("batches_consumed_count", batchesConsumedCount))
-				return fmt.Errorf("consume logs: %w", err)
+			if err := w.flush(ctx, ld, batchesConsumedCount, recordLogger); err != nil {
+				return err
 			}
-			w.metrics.GcseventBatchSize.Record(ctx, int64(ld.LogRecordCount()))
-			w.obsrecv.EndLogsOp(obsCtx, metadata.Type.String(), ld.LogRecordCount(), nil)
 
 			batchesConsumedCount++
 			recordLogger.Debug("Reached max logs for single batch, starting new batch", zap.Int("batches_consumed_count", batchesConsumedCount))
 
 			// Save the offset to storage
-			pos := producer.position()
-			if err := w.offsetStorage.SaveStorageData(ctx, offsetStorageKey, &pos); err != nil {
-				recordLogger.Error("Failed to save offset", zap.Error(err), zap.String("offset_storage_key", offsetStorageKey), zap.Int("entry_index", pos.EntryIndex), zap.Int64("offset", pos.Offset))
-			}
+			w.checkpoint(ctx, offsetStorageKey, producer.position(), recordLogger)
 
 			ld = plog.NewLogs()
 			rls = ld.ResourceLogs().AppendEmpty()
@@ -437,27 +468,58 @@ func (w *Worker) consumeLogsFromGCSObject(ctx context.Context, bucket, object st
 		}
 	}
 
-	if ld.LogRecordCount() == 0 {
-		return nil
-	}
-	w.metrics.GcseventBatchSize.Record(ctx, int64(ld.LogRecordCount()))
+	if ld.LogRecordCount() > 0 {
+		if err := w.flush(ctx, ld, batchesConsumedCount, recordLogger); err != nil {
+			return err
+		}
+		if parseErr == nil {
+			recordLogger.Debug("processed GCS object", zap.Int("batches_consumed_count", batchesConsumedCount+1))
+		}
 
-	obsCtx := w.obsrecv.StartLogsOp(ctx)
-	if err := w.nextConsumer.ConsumeLogs(ctx, ld); err != nil {
-		w.obsrecv.EndLogsOp(obsCtx, metadata.Type.String(), ld.LogRecordCount(), err)
-		recordLogger.Error("consume logs", zap.Error(err), zap.Int("batches_consumed_count", batchesConsumedCount))
-		return fmt.Errorf("consume logs: %w", err)
+		// Save the offset to storage
+		w.checkpoint(ctx, offsetStorageKey, producer.position(), recordLogger)
 	}
-	w.obsrecv.EndLogsOp(obsCtx, metadata.Type.String(), ld.LogRecordCount(), nil)
-	recordLogger.Debug("processed GCS object", zap.Int("batches_consumed_count", batchesConsumedCount+1))
 
-	// Save the offset to storage
-	pos := producer.position()
-	if err := w.offsetStorage.SaveStorageData(ctx, offsetStorageKey, &pos); err != nil {
-		recordLogger.Error("Failed to save offset", zap.Error(err), zap.String("offset_storage_key", offsetStorageKey), zap.Int("entry_index", pos.EntryIndex), zap.Int64("offset", pos.Offset))
+	if parseErr != nil {
+		// The read stopped partway. Everything read is delivered and checkpointed
+		// above, so redelivery resumes at the first unread record.
+		return fmt.Errorf("read object: %w", parseErr)
 	}
 
 	return nil
+}
+
+// flush sends a batch to the next consumer on a drain context. Records already read
+// are delivered during wind-down.
+//
+// The line parser drops a truncated record, so a batch always ends on a record
+// boundary and the checkpoint stays accurate. Reading stops at the next failed refill.
+func (w *Worker) flush(ctx context.Context, ld plog.Logs, batchesConsumedCount int, recordLogger *zap.Logger) error {
+	flushCtx, cancel := drainContext(ctx)
+	defer cancel()
+
+	obsCtx := w.obsrecv.StartLogsOp(flushCtx)
+	err := consumeWithRetry(flushCtx, w.errorBackOff, recordLogger, func() error {
+		return w.nextConsumer.ConsumeLogs(flushCtx, ld)
+	})
+	w.obsrecv.EndLogsOp(obsCtx, metadata.Type.String(), ld.LogRecordCount(), err)
+	if err != nil {
+		recordLogger.Error("consume logs", zap.Error(err), zap.Int("batches_consumed_count", batchesConsumedCount))
+		return fmt.Errorf("consume logs: %w", err)
+	}
+	w.metrics.GcseventBatchSize.Record(flushCtx, int64(ld.LogRecordCount()))
+	return nil
+}
+
+// checkpoint saves the parse position on a drain context. A late cancellation then
+// cannot lose the offset.
+func (w *Worker) checkpoint(ctx context.Context, offsetStorageKey string, pos Offset, recordLogger *zap.Logger) {
+	saveCtx, cancel := drainContext(ctx)
+	defer cancel()
+
+	if err := w.offsetStorage.SaveStorageData(saveCtx, offsetStorageKey, &pos); err != nil {
+		recordLogger.Error("Failed to save offset", zap.Error(err), zap.String("offset_storage_key", offsetStorageKey), zap.Int("entry_index", pos.EntryIndex), zap.Int64("offset", pos.Offset))
+	}
 }
 
 // dlqErrorKind categorizes an error into a DLQ condition bucket.
@@ -473,7 +535,9 @@ const (
 // dlqConditionKind returns the DLQ error kind for the given error, or
 // dlqErrorKindNone if the error does not trigger a DLQ condition.
 func dlqConditionKind(err error) dlqErrorKind {
-	if err == nil {
+	// Cancellation is never a DLQ condition. A config push must not send good data to
+	// the dead-letter queue.
+	if err == nil || isCancellation(err) {
 		return dlqErrorKindNone
 	}
 	// GCS returns storage.ErrObjectNotExist when the object is not found.
@@ -540,13 +604,27 @@ func (w *Worker) recordDLQMetrics(ctx context.Context, err error) {
 // redelivery / DLQ processing. For transient errors the message is also nacked
 // so Pub/Sub can redeliver it after the ack deadline expires.
 func (w *Worker) handleProcessingError(ctx context.Context, ackID, subscriptionPath string, err error, logger *zap.Logger) {
+	// Only a genuine shutdown/config-push counts as a cancellation: our own context is
+	// cancelled, or the error is context.Canceled. A bare DeadlineExceeded with a live
+	// context is a downstream timeout (backpressure), not a shutdown, so it must fall
+	// through to the retry path below rather than nacking for immediate redelivery.
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		// A config push or a shutdown cancelled the context. Nack the message, so it
+		// redelivers at once and resumes from the checkpoint. This is not a failure.
+		logger.Info("processing cancelled, nacking message for redelivery", zap.Error(err))
+		w.nackMessage(ctx, ackID, subscriptionPath)
+		return
+	}
 	if isDLQConditionError(err) {
 		logger.Error("DLQ condition triggered, nacking message for redelivery/DLQ processing", zap.Error(err))
 		w.recordDLQMetrics(ctx, err)
 		w.nackMessage(ctx, ackID, subscriptionPath)
 		return
 	}
-	logger.Error("error processing record, nacking message for retry", zap.Error(err))
+	// A transient failure such as a broken source stream. Preserve the message and let
+	// the ack deadline lapse, so redelivery backs off instead of retrying at once. This
+	// matches the awss3 receiver's visibility-timeout behavior. The cancellation and DLQ
+	// conditions above still nack for immediate redelivery.
+	logger.Error("error processing record, preserving message for retry", zap.Error(err))
 	w.metrics.GcseventFailures.Add(ctx, 1)
-	w.nackMessage(ctx, ackID, subscriptionPath)
 }

--- a/receiver/gcspubsubeventreceiver/internal/worker/worker_cancellation_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/worker_cancellation_test.go
@@ -1,0 +1,412 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	publisher "cloud.google.com/go/pubsub/apiv1"
+	subscriber "cloud.google.com/go/pubsub/apiv1"
+	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
+	"cloud.google.com/go/pubsub/pstest"
+	"cloud.google.com/go/storage"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/observiq/bindplane-otel-contrib/internal/storageclient"
+	"github.com/observiq/bindplane-otel-contrib/receiver/gcspubsubeventreceiver/internal/metadata"
+	"github.com/observiq/bindplane-otel-contrib/receiver/gcspubsubeventreceiver/internal/worker"
+)
+
+// memStorage is an in-memory StorageClient that obeys context cancellation. A test can
+// then tell whether a checkpoint ran on a live context.
+type memStorage struct {
+	mu        sync.Mutex
+	data      map[string][]byte
+	deleted   []string // keys passed to DeleteStorageData, for tests asserting delete ordering
+	deleteErr error    // when set, DeleteStorageData fails with it, for the delete-error path
+}
+
+func newMemStorage() *memStorage {
+	return &memStorage{data: map[string][]byte{}}
+}
+
+func (m *memStorage) SaveStorageData(ctx context.Context, key string, data storageclient.StorageData) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	b, err := data.Marshal()
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[key] = b
+	return nil
+}
+
+func (m *memStorage) LoadStorageData(ctx context.Context, key string, data storageclient.StorageData) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	b, ok := m.data[key]
+	if !ok {
+		return nil
+	}
+	return data.Unmarshal(b)
+}
+
+func (m *memStorage) DeleteStorageData(ctx context.Context, key string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deleted = append(m.deleted, key)
+	delete(m.data, key)
+	return nil
+}
+
+func (m *memStorage) Close(context.Context) error { return nil }
+
+// fakeGCS serves an object as head followed by tail, so the storage client can stream
+// from an httptest server rather than real GCS. When hold is set the handler stops after
+// head and keeps the response open until the request context is cancelled, which is what
+// puts a cancellation partway through the worker's read rather than before it starts.
+// head must exceed the content-detection window, or the worker blocks before parsing.
+func fakeGCS(t *testing.T, head, tail string, hold bool) *storage.Client {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Object metadata lookups get a minimal JSON payload; everything else is a read.
+		if r.URL.Query().Get("alt") != "media" && strings.Contains(r.URL.Path, "/storage/v1/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"myobject","bucket":"mybucket","contentType":"text/plain"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Length", strconv.Itoa(len(head)+len(tail)))
+		_, _ = io.WriteString(w, head)
+		if hold {
+			// The declared length is never satisfied, so the client keeps waiting until
+			// its request context is cancelled.
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			<-r.Context().Done()
+			return
+		}
+		_, _ = io.WriteString(w, tail)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := storage.NewClient(context.Background(),
+		option.WithEndpoint(srv.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+// fakePubSub stands up a pstest server with one topic and subscription, publishes a
+// message carrying attrs, and pulls it so the returned ack ID is live.
+type fakePubSub struct {
+	srv          *pstest.Server
+	client       *subscriber.SubscriberClient
+	subscription string
+	messageID    string
+	ackID        string
+}
+
+func newFakePubSub(t *testing.T, attrs map[string]string) *fakePubSub {
+	t.Helper()
+
+	ctx := context.Background()
+	srv := pstest.NewServer()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	conn, err := grpc.NewClient(srv.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	pubClient, err := publisher.NewPublisherClient(ctx, option.WithGRPCConn(conn))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pubClient.Close() })
+
+	subClient, err := subscriber.NewSubscriberClient(ctx, option.WithGRPCConn(conn))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = subClient.Close() })
+
+	const topic = "projects/test/topics/test-topic"
+	const subscription = "projects/test/subscriptions/test-sub"
+
+	_, err = pubClient.CreateTopic(ctx, &pubsubpb.Topic{Name: topic})
+	require.NoError(t, err)
+	_, err = subClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name:               subscription,
+		Topic:              topic,
+		AckDeadlineSeconds: 600,
+	})
+	require.NoError(t, err)
+
+	messageID := srv.Publish(topic, []byte("{}"), attrs)
+
+	pull, err := subClient.Pull(ctx, &pubsubpb.PullRequest{
+		Subscription: subscription,
+		MaxMessages:  1,
+	})
+	require.NoError(t, err)
+	require.Len(t, pull.ReceivedMessages, 1)
+
+	return &fakePubSub{
+		srv:          srv,
+		client:       subClient,
+		subscription: subscription,
+		messageID:    messageID,
+		ackID:        pull.ReceivedMessages[0].AckId,
+	}
+}
+
+func (f *fakePubSub) acks() int {
+	return f.srv.Message(f.messageID).Acks
+}
+
+// nacked reports whether the message had its ack deadline set to 0, which is how the
+// worker makes a message immediately available for redelivery.
+func (f *fakePubSub) nacked() bool {
+	for _, m := range f.srv.Message(f.messageID).Modacks {
+		if m.AckDeadline == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+type gcsHarness struct {
+	worker *worker.Worker
+	pubsub *fakePubSub
+	sink   *consumertest.LogsSink
+	logs   *observer.ObservedLogs
+}
+
+// newGCSHarness builds a worker over a fake Pub/Sub and, when storageClient is non-nil, a
+// fake GCS. cancelAfterBatches makes the downstream consumer cancel the worker's context
+// once it has accepted that many batches, which is how a config push lands partway
+// through an object. Zero leaves the context alone.
+func newGCSHarness(t *testing.T, attrs map[string]string, maxLogsEmitted int, store *memStorage,
+	storageClient *storage.Client, cancel context.CancelFunc, cancelAfterBatches int) *gcsHarness {
+	t.Helper()
+
+	ps := newFakePubSub(t, attrs)
+
+	core, recorded := observer.New(zap.DebugLevel)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zap.New(core)
+
+	tb, err := metadata.NewTelemetryBuilder(set)
+	require.NoError(t, err)
+
+	params := receivertest.NewNopSettings(metadata.Type)
+	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		ReceiverID:             params.ID,
+		Transport:              "pubsub",
+		ReceiverCreateSettings: params,
+	})
+	require.NoError(t, err)
+
+	sink := new(consumertest.LogsSink)
+	batches := 0
+	// Downstream consumers reject a cancelled context, so the sink must also reject it.
+	next, err := consumer.NewLogs(func(ctx context.Context, ld plog.Logs) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := sink.ConsumeLogs(ctx, ld); err != nil {
+			return err
+		}
+		batches++
+		if cancelAfterBatches > 0 && batches == cancelAfterBatches {
+			cancel()
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	w := worker.New(set, next, storageClient, obsrecv, 4096, maxLogsEmitted,
+		worker.WithTelemetryBuilder(tb),
+		worker.WithSubscriberClient(ps.client),
+	)
+	w.SetOffsetStorage(store)
+
+	return &gcsHarness{worker: w, pubsub: ps, sink: sink, logs: recorded}
+}
+
+func (h *gcsHarness) process(ctx context.Context) bool {
+	msg := &worker.PullMessage{
+		AckID:      h.pubsub.ackID,
+		MessageID:  h.pubsub.messageID,
+		Attributes: h.pubsub.srv.Message(h.pubsub.messageID).Attributes,
+	}
+	return h.worker.ProcessMessage(ctx, msg, h.pubsub.subscription, func() {})
+}
+
+func (h *gcsHarness) bodyStrings() []string {
+	var got []string
+	for _, ld := range h.sink.AllLogs() {
+		for i := 0; i < ld.ResourceLogs().Len(); i++ {
+			sls := ld.ResourceLogs().At(i).ScopeLogs()
+			for j := 0; j < sls.Len(); j++ {
+				lrs := sls.At(j).LogRecords()
+				for k := 0; k < lrs.Len(); k++ {
+					got = append(got, lrs.At(k).Body().Str())
+				}
+			}
+		}
+	}
+	return got
+}
+
+func (h *gcsHarness) logged(msg string) bool {
+	for _, e := range h.logs.All() {
+		if e.Message == msg {
+			return true
+		}
+	}
+	return false
+}
+
+func finalizeAttrs() map[string]string {
+	return map[string]string{
+		worker.AttrEventType: worker.EventTypeObjectFinalize,
+		worker.AttrBucketID:  "mybucket",
+		worker.AttrObjectID:  "myobject",
+	}
+}
+
+// objectLines builds n newline-terminated lines and returns both the encoded bytes and
+// the lines they should parse into. Lines are padded so a modest count still exceeds the
+// content-detection window.
+func objectLines(start, n int) (body string, lines []string) {
+	var sb strings.Builder
+	for i := start; i < start+n; i++ {
+		line := fmt.Sprintf("line-%06d-padding-to-keep-the-object-comfortably-larger-than-the-detection-window", i)
+		lines = append(lines, line)
+		sb.WriteString(line)
+		sb.WriteString("\n")
+	}
+	return sb.String(), lines
+}
+
+// TestProcessMessage_AcksFilteredMessageAfterCancellation asserts that the ack for a
+// message the receiver deliberately skips still lands once the context is cancelled.
+// Without it the message is redelivered forever.
+func TestProcessMessage_AcksFilteredMessageAfterCancellation(t *testing.T) {
+	attrs := map[string]string{
+		worker.AttrEventType: "OBJECT_DELETE",
+		worker.AttrBucketID:  "mybucket",
+		worker.AttrObjectID:  "myobject",
+	}
+	h := newGCSHarness(t, attrs, 1000, newMemStorage(), nil, func() {}, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.False(t, h.process(ctx), "a non-finalize event is skipped rather than processed")
+	require.Eventually(t, func() bool { return h.pubsub.acks() == 1 }, 5*time.Second, 10*time.Millisecond,
+		"a skipped message must still be acked after cancellation")
+}
+
+// TestProcessMessage_CancelledMidObject asserts the wind-down contract: records already
+// read are delivered and checkpointed, the message is nacked for redelivery rather than
+// acked, and the cancellation is not treated as a DLQ condition.
+func TestProcessMessage_CancelledMidObject(t *testing.T) {
+	const batchSize = 100
+	head, headLines := objectLines(0, 250)
+	tail, _ := objectLines(250, 50)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newGCSHarness(t, finalizeAttrs(), batchSize, newMemStorage(), fakeGCS(t, head, tail, true), cancel, 1)
+
+	require.False(t, h.process(ctx), "a cancelled object is not fully processed")
+
+	delivered := h.bodyStrings()
+	require.Greater(t, len(delivered), batchSize,
+		"the partial batch left in hand is drained rather than dropped for redelivery")
+	require.Less(t, len(delivered), len(headLines)+50,
+		"a cancelled read should stop rather than draining the whole object")
+	require.Equal(t, headLines[:len(delivered)], delivered,
+		"delivered records should be whole records forming a prefix of the object")
+
+	require.Eventually(t, func() bool { return h.pubsub.nacked() }, 5*time.Second, 10*time.Millisecond,
+		"a cancelled message should be nacked so it redelivers immediately")
+	require.Zero(t, h.pubsub.acks(), "a partially read object must not be acked")
+	require.False(t, h.logged("DLQ condition triggered, nacking message for redelivery/DLQ processing"),
+		"cancellation must never route an object to the DLQ")
+}
+
+// TestProcessMessage_ResumesFromCheckpointAfterCancellation asserts that the checkpoint
+// written during wind-down matches what was flushed, so redelivery loses no records and
+// replays none.
+func TestProcessMessage_ResumesFromCheckpointAfterCancellation(t *testing.T) {
+	const batchSize = 100
+	head, headLines := objectLines(0, 250)
+	tail, tailLines := objectLines(250, 50)
+	lines := append(headLines, tailLines...)
+	store := newMemStorage()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	first := newGCSHarness(t, finalizeAttrs(), batchSize, store, fakeGCS(t, head, tail, true), cancel, 1)
+	first.process(ctx)
+	delivered := first.bodyStrings()
+	require.NotEmpty(t, delivered)
+
+	// Redelivery: the same object, now served in full, processed on a live context.
+	second := newGCSHarness(t, finalizeAttrs(), batchSize, store, fakeGCS(t, head, tail, false), func() {}, 0)
+	require.True(t, second.process(context.Background()), "a complete read should report success")
+
+	require.Equal(t, lines, append(delivered, second.bodyStrings()...),
+		"the two runs together should cover the object exactly once")
+	require.Eventually(t, func() bool { return second.pubsub.acks() == 1 }, 5*time.Second, 10*time.Millisecond,
+		"a fully read object should be acked")
+}

--- a/receiver/gcspubsubeventreceiver/internal/worker/worker_offset_delete_error_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/worker_offset_delete_error_test.go
@@ -1,0 +1,38 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessMessage_LogsOffsetDeleteFailure asserts that after a fully-read object is
+// acked, a failure to delete its stored offset is logged rather than escalated. The stale
+// offset is harmless once the object is acked, so the delete error must not fail the run.
+func TestProcessMessage_LogsOffsetDeleteFailure(t *testing.T) {
+	store := newMemStorage()
+	store.deleteErr = errors.New("storage extension unavailable")
+
+	body, _ := objectLines(0, 5)
+	h := newGCSHarness(t, finalizeAttrs(), 1000, store, fakeGCS(t, body, "", false), func() {}, 0)
+
+	require.True(t, h.process(context.Background()), "a complete read should report success")
+	require.True(t, h.logged("failed to delete offset"),
+		"a failed offset delete after a successful ack is logged, not escalated")
+}

--- a/receiver/gcspubsubeventreceiver/receiver.go
+++ b/receiver/gcspubsubeventreceiver/receiver.go
@@ -169,6 +169,7 @@ func (r *logsReceiver) Start(_ context.Context, host component.Host) error {
 			worker.WithObjectKeyFilter(r.objectKeyFilter),
 			worker.WithSubscriberClient(r.subClient),
 			worker.WithMaxExtension(r.cfg.MaxExtension),
+			worker.WithErrorBackOff(r.cfg.ErrorBackOff),
 		)
 		w.SetOffsetStorage(r.offsetStorage)
 		return w

--- a/receiver/gcspubsubeventreceiver/receiver.go
+++ b/receiver/gcspubsubeventreceiver/receiver.go
@@ -273,9 +273,11 @@ func (r *logsReceiver) poll(ctx context.Context, deferThis func()) {
 // pullMessages issues a single Pull RPC, deduplicates the batch, and dispatches
 // unique messages to the worker channel. Returns the number of messages dispatched.
 func (r *logsReceiver) pullMessages(ctx context.Context) int {
+	// Workers is validated > 0 and is a small operator-configured count.
+	maxMessages := int32(r.cfg.Workers) // #nosec G115 -- workers is validated > 0 and small
 	resp, err := r.subClient.Pull(ctx, &pubsubpb.PullRequest{
 		Subscription: r.subscriptionPath,
-		MaxMessages:  int32(r.cfg.Workers),
+		MaxMessages:  maxMessages,
 	})
 	if err != nil {
 		// Context cancellation is expected during shutdown.


### PR DESCRIPTION
### Proposed Change

Every wind-down operation took the context that had just been cancelled. That covers both checkpoint saves, the offset delete, the ack, and both nack paths. None of them ran. A customer support bundle shows `failed to ack message` 25 seconds after a config push.

Recovery then happened by accident. The ack deadline lapsed, the message redelivered, and work resumed from the last saved batch offset.

Those operations now run on a context detached from the cancellation, with a 30 second timeout. The worker nacks the message at once instead of waiting for its deadline.

The worker also flushes and checkpoints the partial batch before the cancellation propagates. This is only safe because the parser now drops a record that a broken stream cut short. A batch therefore ends on a record boundary, and the checkpoint stays accurate.

Cancellation is never a DLQ condition. The check is explicit, because the S3 classifiers match on error text. Cancellation also no longer counts as a failure.

The offset load still uses the caller context. It starts work rather than ending it, so a cancelled read aborts instead of loading unused state.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
