### PR TITLE
feat(gcspubsubeventreceiver,awss3eventreceiver): read NDJSON as a JSON value sequence [PIPE-1413]

### DIFF
--- a/internal/blobstream/buffered_reader.go
+++ b/internal/blobstream/buffered_reader.go
@@ -55,7 +55,14 @@ type bufferedReader struct {
 	raw *countingReader
 	// expectedSize is the object's known raw size (Content-Length), or 0 when unknown.
 	expectedSize int64
+	// bufSize is the read buffer size, which equals the configured max_log_size. Parsers
+	// use it to bound a single record the way max_log_size bounds a single line.
+	bufSize int
 }
+
+// maxRecordBytes reports the configured max_log_size, so a parser can bound a single
+// record to the same limit that bounds a single line.
+func (r *bufferedReader) maxRecordBytes() int64 { return int64(r.bufSize) }
 
 // NewBufferedReader returns a BufferedReader that wraps the given reader and buffers the
 // reads. The buffer size is the size of the buffer to use for the reader. It will be the
@@ -67,6 +74,7 @@ func NewBufferedReader(reader io.Reader, bufferSize int) BufferedReader {
 		countingReader: r,
 		reader:         bufio.NewReaderSize(r, bufferSize),
 		raw:            r,
+		bufSize:        bufferSize,
 	}
 }
 
@@ -80,6 +88,7 @@ func newBufferedReaderWithRaw(reader io.Reader, bufferSize int, raw *countingRea
 		reader:         bufio.NewReaderSize(r, bufferSize),
 		raw:            raw,
 		expectedSize:   expectedSize,
+		bufSize:        bufferSize,
 	}
 }
 

--- a/internal/blobstream/json_append_body_test.go
+++ b/internal/blobstream/json_append_body_test.go
@@ -29,7 +29,7 @@ import (
 func newJSONParserForBody(t *testing.T, opts BodyOptions) LogParser {
 	t.Helper()
 	reader := NewBufferedReader(strings.NewReader("[]"), 4096)
-	return NewJSONParser(reader, opts)
+	return NewJSONParser(reader, nil, opts)
 }
 
 func TestJSONAppendLogBody_RejectsForeignRecordType(t *testing.T) {

--- a/internal/blobstream/json_boundary_error_test.go
+++ b/internal/blobstream/json_boundary_error_test.go
@@ -1,0 +1,115 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// jsonArrayNoClose builds a JSON array of complete records with no closing ']', large
+// enough that content detection completes before the end.
+func jsonArrayNoClose() []byte {
+	var b bytes.Buffer
+	b.WriteByte('[')
+	for i := 0; i < 120; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`{"host":"h","msg":"padding padding padding"}`)
+	}
+	return b.Bytes()
+}
+
+// TestJSONArray_BrokenStreamAtBoundaryRetries asserts a stream failure landing exactly on
+// a JSON array element boundary is reported as a broken stream (retry), not as a truncated
+// object (which would dead-letter a recoverable download). The trailing closing-delimiter
+// check must classify its error the same way the per-element decode does.
+func TestJSONArray_BrokenStreamAtBoundaryRetries(t *testing.T) {
+	t.Parallel()
+
+	connReset := errors.New("connection reset by peer")
+	stream := LogStream{
+		Name:        "o.json",
+		Body:        io.NopCloser(&errAfterReader{data: jsonArrayNoClose(), err: connReset}),
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+	seq, err := producer.Records(context.Background(), Offset{})
+	require.NoError(t, err)
+
+	var recs int
+	var last error
+	for _, rerr := range seq {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		recs++
+	}
+
+	require.Positive(t, recs, "records read before the break are still delivered")
+	require.Error(t, last)
+	require.True(t, IsStreamRead(last), "a broken stream at an element boundary retries")
+	require.False(t, IsTruncatedObject(last), "a broken download is not a truncated object")
+}
+
+// TestJSONArray_TruncatedAtBoundaryIsTruncation asserts an array whose bytes simply run out
+// at an element boundary (clean source EOF, no closing ']') is a truncated object.
+func TestJSONArray_TruncatedAtBoundaryIsTruncation(t *testing.T) {
+	t.Parallel()
+
+	stream := LogStream{
+		Name:        "o.json",
+		Body:        io.NopCloser(bytes.NewReader(jsonArrayNoClose())),
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+	seq, err := producer.Records(context.Background(), Offset{})
+	require.NoError(t, err)
+
+	var recs int
+	var last error
+	for _, rerr := range seq {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		recs++
+	}
+
+	require.Positive(t, recs)
+	require.Error(t, last)
+	require.True(t, IsTruncatedObject(last), "a clean-EOF array with no closing bracket is truncated")
+	require.False(t, IsStreamRead(last))
+}

--- a/internal/blobstream/json_classification_test.go
+++ b/internal/blobstream/json_classification_test.go
@@ -68,7 +68,7 @@ func TestJSONSequence_TruncatedFinalValueStops(t *testing.T) {
 	t.Parallel()
 
 	reader := NewBufferedReader(strings.NewReader("{\"host\":\"a\"}\n{\"host\":\"b"), 4096)
-	parser := NewJSONParser(reader, BodyOptions{})
+	parser := NewJSONParser(reader, nil, BodyOptions{})
 
 	records, err := parser.Parse(context.Background(), 0)
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestJSONSequence_StopsWhenConsumerBreaks(t *testing.T) {
 	t.Parallel()
 
 	reader := NewBufferedReader(strings.NewReader("{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n"), 4096)
-	parser := NewJSONParser(reader, BodyOptions{})
+	parser := NewJSONParser(reader, nil, BodyOptions{})
 
 	records, err := parser.Parse(context.Background(), 0)
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestJSONSequence_SkipsRecordsBeforeStartOffset(t *testing.T) {
 	startOffset := int64(strings.Index(body, "{\"n\":3}"))
 
 	reader := NewBufferedReader(strings.NewReader(body), 4096)
-	parser := NewJSONParser(reader, BodyOptions{})
+	parser := NewJSONParser(reader, nil, BodyOptions{})
 
 	records, err := parser.Parse(context.Background(), startOffset)
 	require.NoError(t, err)

--- a/internal/blobstream/json_classification_test.go
+++ b/internal/blobstream/json_classification_test.go
@@ -1,0 +1,129 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyJSON_RejectsEmptyAndBlankStreams(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		body string
+	}{
+		{name: "empty", body: ""},
+		{name: "spaces", body: "   "},
+		{name: "newlines and tabs", body: "\n\t\r\n"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			reader := NewBufferedReader(strings.NewReader(tc.body), 4096)
+			_, err := classifyJSON(reader)
+			require.ErrorIs(t, err, ErrNotArrayOrKnownObject)
+		})
+	}
+}
+
+func TestClassifyJSON_PropagatesPeekErrors(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("connection reset by peer")
+	// The shared stub lives in parser_detection_test.go.
+	reader := &failingPeekReader{
+		BufferedReader: NewBufferedReader(strings.NewReader(`[{"host":"a"}]`), 4096),
+		peekErr:        readErr,
+	}
+
+	_, err := classifyJSON(reader)
+	require.ErrorIs(t, err, readErr)
+}
+
+// TestJSONSequence_TruncatedFinalValueStops asserts a stream cut mid-record keeps the
+// complete records and reports the cut. The fragment is never emitted, and ending
+// quietly would ack the object and lose whatever followed.
+func TestJSONSequence_TruncatedFinalValueStops(t *testing.T) {
+	t.Parallel()
+
+	reader := NewBufferedReader(strings.NewReader("{\"host\":\"a\"}\n{\"host\":\"b"), 4096)
+	parser := NewJSONParser(reader, BodyOptions{})
+
+	records, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	var got []string
+	var last error
+	for record, err := range records {
+		if err != nil {
+			last = err
+			continue
+		}
+		got = append(got, string(record.(json.RawMessage)))
+	}
+	require.Equal(t, []string{`{"host":"a"}`}, got, "the complete record is still delivered")
+	require.True(t, IsTruncatedObject(last), "the cut record must be reported, not dropped quietly")
+}
+
+// TestJSONSequence_StopsWhenConsumerBreaks asserts the iterator releases when the
+// caller stops early, which is how a batch limit ends a read.
+func TestJSONSequence_StopsWhenConsumerBreaks(t *testing.T) {
+	t.Parallel()
+
+	reader := NewBufferedReader(strings.NewReader("{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n"), 4096)
+	parser := NewJSONParser(reader, BodyOptions{})
+
+	records, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	var seen int
+	for range records {
+		seen++
+		break
+	}
+	require.Equal(t, 1, seen)
+	require.Positive(t, parser.Offset(), "the offset must mark the consumed record")
+}
+
+// TestJSONSequence_SkipsRecordsBeforeStartOffset asserts resume drops the records a
+// previous run already sent.
+func TestJSONSequence_SkipsRecordsBeforeStartOffset(t *testing.T) {
+	t.Parallel()
+
+	body := "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n"
+	startOffset := int64(strings.Index(body, "{\"n\":3}"))
+
+	reader := NewBufferedReader(strings.NewReader(body), 4096)
+	parser := NewJSONParser(reader, BodyOptions{})
+
+	records, err := parser.Parse(context.Background(), startOffset)
+	require.NoError(t, err)
+
+	var got []string
+	for record, err := range records {
+		require.NoError(t, err)
+		got = append(got, string(record.(json.RawMessage)))
+	}
+	require.Equal(t, []string{`{"n":3}`}, got)
+}

--- a/internal/blobstream/json_classify_truncated_test.go
+++ b/internal/blobstream/json_classify_truncated_test.go
@@ -1,0 +1,59 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestJSONSequence_TruncatedCompressedJSONIsClassified asserts a compressed JSON object
+// whose decompressed content ends short (io.ErrUnexpectedEOF) at classification is
+// classified rather than returned as a bare error. A bare classifyJSON error is treated as
+// transient, so the same deterministic object redelivers forever; classifying it as a
+// truncated object delivers what was read and acks, breaking the loop.
+func TestJSONSequence_TruncatedCompressedJSONIsClassified(t *testing.T) {
+	t.Parallel()
+
+	// A JSON object that fits the classification window but exceeds the detection window,
+	// so StartsWithJSONObjectOrArray (512 bytes) succeeds while classifyJSON (4096 bytes)
+	// reads to the truncation.
+	content := `{"msg":"` + strings.Repeat("x", 3000) + `"}`
+	require.Less(t, len(content), maxRecordsSearchBytes, "content must fit the classification window")
+	require.Greater(t, len(content), jsonPeekBytes, "content must exceed the detection window")
+
+	// Drop the 8-byte gzip footer: the DEFLATE stream stays intact, so decompression
+	// yields the full content and then io.ErrUnexpectedEOF when the missing footer is read.
+	g := gzipBytes(t, content)
+	truncated := g[:len(g)-8]
+
+	_, last := driveStream(LogStream{
+		Name:        "logs/object.json.gz",
+		Body:        io.NopCloser(bytes.NewReader(truncated)),
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	})
+
+	require.Error(t, last, "a truncated compressed object must be classified, not returned bare")
+	require.True(t, IsTruncatedObject(last),
+		"a complete-at-rest but content-truncated object delivers what was read and acks")
+	require.False(t, IsStreamRead(last), "the raw source completed, so it is not a retryable broken stream")
+}

--- a/internal/blobstream/json_concat_boundary_short_test.go
+++ b/internal/blobstream/json_concat_boundary_short_test.go
@@ -1,0 +1,173 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// bigJSONArray builds a complete JSON array of n object records, large enough that content
+// detection (which peeks maxRecordsSearchBytes) completes well before the array's end.
+func bigJSONArray(n int) string {
+	var sb strings.Builder
+	sb.WriteByte('[')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		fmt.Fprintf(&sb, `{"n":"%03d","pad":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}`, i)
+	}
+	sb.WriteByte(']')
+	return sb.String()
+}
+
+// TestJSONConcatenated_ShortDownloadAtArrayBoundaryRetries covers the concat boundary of a
+// bracketed shape: the first array closes cleanly, but the source ends short of the known
+// size right at the boundary where the next document would begin. json.Decoder.More()
+// swallows the look-ahead read, so the loop ends like a clean finish; without consulting
+// the raw source the worker would ack an incomplete download and lose the rest.
+func TestJSONConcatenated_ShortDownloadAtArrayBoundaryRetries(t *testing.T) {
+	t.Parallel()
+
+	// Two concatenated arrays; the source is cut cleanly right after the first array's
+	// closing ']', which is exactly the concat boundary.
+	first := `[{"n":"000","pad":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},{"n":"001","pad":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}]`
+	full := first + `[{"n":"002","pad":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}]`
+
+	stream := LogStream{
+		Name:        "logs/object.json",
+		Body:        &cutAfter{data: []byte(full), n: len(first)}, // clean EOF at the boundary
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+		Size:        int64(len(full)), // known size; delivered short at the boundary
+	}
+
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+	seq, err := producer.Records(context.Background(), Offset{})
+	require.NoError(t, err)
+
+	var recs int
+	var last error
+	for _, rerr := range seq {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		recs++
+	}
+
+	require.Equal(t, 2, recs, "the first array's records are delivered before the short end")
+	require.Error(t, last, "a source short of the known size at the concat boundary must surface an error")
+	require.True(t, IsStreamRead(last), "an incomplete download at the boundary must retry")
+	require.False(t, IsTruncatedObject(last), "a short download is not a truncated object")
+}
+
+// TestJSONConcatenated_BrokenStreamAtArrayBoundaryRetries covers the same concat boundary
+// with a hard read error rather than a clean short EOF. The first array closes, then the
+// source fails where the next document would begin; that must retry, not ack.
+func TestJSONConcatenated_BrokenStreamAtArrayBoundaryRetries(t *testing.T) {
+	t.Parallel()
+
+	// The first array must exceed the detection peek window so the read error surfaces at
+	// the concat boundary during iteration, not during detection.
+	first := bigJSONArray(120)
+	full := first + `[{"n":"999","pad":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}]`
+
+	readErr := errors.New("connection reset by peer")
+	stream := LogStream{
+		Name:        "logs/object.json",
+		Body:        &cutAfter{data: []byte(full), n: len(first), err: readErr},
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+	seq, err := producer.Records(context.Background(), Offset{})
+	require.NoError(t, err)
+
+	var recs int
+	var last error
+	for _, rerr := range seq {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		recs++
+	}
+
+	require.Equal(t, 120, recs, "the first array's records are delivered before the break")
+	require.Error(t, last, "a broken stream at the concat boundary must surface an error")
+	require.True(t, IsStreamRead(last), "a broken stream at the boundary must retry")
+	require.ErrorIs(t, last, readErr)
+}
+
+// TestJSONConcatenated_ShortDownloadInWrapperTailRetries covers the records-wrapper tail:
+// after the Records array closes, the object still holds trailing keys and its closing
+// brace. If the source ends short of the known size while those are consumed, the token
+// reads swallow it the same way; without consulting the raw source the worker would ack an
+// incomplete download.
+func TestJSONConcatenated_ShortDownloadInWrapperTailRetries(t *testing.T) {
+	t.Parallel()
+
+	// A wrapper whose Records array is followed by a trailing key, cut cleanly partway
+	// through that tail (after the array's records are all delivered).
+	head := `{"Records":[{"n":"000"},{"n":"001"}],"nextToken":"`
+	full := head + `abcdef"}`
+
+	stream := LogStream{
+		Name:        "logs/object.json",
+		Body:        &cutAfter{data: []byte(full), n: len(head)}, // clean EOF inside the tail
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+		Size:        int64(len(full)), // known size; delivered short in the tail
+	}
+
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+	seq, err := producer.Records(context.Background(), Offset{})
+	require.NoError(t, err)
+
+	var recs int
+	var last error
+	for _, rerr := range seq {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		recs++
+	}
+
+	require.Equal(t, 2, recs, "the wrapper's records are delivered before the short tail")
+	require.Error(t, last, "a source short of the known size in the wrapper tail must surface an error")
+	require.True(t, IsStreamRead(last), "an incomplete download in the wrapper tail must retry")
+}

--- a/internal/blobstream/json_concat_drop_counted_test.go
+++ b/internal/blobstream/json_concat_drop_counted_test.go
@@ -1,0 +1,42 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestJSONConcatenated_ArrayFollowedByGarbageIsCounted asserts that trailing content after
+// a concatenated array that is not another array is surfaced as a parse error, rather than
+// silently dropped. The array's records are still delivered and the object still acks.
+func TestJSONConcatenated_ArrayFollowedByGarbageIsCounted(t *testing.T) {
+	t.Parallel()
+
+	got, errCount := collectRecordsAndErrors(t, `[{"n":1},{"n":2}]garbage`)
+	require.Equal(t, []string{`{"n":1}`, `{"n":2}`}, got, "the array's records are delivered")
+	require.Equal(t, 1, errCount, "the dropped trailing content is counted, not silently discarded")
+}
+
+// TestJSONConcatenated_WrapperFollowedByNonWrapperIsCounted asserts the same for a records
+// wrapper followed by a document that is not a wrapper.
+func TestJSONConcatenated_WrapperFollowedByNonWrapperIsCounted(t *testing.T) {
+	t.Parallel()
+
+	got, errCount := collectRecordsAndErrors(t, `{"Records":[{"n":1}]}{"not":"a wrapper"}`)
+	require.Equal(t, []string{`{"n":1}`}, got, "the first wrapper's records are delivered")
+	require.Equal(t, 1, errCount, "the dropped trailing document is counted")
+}

--- a/internal/blobstream/json_concatenated_test.go
+++ b/internal/blobstream/json_concatenated_test.go
@@ -1,0 +1,89 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestJSONConcatenated_Arrays asserts every element of concatenated arrays is delivered,
+// not just the first array's, so naively concatenated array files are read in full.
+func TestJSONConcatenated_Arrays(t *testing.T) {
+	t.Parallel()
+
+	got, errCount := collectRecordsAndErrors(t, `[{"n":1},{"n":2}][{"n":3}][{"n":4},{"n":5}]`)
+	require.Equal(t, []string{`{"n":1}`, `{"n":2}`, `{"n":3}`, `{"n":4}`, `{"n":5}`}, got)
+	require.Zero(t, errCount)
+}
+
+// TestJSONConcatenated_RecordsWrappers asserts every Records element of concatenated
+// {"Records": [...]} documents is delivered, not just the first wrapper's.
+func TestJSONConcatenated_RecordsWrappers(t *testing.T) {
+	t.Parallel()
+
+	got, errCount := collectRecordsAndErrors(t, `{"Records":[{"n":1},{"n":2}]}{"Records":[{"n":3}]}`)
+	require.Equal(t, []string{`{"n":1}`, `{"n":2}`, `{"n":3}`}, got)
+	require.Zero(t, errCount)
+}
+
+// TestJSONConcatenated_WrapperWithKeysAfterRecords asserts a wrapper whose object has
+// keys after its Records array is fully consumed, so the next concatenated wrapper is
+// still read.
+func TestJSONConcatenated_WrapperWithKeysAfterRecords(t *testing.T) {
+	t.Parallel()
+
+	got, errCount := collectRecordsAndErrors(t, `{"Records":[{"n":1}],"nextToken":"abc"}{"Records":[{"n":2}]}`)
+	require.Equal(t, []string{`{"n":1}`, `{"n":2}`}, got)
+	require.Zero(t, errCount)
+}
+
+// TestJSONConcatenated_WrapperFollowedByNonWrapperStops asserts that when a concatenated
+// document is not another wrapper, the records read so far are kept and reading stops
+// (best effort), rather than failing the whole object.
+func TestJSONConcatenated_WrapperFollowedByNonWrapperStops(t *testing.T) {
+	t.Parallel()
+
+	got, _ := collectRecordsAndErrors(t, `{"Records":[{"n":1}]}{"not":"a wrapper"}`)
+	require.Equal(t, []string{`{"n":1}`}, got, "the first wrapper's records are delivered; the trailing non-wrapper stops the run")
+}
+
+// TestJSONConcatenated_WrapperWithMalformedTailStops asserts a wrapper malformed after its
+// Records array keeps the records read and stops (best effort).
+func TestJSONConcatenated_WrapperWithMalformedTailStops(t *testing.T) {
+	t.Parallel()
+
+	got, _ := collectRecordsAndErrors(t, `{"Records":[{"n":1}],"trailing":`)
+	require.Equal(t, []string{`{"n":1}`}, got)
+}
+
+// TestJSONConcatenated_ArrayFollowedByGarbageStops asserts an array followed by non-JSON
+// garbage keeps the array's records and stops, rather than failing the whole object.
+func TestJSONConcatenated_ArrayFollowedByGarbageStops(t *testing.T) {
+	t.Parallel()
+
+	got, _ := collectRecordsAndErrors(t, `[{"n":1},{"n":2}]garbage`)
+	require.Equal(t, []string{`{"n":1}`, `{"n":2}`}, got)
+}
+
+// TestJSONConcatenated_WrapperWithGarbageKeyStops asserts a wrapper whose object has
+// garbage where a key should be, after its Records array, keeps the records and stops.
+func TestJSONConcatenated_WrapperWithGarbageKeyStops(t *testing.T) {
+	t.Parallel()
+
+	got, _ := collectRecordsAndErrors(t, `{"Records":[{"n":1}],garbage}`)
+	require.Equal(t, []string{`{"n":1}`}, got)
+}

--- a/internal/blobstream/json_mixed_sequence_test.go
+++ b/internal/blobstream/json_mixed_sequence_test.go
@@ -17,6 +17,8 @@ package blobstream
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -72,29 +74,149 @@ func TestJSONValueSequence_WarnsOncePerFile(t *testing.T) {
 		"the warning is emitted once per file, not once per line")
 }
 
-// TestJSONValueSequence_MalformedLineDroppedButWarns asserts genuinely malformed bytes stay
-// a dropped parse error (not rescued as a string) while still marking the file as mixed.
-func TestJSONValueSequence_MalformedLineDroppedButWarns(t *testing.T) {
+// TestJSONValueSequence_EmitsUnquotedTextLineAsBody asserts a plain (unquoted) text line is a
+// true string and is emitted as a string body rather than dropped as a parse error.
+func TestJSONValueSequence_EmitsUnquotedTextLineAsBody(t *testing.T) {
 	t.Parallel()
 
-	parser, logs := mixedSequenceParser(t, "{\"a\":1}\nthis is not json\n{\"b\":2}\n")
+	parser, logs := mixedSequenceParser(t, "{\"a\":1}\n2026-01-01 INFO started\n{\"b\":2}\n")
 	records, err := drainJSON(t, parser)
-	require.ErrorContains(t, err, "decode record", "malformed bytes remain a parse error")
-	require.Len(t, records, 2, "the malformed line is dropped, the objects still deliver")
+	require.NoError(t, err, "an unquoted text line is not an error")
+	require.Len(t, records, 3, "the timestamped text line is emitted, not dropped")
+	require.Equal(t, "2026-01-01 INFO started", jsonBodyStr(t, parser, records[1]),
+		"a text line whose prefix looks like a JSON number is still emitted whole")
 	require.Equal(t, 1, logs.FilterMessage(mixedSequenceLogMsg).Len(),
-		"malformed content also marks the file as mixed")
+		"a mixed value sequence warns exactly once")
 }
 
-// TestJSONValueSequence_NonStringScalarWarnsButNotEmitted asserts a non-object, non-string
-// value (a number) marks the file mixed and stays a parse error rather than being emitted.
-func TestJSONValueSequence_NonStringScalarWarnsButNotEmitted(t *testing.T) {
+// TestJSONValueSequence_CorruptedJSONDroppedButWarns asserts a broken JSON object (not a text
+// line) stays a dropped parse error while still marking the file as mixed. This is the case
+// whose classification depends on the resync capturing the value from its opening byte.
+func TestJSONValueSequence_CorruptedJSONDroppedButWarns(t *testing.T) {
+	t.Parallel()
+
+	parser, logs := mixedSequenceParser(t, "{\"a\":1}\n{bad json here}\n{\"b\":2}\n")
+	records, err := drainJSON(t, parser)
+	require.ErrorContains(t, err, "decode record", "corrupted JSON stays a parse error")
+	require.Len(t, records, 2, "the corrupted object is dropped, the valid objects still deliver")
+	require.Equal(t, 1, logs.FilterMessage(mixedSequenceLogMsg).Len(),
+		"corrupted content also marks the file as mixed")
+}
+
+// TestJSONValueSequence_BareScalarEmittedAsText asserts a bare non-string scalar that is the
+// whole line (a number here) is emitted as its own text rather than dropped.
+func TestJSONValueSequence_BareScalarEmittedAsText(t *testing.T) {
 	t.Parallel()
 
 	parser, logs := mixedSequenceParser(t, "{\"a\":1}\n42\n{\"b\":2}\n")
 	records, err := drainJSON(t, parser)
-	require.ErrorContains(t, err, "expected a JSON object", "a bare number is not a record")
-	require.Len(t, records, 2, "the number is not emitted; the objects still deliver")
+	require.NoError(t, err)
+	require.Len(t, records, 3, "the bare scalar line is emitted as text")
+	require.Equal(t, "42", jsonBodyStr(t, parser, records[1]))
 	require.Equal(t, 1, logs.FilterMessage(mixedSequenceLogMsg).Len())
+}
+
+// TestJSONValueSequence_ConcatenatedObjectsStillParse guards that same-line concatenated
+// objects remain records (the whole-line rule applies only to non-object values).
+func TestJSONValueSequence_ConcatenatedObjectsStillParse(t *testing.T) {
+	t.Parallel()
+
+	parser, _ := mixedSequenceParser(t, "{\"a\":1}{\"b\":2}\n{\"c\":3}\n")
+	records, err := drainJSON(t, parser)
+	require.NoError(t, err)
+	require.Len(t, records, 3, "two objects on one line plus one more are three records")
+}
+
+// TestJSONValueSequence_TextLineAtEOF covers a text line with no terminating newline.
+func TestJSONValueSequence_TextLineAtEOF(t *testing.T) {
+	t.Parallel()
+
+	parser, _ := mixedSequenceParser(t, "{\"a\":1}\nhello at eof")
+	records, err := drainJSON(t, parser)
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	require.Equal(t, "hello at eof", jsonBodyStr(t, parser, records[1]))
+}
+
+// TestJSONValueSequence_BareScalarAtEOF covers a bare scalar at end of input (no newline).
+func TestJSONValueSequence_BareScalarAtEOF(t *testing.T) {
+	t.Parallel()
+
+	parser, _ := mixedSequenceParser(t, "{\"a\":1}\n5")
+	records, err := drainJSON(t, parser)
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	require.Equal(t, "5", jsonBodyStr(t, parser, records[1]))
+}
+
+// TestJSONValueSequence_ScalarPrefixTextAtEOF covers a scalar-prefixed text line at EOF.
+func TestJSONValueSequence_ScalarPrefixTextAtEOF(t *testing.T) {
+	t.Parallel()
+
+	parser, _ := mixedSequenceParser(t, "{\"a\":1}\n2026-01-01 INFO")
+	records, err := drainJSON(t, parser)
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	require.Equal(t, "2026-01-01 INFO", jsonBodyStr(t, parser, records[1]))
+}
+
+// TestJSONValueSequence_PreservesInteriorWhitespace covers whitespace between a scalar prefix
+// and its trailing text (e.g. "5 items processed").
+func TestJSONValueSequence_PreservesInteriorWhitespace(t *testing.T) {
+	t.Parallel()
+
+	parser, _ := mixedSequenceParser(t, "{\"a\":1}\n5 items processed\n{\"b\":2}\n")
+	records, err := drainJSON(t, parser)
+	require.NoError(t, err)
+	require.Len(t, records, 3)
+	require.Equal(t, "5 items processed", jsonBodyStr(t, parser, records[1]))
+}
+
+// TestJSONValueSequence_TrailingCorruptedDropped covers a value whose whole line, once the
+// trailing is captured, is corrupted JSON structure (an array prefix) rather than text.
+func TestJSONValueSequence_TrailingCorruptedDropped(t *testing.T) {
+	t.Parallel()
+
+	parser, _ := mixedSequenceParser(t, "{\"a\":1}\n[1,2]xyz\n{\"b\":2}\n")
+	records, err := drainJSON(t, parser)
+	require.ErrorContains(t, err, "decode record")
+	require.Len(t, records, 2, "the corrupted-array line is dropped")
+}
+
+// TestJSONValueSequence_CorruptedAtEOF covers a corrupted line with no terminating newline.
+func TestJSONValueSequence_CorruptedAtEOF(t *testing.T) {
+	t.Parallel()
+
+	parser, _ := mixedSequenceParser(t, "{\"a\":1}\n{bad")
+	records, err := drainJSON(t, parser)
+	require.ErrorContains(t, err, "decode record")
+	require.Len(t, records, 1)
+}
+
+// TestJSONValueSequence_StopsWhenConsumerBreaksOnEmittedLine covers the early returns taken
+// when the consumer stops iterating on an emitted line reached by each path: a malformed text
+// line, a bare scalar, and a scalar-prefixed text line.
+func TestJSONValueSequence_StopsWhenConsumerBreaksOnEmittedLine(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{
+		"{\"a\":1}\nplain text\n{\"b\":2}\n",   // malformed-path text line
+		"{\"a\":1}\n5\n{\"b\":2}\n",            // bare scalar
+		"{\"a\":1}\n2026-01-01 x\n{\"b\":2}\n", // scalar-prefix trailing text
+	} {
+		parser, _ := mixedSequenceParser(t, in)
+		seq, err := parser.Parse(context.Background(), 0)
+		require.NoError(t, err)
+		count := 0
+		for _, rerr := range seq {
+			require.NoError(t, rerr)
+			count++
+			if count == 2 {
+				break
+			}
+		}
+		require.Equal(t, 2, count, "iteration stops on the emitted line for %q", in)
+	}
 }
 
 // TestJSONValueSequence_StopsWhenConsumerBreaksOnString covers the early return taken when
@@ -116,4 +238,83 @@ func TestJSONValueSequence_StopsWhenConsumerBreaksOnString(t *testing.T) {
 	}
 	require.Len(t, got, 2, "iteration stops on the string, before the trailing object")
 	require.Equal(t, "stop here", jsonBodyStr(t, parser, got[1]))
+}
+
+// TestJSONValueSequence_StopsWhenConsumerBreaksOnCorruptedError covers the early returns taken
+// when the consumer stops on a corrupted line's parse error, reached by the malformed path and
+// by the reject path (trailing corrupted).
+func TestJSONValueSequence_StopsWhenConsumerBreaksOnCorruptedError(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{
+		"{\"a\":1}\n{bad}\n{\"b\":2}\n",    // corrupted line via the malformed path
+		"{\"a\":1}\n[1,2]xyz\n{\"b\":2}\n", // trailing-corrupted via the reject path
+	} {
+		parser, _ := mixedSequenceParser(t, in)
+		seq, err := parser.Parse(context.Background(), 0)
+		require.NoError(t, err)
+		n := 0
+		for _, rerr := range seq {
+			_ = rerr
+			n++
+			if n == 2 {
+				break
+			}
+		}
+		require.Equal(t, 2, n, "iteration stops on the corrupted line for %q", in)
+	}
+}
+
+// drainBrokenSeqAfter builds a value sequence of many objects then lastLine with no newline,
+// with the source breaking at the end so the resync scan hits the read error.
+func drainBrokenSeqAfter(t *testing.T, lastLine string) (recs int, last error) {
+	t.Helper()
+	var sb strings.Builder
+	for i := 0; i < 800; i++ {
+		fmt.Fprintf(&sb, `{"n":%d}`+"\n", i)
+	}
+	sb.WriteString(lastLine)
+	body := []byte(sb.String())
+	require.Greater(t, len(body), maxRecordsSearchBytes+256, "body must exceed the classification window")
+	stream := LogStream{
+		Name:        "logs/object.json",
+		Body:        &cutAfter{data: body, n: len(body), err: errors.New("connection reset by peer")},
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+	seq, err := producer.Records(context.Background(), Offset{})
+	require.NoError(t, err)
+	for _, rerr := range seq {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		recs++
+	}
+	return recs, last
+}
+
+// TestJSONValueSequence_BrokenStreamAfterTextLine asserts a source that breaks while capturing
+// a trailing text line surfaces a retryable read error rather than acking a partial read.
+func TestJSONValueSequence_BrokenStreamAfterTextLine(t *testing.T) {
+	t.Parallel()
+
+	recs, last := drainBrokenSeqAfter(t, "broken text line")
+	require.Positive(t, recs, "records before the break are delivered")
+	require.True(t, IsStreamRead(last), "a broken stream after a text line must retry")
+}
+
+// TestJSONValueSequence_BrokenStreamAfterScalarPrefix asserts the same for a scalar-prefixed
+// text line, where the break lands during the trailing capture.
+func TestJSONValueSequence_BrokenStreamAfterScalarPrefix(t *testing.T) {
+	t.Parallel()
+
+	recs, last := drainBrokenSeqAfter(t, "42 trailing text")
+	require.Positive(t, recs, "records before the break are delivered")
+	require.True(t, IsStreamRead(last), "a broken stream during the trailing capture must retry")
 }

--- a/internal/blobstream/json_mixed_sequence_test.go
+++ b/internal/blobstream/json_mixed_sequence_test.go
@@ -1,0 +1,119 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// mixedSequenceParser builds a value-sequence parser over input with an observing logger.
+func mixedSequenceParser(t *testing.T, input string) (LogParser, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zapcore.WarnLevel)
+	reader := NewBufferedReader(strings.NewReader(input), 4096)
+	return NewJSONParser(reader, zap.New(core), BodyOptions{}), logs
+}
+
+// jsonBodyStr runs AppendLogBody and returns the resulting body string.
+func jsonBodyStr(t *testing.T, parser LogParser, rec any) string {
+	t.Helper()
+	lr := plog.NewLogRecord()
+	require.NoError(t, parser.AppendLogBody(context.Background(), lr, rec))
+	return lr.Body().Str()
+}
+
+// TestJSONValueSequence_EmitsStringLineAsBody pins Finding A: a value sequence that starts
+// with an object (so it classifies as NDJSON) and then holds a valid JSON string value must
+// emit that string as a string body rather than dropping it.
+func TestJSONValueSequence_EmitsStringLineAsBody(t *testing.T) {
+	t.Parallel()
+
+	parser, logs := mixedSequenceParser(t, "{\"a\":1}\n\"plain text line\"\n{\"b\":2}\n")
+	records, err := drainJSON(t, parser)
+	require.NoError(t, err)
+	require.Len(t, records, 3, "the string line must be emitted, not dropped")
+	require.Equal(t, "plain text line", jsonBodyStr(t, parser, records[1]),
+		"a top-level JSON string is emitted as its string body")
+	require.Equal(t, 1, logs.FilterMessage(mixedSequenceLogMsg).Len(),
+		"a mixed value sequence warns exactly once")
+}
+
+// TestJSONValueSequence_WarnsOncePerFile asserts the mixed-content warning fires a single
+// time even when several non-object lines appear.
+func TestJSONValueSequence_WarnsOncePerFile(t *testing.T) {
+	t.Parallel()
+
+	parser, logs := mixedSequenceParser(t, "{\"a\":1}\n\"one\"\n\"two\"\n{\"b\":2}\n")
+	records, err := drainJSON(t, parser)
+	require.NoError(t, err)
+	require.Len(t, records, 4, "both string lines are emitted")
+	require.Equal(t, 1, logs.FilterMessage(mixedSequenceLogMsg).Len(),
+		"the warning is emitted once per file, not once per line")
+}
+
+// TestJSONValueSequence_MalformedLineDroppedButWarns asserts genuinely malformed bytes stay
+// a dropped parse error (not rescued as a string) while still marking the file as mixed.
+func TestJSONValueSequence_MalformedLineDroppedButWarns(t *testing.T) {
+	t.Parallel()
+
+	parser, logs := mixedSequenceParser(t, "{\"a\":1}\nthis is not json\n{\"b\":2}\n")
+	records, err := drainJSON(t, parser)
+	require.ErrorContains(t, err, "decode record", "malformed bytes remain a parse error")
+	require.Len(t, records, 2, "the malformed line is dropped, the objects still deliver")
+	require.Equal(t, 1, logs.FilterMessage(mixedSequenceLogMsg).Len(),
+		"malformed content also marks the file as mixed")
+}
+
+// TestJSONValueSequence_NonStringScalarWarnsButNotEmitted asserts a non-object, non-string
+// value (a number) marks the file mixed and stays a parse error rather than being emitted.
+func TestJSONValueSequence_NonStringScalarWarnsButNotEmitted(t *testing.T) {
+	t.Parallel()
+
+	parser, logs := mixedSequenceParser(t, "{\"a\":1}\n42\n{\"b\":2}\n")
+	records, err := drainJSON(t, parser)
+	require.ErrorContains(t, err, "expected a JSON object", "a bare number is not a record")
+	require.Len(t, records, 2, "the number is not emitted; the objects still deliver")
+	require.Equal(t, 1, logs.FilterMessage(mixedSequenceLogMsg).Len())
+}
+
+// TestJSONValueSequence_StopsWhenConsumerBreaksOnString covers the early return taken when
+// the consumer stops iterating on an emitted string line.
+func TestJSONValueSequence_StopsWhenConsumerBreaksOnString(t *testing.T) {
+	t.Parallel()
+
+	parser, _ := mixedSequenceParser(t, "{\"a\":1}\n\"stop here\"\n{\"b\":2}\n")
+	seq, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	var got []any
+	for rec, rerr := range seq {
+		require.NoError(t, rerr)
+		got = append(got, rec)
+		if isJSONString(rec.(json.RawMessage)) {
+			break
+		}
+	}
+	require.Len(t, got, 2, "iteration stops on the string, before the trailing object")
+	require.Equal(t, "stop here", jsonBodyStr(t, parser, got[1]))
+}

--- a/internal/blobstream/json_object_strictness_test.go
+++ b/internal/blobstream/json_object_strictness_test.go
@@ -37,7 +37,14 @@ func collectRecordsAndErrors(t *testing.T, body string) ([]string, int) {
 			errCount++
 			continue
 		}
-		got = append(got, string(record.(json.RawMessage)))
+		switch r := record.(type) {
+		case json.RawMessage:
+			got = append(got, string(r))
+		case rawTextLine:
+			got = append(got, string(r))
+		default:
+			t.Fatalf("unexpected record type %T", record)
+		}
 	}
 	return got, errCount
 }
@@ -52,14 +59,15 @@ func TestJSONArray_SkipsNonObjectElements(t *testing.T) {
 	require.Equal(t, 2, errCount, "each non-object element is reported as a skipped parse error")
 }
 
-// TestJSONSequence_SkipsNonObjectValues asserts the same strictness for a top-level value
-// sequence (NDJSON): a scalar line is skipped, the object lines deliver.
-func TestJSONSequence_SkipsNonObjectValues(t *testing.T) {
+// TestJSONSequence_EmitsScalarLineAsText asserts a top-level value sequence (NDJSON) is more
+// lenient than an array: a bare scalar line is emitted as its own text rather than skipped,
+// so no data is lost. The object lines still deliver as records.
+func TestJSONSequence_EmitsScalarLineAsText(t *testing.T) {
 	t.Parallel()
 
 	got, errCount := collectRecordsAndErrors(t, "{\"n\":1}\n5\n{\"n\":2}\n")
-	require.Equal(t, []string{`{"n":1}`, `{"n":2}`}, got, "only object values are delivered")
-	require.Equal(t, 1, errCount, "the scalar value is reported as a skipped parse error")
+	require.Equal(t, []string{`{"n":1}`, `5`, `{"n":2}`}, got, "the scalar line is emitted as text between the objects")
+	require.Equal(t, 0, errCount, "nothing is dropped")
 }
 
 // TestJSONArray_StopsWhenConsumerBreaksOnSkippedElement asserts the iterator releases if

--- a/internal/blobstream/json_object_strictness_test.go
+++ b/internal/blobstream/json_object_strictness_test.go
@@ -1,0 +1,83 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func collectRecordsAndErrors(t *testing.T, body string) ([]string, int) {
+	t.Helper()
+	reader := NewBufferedReader(strings.NewReader(body), 4096)
+	parser := NewJSONParser(reader, BodyOptions{})
+	records, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	var got []string
+	var errCount int
+	for record, rerr := range records {
+		if rerr != nil {
+			errCount++
+			continue
+		}
+		got = append(got, string(record.(json.RawMessage)))
+	}
+	return got, errCount
+}
+
+// TestJSONArray_SkipsNonObjectElements asserts a non-object array element is skipped as a
+// parse error rather than emitted as a scalar body; the object elements still deliver.
+func TestJSONArray_SkipsNonObjectElements(t *testing.T) {
+	t.Parallel()
+
+	got, errCount := collectRecordsAndErrors(t, `[{"host":"a"}, 5, "x", {"host":"b"}]`)
+	require.Equal(t, []string{`{"host":"a"}`, `{"host":"b"}`}, got, "only object elements are delivered")
+	require.Equal(t, 2, errCount, "each non-object element is reported as a skipped parse error")
+}
+
+// TestJSONSequence_SkipsNonObjectValues asserts the same strictness for a top-level value
+// sequence (NDJSON): a scalar line is skipped, the object lines deliver.
+func TestJSONSequence_SkipsNonObjectValues(t *testing.T) {
+	t.Parallel()
+
+	got, errCount := collectRecordsAndErrors(t, "{\"n\":1}\n5\n{\"n\":2}\n")
+	require.Equal(t, []string{`{"n":1}`, `{"n":2}`}, got, "only object values are delivered")
+	require.Equal(t, 1, errCount, "the scalar value is reported as a skipped parse error")
+}
+
+// TestJSONArray_StopsWhenConsumerBreaksOnSkippedElement asserts the iterator releases if
+// the caller stops while a non-object element is being skipped (a batch limit reached on
+// the skip error itself).
+func TestJSONArray_StopsWhenConsumerBreaksOnSkippedElement(t *testing.T) {
+	t.Parallel()
+
+	reader := NewBufferedReader(strings.NewReader(`[5, {"a":1}]`), 4096)
+	parser := NewJSONParser(reader, BodyOptions{})
+	records, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	var seen int
+	for _, rerr := range records {
+		seen++
+		require.Error(t, rerr, "the first element is a non-object, reported as a skip error")
+		break
+	}
+	require.Equal(t, 1, seen)
+}

--- a/internal/blobstream/json_object_strictness_test.go
+++ b/internal/blobstream/json_object_strictness_test.go
@@ -26,7 +26,7 @@ import (
 func collectRecordsAndErrors(t *testing.T, body string) ([]string, int) {
 	t.Helper()
 	reader := NewBufferedReader(strings.NewReader(body), 4096)
-	parser := NewJSONParser(reader, BodyOptions{})
+	parser := NewJSONParser(reader, nil, BodyOptions{})
 	records, err := parser.Parse(context.Background(), 0)
 	require.NoError(t, err)
 
@@ -69,7 +69,7 @@ func TestJSONArray_StopsWhenConsumerBreaksOnSkippedElement(t *testing.T) {
 	t.Parallel()
 
 	reader := NewBufferedReader(strings.NewReader(`[5, {"a":1}]`), 4096)
-	parser := NewJSONParser(reader, BodyOptions{})
+	parser := NewJSONParser(reader, nil, BodyOptions{})
 	records, err := parser.Parse(context.Background(), 0)
 	require.NoError(t, err)
 

--- a/internal/blobstream/json_oversized_value_test.go
+++ b/internal/blobstream/json_oversized_value_test.go
@@ -1,0 +1,39 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestJSONSequence_OversizedValueIsSkipped asserts that a single top-level value larger
+// than max_log_size is skipped as a per-record parse error and the records after it are
+// still delivered, rather than buffered whole in memory. Without a bound a multi-gigabyte
+// NDJSON value would be read entirely into memory and OOM the collector; the reader here
+// is sized to 4096, so a 6 KB value exceeds the bound.
+func TestJSONSequence_OversizedValueIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	big := strings.Repeat("x", 6000)
+	body := `{"n":1}` + "\n" + `{"big":"` + big + `"}` + "\n" + `{"n":2}` + "\n"
+
+	got, errCount := collectRecordsAndErrors(t, body)
+	require.Equal(t, []string{`{"n":1}`, `{"n":2}`}, got,
+		"records before and after the oversized value are delivered")
+	require.Equal(t, 1, errCount, "the oversized value is skipped and reported once")
+}

--- a/internal/blobstream/json_parser.go
+++ b/internal/blobstream/json_parser.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"strings"
 
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
@@ -50,7 +51,7 @@ const (
 
 	// mixedSequenceLogMsg is warned once per file for a value sequence that mixes objects
 	// with non-object lines.
-	mixedSequenceLogMsg = "mixed content in JSON value sequence; string lines are emitted as bodies, malformed lines are dropped"
+	mixedSequenceLogMsg = "mixed content in JSON value sequence; text lines are emitted as bodies, corrupted JSON is dropped"
 )
 
 // MinLogSize is the smallest usable max_log_size. Content detection peeks fixed windows
@@ -469,30 +470,52 @@ func (p *jsonParser) yieldValues(startOffset int64, shape jsonShape) iter.Seq2[a
 					// after it; a bracketed shape has no delimiter to realign to after a
 					// mid-decode failure, so it stops. A retry reads the same bytes.
 					if isJSONStructureError(err) || errors.Is(err, errRecordTooLarge) {
-						// On resume, a malformed line below the checkpoint was already
-						// reported in the first pass; re-yielding it double-counts the
-						// parse-error metric. Skip the report but still resync past it so
-						// the records after it are reached, mirroring the below-offset
-						// record skip above.
+						// Bracketed shapes stop here rather than resync: recovering the elements
+						// after a bad one needs bracket-depth tracking that mis-fires on braces
+						// and commas inside strings, so it is intentionally deferred for now.
+						if closes {
+							if currentOffset >= startOffset {
+								if !yield(nil, fmt.Errorf("decode record: %w", err)) {
+									return
+								}
+							}
+							return
+						}
+						// A value sequence captures the bad line and resyncs past it. Malformed
+						// bytes mark the file mixed; an over-size record does not.
+						line, ok := p.resyncAfterNewline(false)
+						if isJSONStructureError(err) {
+							p.warnMixedOnce()
+						}
+						// A line that is text rather than broken JSON structure is a real string:
+						// emit it as a string body. Corrupted JSON and an over-size record stay
+						// parse errors. On resume a line below the checkpoint was already handled,
+						// so gate the yield while still resyncing past it.
+						if isJSONStructureError(err) && isTextLine(line) {
+							if currentOffset >= startOffset {
+								if !yield(rawTextLine(bytes.TrimRight(line, "\r")), nil) {
+									return
+								}
+							}
+							if !ok {
+								// A broken or short source mid-capture is a retryable read
+								// failure, not a clean end to be acked.
+								if serr := p.boundaryStreamErr(); serr != nil {
+									yield(nil, serr)
+								}
+								return
+							}
+							continue
+						}
 						if currentOffset >= startOffset {
 							if !yield(nil, fmt.Errorf("decode record: %w", err)) {
 								return
 							}
 						}
-						// Bracketed shapes stop here rather than resync: recovering the elements
-						// after a bad one needs bracket-depth tracking that mis-fires on braces
-						// and commas inside strings, so it is intentionally deferred for now.
-						if closes {
-							return
-						}
-						// Malformed bytes mark the file mixed; an over-size record does not.
-						if isJSONStructureError(err) {
-							p.warnMixedOnce()
-						}
-						if !p.resyncAfterNewline() {
-							// The resync gave up. If it gave up because the raw source broke
-							// or fell short (rather than a clean end), that is a retryable
-							// read failure, not a clean finish to be acked.
+						if !ok {
+							// The resync gave up. If the raw source broke or fell short (rather
+							// than a clean end), that is a retryable read failure, not a clean
+							// finish to be acked.
 							if serr := p.boundaryStreamErr(); serr != nil {
 								yield(nil, serr)
 							}
@@ -519,20 +542,45 @@ func (p *jsonParser) yieldValues(startOffset int64, shape jsonShape) iter.Seq2[a
 					}
 					continue
 				}
-				// In a value sequence a top-level string is a text line: mark the file mixed
-				// and emit it as a string body. Any other non-object value stays a per-record
-				// parse error so the other records still deliver.
+				// A non-object value in a value sequence is not a record. Objects fall through
+				// as records below, so same-line concatenated objects still parse.
 				if !isJSONObject(record) {
-					if shape == jsonShapeValueSequence {
-						p.warnMixedOnce()
+					if shape != jsonShapeValueSequence {
+						if !yield(nil, fmt.Errorf("decode record: expected a JSON object")) {
+							return
+						}
+						continue
+					}
+					p.warnMixedOnce()
+					// If the value consumed its whole line it is a bare scalar: a JSON string
+					// keeps its unquoted body, anything else is emitted as its own text. If there
+					// is trailing content the value was only the prefix of a text line (e.g. a
+					// timestamp the decoder read as a number), so emit the whole line as text;
+					// corrupted JSON structure is dropped.
+					if !lineHasTrailing(p.decoder) {
 						if isJSONString(record) {
 							if !yield(record, nil) {
 								return
 							}
-							continue
+						} else if !yield(rawTextLine(string(record)), nil) {
+							return
 						}
+						continue
 					}
-					if !yield(nil, fmt.Errorf("decode record: expected a JSON object")) {
+					trailing, ok := p.resyncAfterNewline(true)
+					line := append(append([]byte{}, record...), trailing...)
+					if isTextLine(line) {
+						if !yield(rawTextLine(strings.TrimSpace(string(line))), nil) {
+							return
+						}
+					} else if !yield(nil, fmt.Errorf("decode record: expected a JSON object")) {
+						return
+					}
+					if !ok {
+						// A broken or short source mid-capture is a retryable read failure.
+						if serr := p.boundaryStreamErr(); serr != nil {
+							yield(nil, serr)
+						}
 						return
 					}
 					continue
@@ -670,23 +718,33 @@ func (p *jsonParser) boundaryStreamErr() error {
 // the current malformed line, so the lines after it still parse. A json.Decoder cannot
 // resync in place, so the remaining input (its read-ahead buffer plus the source) is
 // re-wrapped in a fresh decoder. baseOffset is advanced by the discarded bytes so Offset()
-// stays absolute for resume. It returns false when no terminating newline remains, i.e.
-// the rest of the object cannot be resynced and reading stops.
-func (p *jsonParser) resyncAfterNewline() bool {
+// stays absolute for resume. It returns the discarded line's content (from its first
+// non-space byte, so the caller can classify text vs corrupted JSON) and whether a
+// terminating newline was found; on EOF it returns the content read with ok=false.
+func (p *jsonParser) resyncAfterNewline(keepLeading bool) (line []byte, ok bool) {
 	base := p.baseOffset + p.decoder.InputOffset()
 	remaining := bufio.NewReader(io.MultiReader(p.decoder.Buffered(), p.src))
 
 	var discarded int64
-	sawContent := false
+	var content []byte
+	// keepLeading captures from the current byte (for trailing after a decoded value, where
+	// leading whitespace is part of the line); otherwise leading whitespace and separator
+	// newlines before the malformed content are skipped.
+	sawContent := keepLeading
 	for {
 		b, err := remaining.ReadByte()
 		if err != nil {
-			return false
+			// The source ended without a terminating newline. Return the content read so a
+			// final unterminated line can still be handled; ok=false means nothing remains.
+			return content, false
 		}
 		discarded++
 		switch b {
 		case ' ', '\t', '\r':
-			// Separator whitespace before the malformed content.
+			// Leading whitespace is a separator; interior whitespace is part of the line.
+			if sawContent {
+				content = append(content, b)
+			}
 		case '\n':
 			// A newline before any content is the separator ending the prior record;
 			// keep going. A newline after content ends the malformed line: resume there.
@@ -699,17 +757,59 @@ func (p *jsonParser) resyncAfterNewline() bool {
 				// The next resync continues from this reader, which has read ahead past
 				// what the decoder has consumed, so it must not fall back to p.reader.
 				p.src = remaining
-				return true
+				return content, true
 			}
 		default:
 			sawContent = true
+			content = append(content, b)
 		}
 	}
 }
 
+// isTextLine reports that a captured value-sequence line is plain text rather than broken
+// JSON structure. A line whose first byte opens an object or array is treated as corrupted
+// JSON; anything else is a real text line.
+func isTextLine(line []byte) bool {
+	return len(line) > 0 && line[0] != '{' && line[0] != '['
+}
+
+// lineHasTrailing reports whether non-whitespace remains before the next newline after the
+// value just decoded, i.e. the value was only the prefix of a longer text line. It reads the
+// decoder's already-buffered bytes, which does not disturb the decoder's own position. If the
+// buffer ends before a newline is seen, it reports no trailing (the common line fits the
+// buffer; a value split across a buffer refill is treated as a clean whole-line value).
+func lineHasTrailing(dec *json.Decoder) bool {
+	buf := dec.Buffered()
+	b := make([]byte, 1)
+	for {
+		n, err := buf.Read(b)
+		if n == 0 || err != nil {
+			return false
+		}
+		switch b[0] {
+		case ' ', '\t', '\r':
+		case '\n':
+			return false
+		default:
+			return true
+		}
+	}
+}
+
+// rawTextLine is a value-sequence line that is text rather than JSON. AppendLogBody emits it
+// as a plain string body, preserving the original line in both raw and structured modes.
+type rawTextLine string
+
 // AppendLogBody appends the log record to the log record body using FromRaw, decoding
 // the element's original bytes. In raw mode the original text becomes the body instead.
 func (p *jsonParser) AppendLogBody(_ context.Context, lr plog.LogRecord, record any) error {
+	// A recovered text line is already a string; emit it verbatim as the body.
+	if txt, ok := record.(rawTextLine); ok {
+		lr.Body().SetStr(string(txt))
+		p.opts.setOriginal(lr, string(txt))
+		return nil
+	}
+
 	raw, ok := record.(json.RawMessage)
 	if !ok {
 		return fmt.Errorf("expected json record, got %T", record)

--- a/internal/blobstream/json_parser.go
+++ b/internal/blobstream/json_parser.go
@@ -15,6 +15,8 @@
 package blobstream
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -29,6 +31,14 @@ var (
 	// ErrNotArrayOrKnownObject is returned when the JSON stream is not a valid array or object
 	// with a known key. When this occurs, try to parse as text.
 	ErrNotArrayOrKnownObject = errors.New("expected array or object with known key")
+
+	// errTrailingRecordsWrapper marks a records-wrapper document whose tail, or the next
+	// concatenated document after it, could not be parsed as a records wrapper. It is a
+	// counted per-record parse error, deliberately NOT ErrNotArrayOrKnownObject: the worker
+	// treats that sentinel as "this object is not JSON" and re-reads the whole object with
+	// the line parser, which would re-emit the records already delivered from this object as
+	// raw line bodies and garble the checkpoint.
+	errTrailingRecordsWrapper = errors.New("trailing document is not a records wrapper")
 )
 
 const (
@@ -38,20 +48,94 @@ const (
 	maxRecordsSearchBytes = 4096
 )
 
+// MinLogSize is the smallest usable max_log_size. Content detection peeks fixed windows
+// (the widest is maxRecordsSearchBytes) against a buffer sized to max_log_size, so a
+// smaller value makes every object fail detection with bufio.ErrBufferFull at runtime.
+// Callers reject a configured max_log_size below this in config validation.
+const MinLogSize = maxRecordsSearchBytes
+
+// maxRecordBytesHardLimit is the OOM backstop on a single Decode: a value too large to
+// even hold in memory is rejected before it is buffered whole. It is deliberately far
+// above max_log_size (which is the exact hard wall, enforced on the decoded size) so a
+// record merely over max_log_size still decodes and can be rejected while the decoder
+// stays aligned. It is a var only so tests can lower it to exercise the backstop.
+var maxRecordBytesHardLimit int64 = 128 << 20
+
+// errRecordTooLarge marks a single top-level value that exceeds the per-record byte cap.
+// It is handled like a JSON structure error: the record is a counted parse error and, for
+// a value sequence, the decoder resyncs past it. Buffering an unbounded value whole is an
+// OOM vector for uncompressed NDJSON, so the cap trips before that happens.
+var errRecordTooLarge = errors.New("record exceeds max_log_size")
+
+// cappedRecordReader bounds how many bytes a single read (a Decode, or a navigation token)
+// may consume while armed, so one very large value cannot be buffered whole into memory.
+// The parser arms it with a per-operation limit and disarms it between operations. A limit
+// <= 0 disables the cap.
+type cappedRecordReader struct {
+	r     io.Reader
+	limit int64
+	n     int64
+	armed bool
+}
+
+func (c *cappedRecordReader) Read(p []byte) (int, error) {
+	if c.armed && c.limit > 0 {
+		if c.n >= c.limit {
+			return 0, errRecordTooLarge
+		}
+		if int64(len(p)) > c.limit-c.n {
+			p = p[:c.limit-c.n]
+		}
+	}
+	m, err := c.r.Read(p)
+	if c.armed {
+		c.n += int64(m)
+	}
+	return m, err
+}
+
+// arm starts counting a fresh operation against limit. disarm stops counting.
+func (c *cappedRecordReader) arm(limit int64) { c.armed, c.n, c.limit = true, 0, limit }
+func (c *cappedRecordReader) disarm()         { c.armed = false }
+
+// recordSizeLimit is the reader's max_log_size when it reports one, else the hard limit.
+func recordSizeLimit(reader BufferedReader) int64 {
+	if l, ok := reader.(interface{ maxRecordBytes() int64 }); ok {
+		if v := l.maxRecordBytes(); v > 0 {
+			return v
+		}
+	}
+	return maxRecordBytesHardLimit
+}
+
 type jsonParser struct {
 	reader  BufferedReader
 	decoder *json.Decoder
 	opts    BodyOptions
+	// capped bounds a single Decode so an unbounded top-level value cannot OOM the process.
+	capped *cappedRecordReader
+	// baseOffset is the absolute byte offset at which the current decoder started. It is
+	// nonzero after a resync rebuilds the decoder past a malformed line, so Offset()
+	// stays absolute for resume.
+	baseOffset int64
+	// src is the reader the current decoder consumes from. It starts as reader and
+	// becomes the resync bufio.Reader after each resync. The resync reader has read ahead
+	// past the decoder, so the next resync must continue from it, not from the drained
+	// original reader, or the buffered-but-unread records between two resyncs are lost.
+	src io.Reader
 }
 
 var _ LogParser = (*jsonParser)(nil)
 
 // NewJSONParser creates a new JSON parser.
 func NewJSONParser(reader BufferedReader, opts BodyOptions) LogParser {
+	capped := &cappedRecordReader{r: reader}
 	return &jsonParser{
 		reader:  reader,
-		decoder: json.NewDecoder(reader),
+		decoder: json.NewDecoder(capped),
 		opts:    opts,
+		src:     reader,
+		capped:  capped,
 	}
 }
 
@@ -114,84 +198,203 @@ func firstMeaningfulByte(buf []byte) (b byte, rest []byte, ok bool) {
 	return 0, nil, false
 }
 
-// Parse parses the JSON stream into a sequence of log records. The JSON stream is
-// expected be either:
+// jsonShape describes how an object holds its records. Classification runs before the
+// decoder reads. A json.Decoder cannot rewind after a search for a "Records" key.
+type jsonShape int
+
+const (
+	// jsonShapeArray is a top-level array of records: [{...},{...}].
+	jsonShapeArray jsonShape = iota
+
+	// jsonShapeRecordsWrapper is a single object whose "Records" key holds the array.
+	jsonShapeRecordsWrapper
+
+	// jsonShapeValueSequence is one top-level value after another. It covers
+	// newline-delimited JSON, a lone object, and concatenated documents. A
+	// json.Decoder reads all three the same way, so NDJSON needs no detection.
+	jsonShapeValueSequence
+)
+
+// classifyJSON reads an object's shape from its leading bytes. It consumes nothing.
 //
-// 1. an array of log records
-//
-// 2. a single object with a "Records" key that contains an array of log records
-//
-// The parser will return an error if the stream is not valid. It will return
-// ErrNotArrayOrKnownObject if the stream does not contain a valid array or object with a
-// "Records" key.
-func (p *jsonParser) Parse(_ context.Context, startOffset int64) (logs iter.Seq2[any, error], err error) {
-	// Read the first object
-	tok, err := p.decoder.Token()
-	if err != nil {
-		return nil, fmt.Errorf("read first token: %w", err)
+// The window matches the budget the "Records" search always used. A wrapper that holds
+// the key deeper than the budget classifies as it did before.
+func classifyJSON(reader BufferedReader) (jsonShape, error) {
+	window, err := reader.Peek(maxRecordsSearchBytes)
+	if err != nil && !errors.Is(err, io.EOF) {
+		// A broken source, a short download, or a truncated compression layer
+		// (io.ErrUnexpectedEOF) surfaces here. A bare error is treated as transient and
+		// redelivers deterministic content forever, so classify it: a broken or short
+		// source retries, a content-truncated one delivers what was read and acks.
+		return 0, classifyReadFailure(reader, err)
 	}
 
-	switch {
-	case tok == json.Delim('['):
-		// json structure is an array
-		return p.yieldArray(startOffset), nil
+	first, _, ok := firstMeaningfulByte(window)
+	if !ok {
+		return 0, ErrNotArrayOrKnownObject
+	}
 
-	case tok == json.Delim('{'):
-		// json structure is an object, find and yield the "Records" array containing log
-		// records
-
-		// iterate through key/value pairs
-		for p.decoder.More() {
-			// key
-			tok, err := p.decoder.Token()
-			if err != nil {
-				return nil, fmt.Errorf("read token: %w", err)
+	switch first {
+	case '[':
+		return jsonShapeArray, nil
+	case '{':
+		// Decode the first value once. If it fits, reuse it to tell a records wrapper
+		// from a value sequence without peeking the window again. If it overflows the
+		// window, only a records wrapper (whose large array need not fit) is still
+		// usable, found by token-streaming; a value that large fills memory, so a value
+		// sequence goes back to the caller to fall back to line parsing. Consequence: an
+		// NDJSON object whose FIRST value exceeds the window is delivered as line-parsed
+		// string bodies rather than structured records. Documented limitation, by design.
+		if first, fits := firstValue(window); fits {
+			if opensRecordsArray(first) {
+				return jsonShapeRecordsWrapper, nil
 			}
-			// Inside an object the decoder only returns string keys, so the
-			// assertion cannot fail. A zero value would fall through to the skip
-			// below, which keeps the decoder aligned.
-			key, _ := tok.(string)
-
-			if key != "Records" {
-				// we only look for Records in the first 4096 bytes
-				if p.decoder.InputOffset() > maxRecordsSearchBytes {
-					return nil, ErrNotArrayOrKnownObject
-				}
-
-				// skip the non-"Records" value
-				if err := skipValue(p.decoder, maxRecordsSearchBytes); err != nil {
-					return nil, fmt.Errorf("skip value: %w", err)
-				}
-				continue
-			}
-
-			// "Records" value
-			tok, err = p.decoder.Token()
-			if err != nil {
-				return nil, fmt.Errorf("read token: %w", err)
-			}
-			switch tok {
-			case json.Delim('['):
-				return p.yieldArray(startOffset), nil
-
-			default:
-				// "Records" exists but is not an array
-				return nil, ErrNotArrayOrKnownObject
-			}
+			return jsonShapeValueSequence, nil
 		}
-
-		// we didn't find a top level array of log records or a "Records" key with an array of
-		// log records
-		return nil, ErrNotArrayOrKnownObject
-
+		if opensRecordsArray(window) {
+			return jsonShapeRecordsWrapper, nil
+		}
+		return 0, ErrNotArrayOrKnownObject
 	default:
-		// not an array or object with a known key
-		return nil, ErrNotArrayOrKnownObject
+		return 0, ErrNotArrayOrKnownObject
 	}
 }
 
+// firstValue decodes the first complete top-level value in window, reporting whether one
+// ends inside the window. It separates a sequence of records from one oversized document:
+// the sequence path holds each record in memory, so it runs only when the first record is
+// small. The decoded value is returned so the caller can inspect it without re-decoding.
+func firstValue(window []byte) (json.RawMessage, bool) {
+	var first json.RawMessage
+	if json.NewDecoder(bytes.NewReader(window)).Decode(&first) != nil {
+		return nil, false
+	}
+	return first, true
+}
+
+// opensRecordsArray reports that window starts an object whose "Records" key holds an
+// array. It decodes instead of matching text, so the word "Records" in a value does not
+// match. The throwaway decoder reads only the peeked bytes.
+func opensRecordsArray(window []byte) bool {
+	decoder := json.NewDecoder(bytes.NewReader(window))
+
+	tok, err := decoder.Token()
+	if err != nil || tok != json.Delim('{') {
+		return false
+	}
+
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			// A truncated window or the end of the object: no "Records" key in budget.
+			return false
+		}
+		// A closing delimiter or a cut window is not a key, so no Records array opens.
+		key, ok := tok.(string)
+		if !ok {
+			return false
+		}
+
+		if key != "Records" {
+			if err := skipValue(decoder, maxRecordsSearchBytes); err != nil {
+				return false
+			}
+			continue
+		}
+
+		tok, err = decoder.Token()
+		if err != nil {
+			return false
+		}
+		return tok == json.Delim('[')
+	}
+}
+
+// Parse reads the JSON stream into a sequence of log records. The stream holds an array
+// of records, an object with a "Records" array, or a sequence of top-level values.
+//
+// It returns ErrNotArrayOrKnownObject for any other content.
+func (p *jsonParser) Parse(_ context.Context, startOffset int64) (logs iter.Seq2[any, error], err error) {
+	shape, err := classifyJSON(p.reader)
+	if err != nil {
+		return nil, err
+	}
+
+	switch shape {
+	case jsonShapeArray:
+		// Step into the array so the loop below sees its elements.
+		if _, err := p.decoder.Token(); err != nil {
+			return nil, fmt.Errorf("read first token: %w", err)
+		}
+
+	case jsonShapeRecordsWrapper:
+		if err := p.seekRecordsArray(); err != nil {
+			return nil, err
+		}
+
+	case jsonShapeValueSequence:
+		// Nothing to step into: the records are the top-level values themselves.
+	}
+
+	// A sequence of top-level values has no closing delimiter, so only the two
+	// bracketed shapes can be checked for one.
+	return p.yieldValues(startOffset, shape), nil
+}
+
+// seekRecordsArray advances the decoder into the "Records" array. It skips the other
+// keys and decodes none of their values.
+func (p *jsonParser) seekRecordsArray() error {
+	// Bound the search relative to this object's start so a later concatenated document
+	// is measured from its own beginning, not the cumulative stream offset.
+	start := p.decoder.InputOffset()
+	if _, err := p.decoder.Token(); err != nil {
+		return fmt.Errorf("read first token: %w", err)
+	}
+
+	for p.decoder.More() {
+		tok, err := p.decoder.Token()
+		if err != nil {
+			return fmt.Errorf("read token: %w", err)
+		}
+		// Inside an object the decoder only returns string keys, so the assertion
+		// cannot fail. A zero value falls through to the skip below, which keeps the
+		// decoder aligned.
+		key, _ := tok.(string)
+
+		if key != "Records" {
+			if p.decoder.InputOffset()-start > maxRecordsSearchBytes {
+				return ErrNotArrayOrKnownObject
+			}
+			// Bound the skipped value: one oversized token must not be buffered whole (an
+			// OOM vector), and a value past the search budget means Records is not here.
+			p.capped.arm(maxRecordsSearchBytes)
+			err := skipValue(p.decoder, start+maxRecordsSearchBytes)
+			p.capped.disarm()
+			if errors.Is(err, errRecordTooLarge) {
+				return ErrNotArrayOrKnownObject
+			}
+			if err != nil {
+				return fmt.Errorf("skip value: %w", err)
+			}
+			continue
+		}
+
+		tok, err = p.decoder.Token()
+		if err != nil {
+			return fmt.Errorf("read token: %w", err)
+		}
+		if tok != json.Delim('[') {
+			// "Records" exists but is not an array
+			return ErrNotArrayOrKnownObject
+		}
+		return nil
+	}
+
+	return ErrNotArrayOrKnownObject
+}
+
 func (p *jsonParser) Offset() int64 {
-	return p.decoder.InputOffset()
+	return p.baseOffset + p.decoder.InputOffset()
 }
 
 func skipValue(decoder *json.Decoder, maxBytes int64) error {
@@ -225,55 +428,258 @@ func skipValue(decoder *json.Decoder, maxBytes int64) error {
 	return nil
 }
 
-func (p *jsonParser) yieldArray(startOffset int64) iter.Seq2[any, error] {
+// yieldValues decodes one record at a time. decoder.More() reports another element or
+// top-level value, so one loop drives an array and a sequence of documents.
+func (p *jsonParser) yieldValues(startOffset int64, shape jsonShape) iter.Seq2[any, error] {
+	// A value sequence has no closing delimiter; the bracketed shapes close with one.
+	closes := shape != jsonShapeValueSequence
 	return func(yield func(any, error) bool) {
-		// Iterate through the array
-		for p.decoder.More() {
-			// RawMessage keeps each element's exact bytes for log.record.original.
-			// AppendLogBody decodes the body from the same bytes.
-			var record json.RawMessage
-			currentOffset := p.decoder.InputOffset()
+		for {
+			for p.decoder.More() {
+				// RawMessage keeps each element's exact bytes for log.record.original.
+				// AppendLogBody decodes the body from the same bytes. Each record is held
+				// whole in memory, so the capped reader bounds a single Decode to the OOM
+				// backstop; the exact max_log_size wall is enforced on the decoded size below.
+				var record json.RawMessage
+				startInput := p.decoder.InputOffset()
+				currentOffset := p.baseOffset + startInput
 
-			if err := p.decoder.Decode(&record); err != nil {
-				// The stream ran out. Whether that is the end of the array or a
-				// cut is settled by the closing-delimiter check below.
-				if errors.Is(err, io.EOF) {
-					break
+				p.capped.arm(maxRecordBytesHardLimit)
+				err := p.decoder.Decode(&record)
+				p.capped.disarm()
+				if err != nil {
+					// The stream ran out. Whether that is the end of the array or a
+					// cut is settled by the closing-delimiter check below.
+					if errors.Is(err, io.EOF) {
+						break
+					}
+					// Malformed bytes, or a value too large to decode within the OOM backstop,
+					// are a per-record parse error. A json.Decoder cannot resync in place, so a
+					// value sequence rebuilds the decoder past the bad line to keep the lines
+					// after it; a bracketed shape has no delimiter to realign to after a
+					// mid-decode failure, so it stops. A retry reads the same bytes.
+					if isJSONStructureError(err) || errors.Is(err, errRecordTooLarge) {
+						// On resume, a malformed line below the checkpoint was already
+						// reported in the first pass; re-yielding it double-counts the
+						// parse-error metric. Skip the report but still resync past it so
+						// the records after it are reached, mirroring the below-offset
+						// record skip above.
+						if currentOffset >= startOffset {
+							if !yield(nil, fmt.Errorf("decode record: %w", err)) {
+								return
+							}
+						}
+						// Bracketed shapes stop here rather than resync: recovering the elements
+						// after a bad one needs bracket-depth tracking that mis-fires on braces
+						// and commas inside strings, so it is intentionally deferred for now.
+						if closes {
+							return
+						}
+						if !p.resyncAfterNewline() {
+							// The resync gave up. If it gave up because the raw source broke
+							// or fell short (rather than a clean end), that is a retryable
+							// read failure, not a clean finish to be acked.
+							if serr := p.boundaryStreamErr(); serr != nil {
+								yield(nil, serr)
+							}
+							return
+						}
+						continue
+					}
+					// Otherwise sort a broken source stream (retry) from a truncated
+					// object (deliver + ack) from content the decoder rejected.
+					yield(nil, classifyReadFailure(p.reader, err))
+					return
 				}
-				// The object stops part way through a record. The missing bytes
-				// were never written, so a retry reads the same thing.
-				if errors.Is(err, io.ErrUnexpectedEOF) {
+
+				// if we haven't hit the start offset, skip the record
+				if currentOffset < startOffset {
+					continue
+				}
+				// max_log_size is a hard wall: reject a record whose decoded size exceeds it.
+				// The decoder is aligned at the next record, so the loop continues and the
+				// records after it still deliver (no dropped tail).
+				if p.decoder.InputOffset()-startInput > recordSizeLimit(p.reader) {
+					if !yield(nil, fmt.Errorf("decode record: exceeds max_log_size")) {
+						return
+					}
+					continue
+				}
+				// A record must be a JSON object. A scalar or array element is skipped as
+				// a per-record parse error so the object's other records still deliver,
+				// rather than emitting a meaningless scalar body.
+				if !isJSONObject(record) {
+					if !yield(nil, fmt.Errorf("decode record: expected a JSON object")) {
+						return
+					}
+					continue
+				}
+				if !yield(record, nil) {
+					return
+				}
+			}
+
+			// A value sequence has no closing delimiter, so the loop ending is normally a
+			// clean finish. json.Decoder.More() swallows the read error from its
+			// look-ahead, though, so a source that breaks at a value boundary ends the
+			// loop the same way. Consult the raw source: a broken or short download
+			// retries; a clean end does not.
+			if !closes {
+				if serr := p.boundaryStreamErr(); serr != nil {
+					yield(nil, serr)
+				}
+				return
+			}
+
+			// A bracketed shape closes with a delimiter; anything else means the bytes
+			// ran out before the boundary.
+			if _, err := p.decoder.Token(); err != nil {
+				if p.reader.RawReadErr() != nil || p.reader.RawTruncated() {
+					yield(nil, ErrStreamRead{Err: err})
+				} else {
 					yield(nil, ErrTruncatedObject{Err: err})
-					return
 				}
-				// Both cases below are terminal. A json.Decoder cannot resync, so
-				// every later Decode fails on the same byte while More() reports
-				// more input.
-				//
-				// Malformed bytes stay a record error, because a retry reads the
-				// same bytes. A broken stream is marked, because the rest of the
-				// object is still readable later.
-				if isJSONStructureError(err) {
-					yield(nil, fmt.Errorf("decode record: %w", err))
-					return
-				}
-				yield(nil, ErrStreamRead{Err: err})
 				return
 			}
 
-			// if we haven't hit the start offset, skip the record
-			if currentOffset < startOffset {
-				continue
+			// A records wrapper still holds the object's remaining keys and closing brace
+			// after its Records array; consume them to reach the next document. A failure
+			// here can be the source breaking mid-tail, which the token reads swallow the
+			// same way, so consult the raw source before ending on it.
+			if shape == jsonShapeRecordsWrapper {
+				if err := p.finishObject(); err != nil {
+					if serr := p.boundaryStreamErr(); serr != nil {
+						yield(nil, serr)
+					} else {
+						// A non-stream failure to consume the wrapper's tail (for example
+						// trailing keys past the search limit). Count it as one parse error
+						// rather than silently dropping the documents concatenated after it. A
+						// non-sentinel error so the worker skips this document and acks, rather
+						// than re-reading the whole object as lines. It re-counts on a
+						// redelivery (the checkpoint cannot advance past a non-delivering tail),
+						// which is accepted as metric-only.
+						yield(nil, fmt.Errorf("%w: %v", errTrailingRecordsWrapper, err))
+					}
+					return
+				}
 			}
-			if !yield(record, nil) {
+
+			// Documents may be concatenated (for example one array file appended to
+			// another, or several {"Records": [...]} objects in a row). Continue into the
+			// next document of the same shape; a clean end stops the loop. More() swallows
+			// the boundary read error, so a source that broke or fell short right here
+			// otherwise looks like a clean end; consult the raw source.
+			if !p.decoder.More() {
+				if serr := p.boundaryStreamErr(); serr != nil {
+					yield(nil, serr)
+				}
 				return
+			}
+			// More() reported another document. A break while reading its prefix is a
+			// stream failure (retryable), not deterministic garbage, so consult the raw
+			// source first; otherwise count it as one parse error, gated so a redelivery
+			// past this point does not re-count it, and the object still acks.
+			switch shape {
+			case jsonShapeArray:
+				if _, err := p.decoder.Token(); err != nil {
+					if serr := p.boundaryStreamErr(); serr != nil {
+						yield(nil, serr)
+					} else {
+						yield(nil, fmt.Errorf("decode record: %w", err))
+					}
+					return
+				}
+			case jsonShapeRecordsWrapper:
+				if err := p.seekRecordsArray(); err != nil {
+					if serr := p.boundaryStreamErr(); serr != nil {
+						yield(nil, serr)
+					} else {
+						// A trailing document that is not a records wrapper. Wrapping
+						// ErrNotArrayOrKnownObject would make the worker re-read the whole
+						// object as lines and re-emit delivered records, so use a non-sentinel
+						// error: the object acks with this document counted and skipped.
+						yield(nil, fmt.Errorf("%w: %v", errTrailingRecordsWrapper, err))
+					}
+					return
+				}
 			}
 		}
-		// The loop above also ends when the object stops part way through, because
-		// More reports no further element either way. A complete array closes with a
-		// delimiter, so anything else here means the bytes ran out early.
+	}
+}
+
+// finishObject consumes the remaining keys and the closing brace of the object the
+// decoder is currently inside, after its records have been read, so the decoder is left
+// positioned at the next concatenated document.
+func (p *jsonParser) finishObject() error {
+	start := p.decoder.InputOffset()
+	for p.decoder.More() {
 		if _, err := p.decoder.Token(); err != nil {
-			yield(nil, ErrTruncatedObject{Err: err})
+			return err
+		}
+		// Bound the skipped tail value so an oversized token is not buffered whole.
+		p.capped.arm(maxRecordsSearchBytes)
+		err := skipValue(p.decoder, start+maxRecordsSearchBytes)
+		p.capped.disarm()
+		if err != nil {
+			return err
+		}
+	}
+	_, err := p.decoder.Token() // the closing '}'
+	return err
+}
+
+// boundaryStreamErr reports the raw source's state at a document boundary. json.Decoder's
+// More() and its boundary token reads swallow the underlying read error from their
+// look-ahead, so a source that broke or fell short of its known size at a boundary looks
+// like a clean end. It returns a retryable ErrStreamRead in that case, or nil when the
+// stream truly ended cleanly.
+func (p *jsonParser) boundaryStreamErr() error {
+	if rerr := p.reader.RawReadErr(); rerr != nil {
+		return ErrStreamRead{Err: rerr}
+	}
+	if p.reader.RawTruncated() {
+		return ErrStreamRead{Err: io.ErrUnexpectedEOF}
+	}
+	return nil
+}
+
+// resyncAfterNewline rebuilds the decoder to read from just past the newline that ends
+// the current malformed line, so the lines after it still parse. A json.Decoder cannot
+// resync in place, so the remaining input (its read-ahead buffer plus the source) is
+// re-wrapped in a fresh decoder. baseOffset is advanced by the discarded bytes so Offset()
+// stays absolute for resume. It returns false when no terminating newline remains, i.e.
+// the rest of the object cannot be resynced and reading stops.
+func (p *jsonParser) resyncAfterNewline() bool {
+	base := p.baseOffset + p.decoder.InputOffset()
+	remaining := bufio.NewReader(io.MultiReader(p.decoder.Buffered(), p.src))
+
+	var discarded int64
+	sawContent := false
+	for {
+		b, err := remaining.ReadByte()
+		if err != nil {
+			return false
+		}
+		discarded++
+		switch b {
+		case ' ', '\t', '\r':
+			// Separator whitespace before the malformed content.
+		case '\n':
+			// A newline before any content is the separator ending the prior record;
+			// keep going. A newline after content ends the malformed line: resume there.
+			if sawContent {
+				p.baseOffset = base + discarded
+				// Rebuild the decoder over the capped reader so the per-record size bound
+				// still applies after a resync.
+				p.capped.r = remaining
+				p.decoder = json.NewDecoder(p.capped)
+				// The next resync continues from this reader, which has read ahead past
+				// what the decoder has consumed, so it must not fall back to p.reader.
+				p.src = remaining
+				return true
+			}
+		default:
+			sawContent = true
 		}
 	}
 }
@@ -307,6 +713,14 @@ func (p *jsonParser) AppendLogBody(_ context.Context, lr plog.LogRecord, record 
 	_ = lr.Body().FromRaw(decoded)
 	p.opts.setOriginal(lr, original)
 	return nil
+}
+
+// isJSONObject reports that raw is a JSON object. A successful Decode into a RawMessage
+// trims leading whitespace, so the first byte is the value's opening token. Array
+// elements and top-level values that are scalars or arrays are not records this receiver
+// emits.
+func isJSONObject(raw json.RawMessage) bool {
+	return len(raw) > 0 && raw[0] == '{'
 }
 
 // isJSONStructureError reports that the bytes themselves are malformed, rather than the

--- a/internal/blobstream/json_parser.go
+++ b/internal/blobstream/json_parser.go
@@ -25,6 +25,7 @@ import (
 	"iter"
 
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
 )
 
 var (
@@ -46,6 +47,10 @@ const (
 	// the first 4096 bytes of the JSON stream. This is to avoid parsing the entire file
 	// looking for a "Records" key and not finding it.
 	maxRecordsSearchBytes = 4096
+
+	// mixedSequenceLogMsg is warned once per file for a value sequence that mixes objects
+	// with non-object lines.
+	mixedSequenceLogMsg = "mixed content in JSON value sequence; string lines are emitted as bodies, malformed lines are dropped"
 )
 
 // MinLogSize is the smallest usable max_log_size. Content detection peeks fixed windows
@@ -123,12 +128,16 @@ type jsonParser struct {
 	// past the decoder, so the next resync must continue from it, not from the drained
 	// original reader, or the buffered-but-unread records between two resyncs are lost.
 	src io.Reader
+	// logger reports a mixed value sequence; may be nil.
+	logger *zap.Logger
+	// warnedMixed gates that warning to once per file.
+	warnedMixed bool
 }
 
 var _ LogParser = (*jsonParser)(nil)
 
-// NewJSONParser creates a new JSON parser.
-func NewJSONParser(reader BufferedReader, opts BodyOptions) LogParser {
+// NewJSONParser creates a new JSON parser. logger (may be nil) reports a mixed value sequence.
+func NewJSONParser(reader BufferedReader, logger *zap.Logger, opts BodyOptions) LogParser {
 	capped := &cappedRecordReader{r: reader}
 	return &jsonParser{
 		reader:  reader,
@@ -136,6 +145,7 @@ func NewJSONParser(reader BufferedReader, opts BodyOptions) LogParser {
 		opts:    opts,
 		src:     reader,
 		capped:  capped,
+		logger:  logger,
 	}
 }
 
@@ -475,6 +485,10 @@ func (p *jsonParser) yieldValues(startOffset int64, shape jsonShape) iter.Seq2[a
 						if closes {
 							return
 						}
+						// Malformed bytes mark the file mixed; an over-size record does not.
+						if isJSONStructureError(err) {
+							p.warnMixedOnce()
+						}
 						if !p.resyncAfterNewline() {
 							// The resync gave up. If it gave up because the raw source broke
 							// or fell short (rather than a clean end), that is a retryable
@@ -505,10 +519,19 @@ func (p *jsonParser) yieldValues(startOffset int64, shape jsonShape) iter.Seq2[a
 					}
 					continue
 				}
-				// A record must be a JSON object. A scalar or array element is skipped as
-				// a per-record parse error so the object's other records still deliver,
-				// rather than emitting a meaningless scalar body.
+				// In a value sequence a top-level string is a text line: mark the file mixed
+				// and emit it as a string body. Any other non-object value stays a per-record
+				// parse error so the other records still deliver.
 				if !isJSONObject(record) {
+					if shape == jsonShapeValueSequence {
+						p.warnMixedOnce()
+						if isJSONString(record) {
+							if !yield(record, nil) {
+								return
+							}
+							continue
+						}
+					}
 					if !yield(nil, fmt.Errorf("decode record: expected a JSON object")) {
 						return
 					}
@@ -721,6 +744,21 @@ func (p *jsonParser) AppendLogBody(_ context.Context, lr plog.LogRecord, record 
 // emits.
 func isJSONObject(raw json.RawMessage) bool {
 	return len(raw) > 0 && raw[0] == '{'
+}
+
+// isJSONString reports that raw is a JSON string value, judged from its opening token.
+func isJSONString(raw json.RawMessage) bool {
+	return len(raw) > 0 && raw[0] == '"'
+}
+
+// warnMixedOnce warns once per file that this value sequence mixes objects with non-object
+// lines. It is a no-op without a logger.
+func (p *jsonParser) warnMixedOnce() {
+	if p.logger == nil || p.warnedMixed {
+		return
+	}
+	p.warnedMixed = true
+	p.logger.Warn(mixedSequenceLogMsg)
 }
 
 // isJSONStructureError reports that the bytes themselves are malformed, rather than the

--- a/internal/blobstream/json_records_test.go
+++ b/internal/blobstream/json_records_test.go
@@ -234,7 +234,7 @@ func TestJSONRecords_ReportsAFailedFirstRead(t *testing.T) {
 		BufferedReader: NewBufferedReader(strings.NewReader(""), 4096),
 		header:         []byte(`[{"host":"a"}]`),
 		readErr:        readErr,
-	}, BodyOptions{})
+	}, nil, BodyOptions{})
 
 	_, err := parser.Parse(context.Background(), 0)
 	require.ErrorIs(t, err, readErr)
@@ -251,7 +251,7 @@ func TestJSONRecords_RejectsNonContainerDocuments(t *testing.T) {
 		t.Run(body, func(t *testing.T) {
 			t.Parallel()
 
-			parser := NewJSONParser(NewBufferedReader(strings.NewReader(body), 4096), BodyOptions{})
+			parser := NewJSONParser(NewBufferedReader(strings.NewReader(body), 4096), nil, BodyOptions{})
 			_, err := parser.Parse(context.Background(), 0)
 			require.ErrorIs(t, err, ErrNotArrayOrKnownObject)
 		})

--- a/internal/blobstream/json_records_test.go
+++ b/internal/blobstream/json_records_test.go
@@ -93,28 +93,51 @@ func TestJSONRecords_ReadsSupportedLayouts(t *testing.T) {
 	}
 }
 
-// TestJSONRecords_RejectsUnusableLayouts covers the shapes the parser refuses. Each
-// returns ErrNotArrayOrKnownObject, which the worker answers with a line-parse retry.
-func TestJSONRecords_RejectsUnusableLayouts(t *testing.T) {
+// TestJSONRecords_ReadsSingleValueLayouts covers the shapes the "Records" search alone
+// rejected. Each is a complete JSON value, so the value-sequence path reads it as one
+// record instead of sending it to the line parser.
+func TestJSONRecords_ReadsSingleValueLayouts(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		name string
 		body string
+		want []any
 	}{
-		{name: "empty object", body: `{}`},
-		{name: "object with no records key", body: `{"host":"a","msg":"first"}`},
-		{name: "records holding a string", body: `{"Records":"not an array"}`},
-		{name: "records holding an object", body: `{"Records":{"host":"a"}}`},
-		{name: "records holding a number", body: `{"Records":7}`},
+		{
+			name: "empty object",
+			body: `{}`,
+			want: []any{map[string]any{}},
+		},
+		{
+			name: "object with no records key",
+			body: `{"host":"a","msg":"first"}`,
+			want: []any{map[string]any{"host": "a", "msg": "first"}},
+		},
+		{
+			name: "records holding a string",
+			body: `{"Records":"not an array"}`,
+			want: []any{map[string]any{"Records": "not an array"}},
+		},
+		{
+			name: "records holding an object",
+			body: `{"Records":{"host":"a"}}`,
+			want: []any{map[string]any{"Records": map[string]any{"host": "a"}}},
+		},
+		{
+			name: "records holding a number",
+			body: `{"Records":7}`,
+			want: []any{map[string]any{"Records": float64(7)}},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := driveJSON(t, tc.body)
-			require.ErrorIs(t, err, ErrNotArrayOrKnownObject)
+			bodies, err := driveJSON(t, tc.body)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, bodies)
 		})
 	}
 }

--- a/internal/blobstream/json_resume_error_test.go
+++ b/internal/blobstream/json_resume_error_test.go
@@ -1,0 +1,75 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestJSONSequence_ResumeDoesNotReReportBelowOffsetError asserts a malformed line below the
+// resume checkpoint is not reported again on resume. It was already reported in the first
+// pass; re-yielding it double-counts the parse-error metric. The resync past it still
+// happens so the records after it are reached.
+func TestJSONSequence_ResumeDoesNotReReportBelowOffsetError(t *testing.T) {
+	t.Parallel()
+
+	body := "{\"n\":1}\n{bad}\n{\"n\":2}\n{\"n\":3}\n"
+
+	// Pass 1: read everything, capturing the offset right after {"n":2}. The malformed
+	// line is reported once here.
+	reader := NewBufferedReader(strings.NewReader(body), 4096)
+	parser := NewJSONParser(reader, BodyOptions{})
+	records, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	var firstPassErrs int
+	var resumeOffset int64
+	for record, rerr := range records {
+		if rerr != nil {
+			firstPassErrs++
+			continue
+		}
+		if string(record.(json.RawMessage)) == `{"n":2}` {
+			resumeOffset = parser.Offset()
+		}
+	}
+	require.Equal(t, 1, firstPassErrs, "the malformed line is reported once in the first pass")
+	require.Positive(t, resumeOffset)
+
+	// Pass 2: resume past {"n":2}. The malformed line sits below the checkpoint, so it must
+	// not be reported again; only {"n":3} remains.
+	reader2 := NewBufferedReader(strings.NewReader(body), 4096)
+	parser2 := NewJSONParser(reader2, BodyOptions{})
+	records2, err := parser2.Parse(context.Background(), resumeOffset)
+	require.NoError(t, err)
+
+	var got []string
+	var resumeErrs int
+	for record, rerr := range records2 {
+		if rerr != nil {
+			resumeErrs++
+			continue
+		}
+		got = append(got, string(record.(json.RawMessage)))
+	}
+
+	require.Equal(t, []string{`{"n":3}`}, got, "resume delivers only the records after the checkpoint")
+	require.Zero(t, resumeErrs, "a malformed line below the checkpoint is not reported again on resume")
+}

--- a/internal/blobstream/json_resume_error_test.go
+++ b/internal/blobstream/json_resume_error_test.go
@@ -35,7 +35,7 @@ func TestJSONSequence_ResumeDoesNotReReportBelowOffsetError(t *testing.T) {
 	// Pass 1: read everything, capturing the offset right after {"n":2}. The malformed
 	// line is reported once here.
 	reader := NewBufferedReader(strings.NewReader(body), 4096)
-	parser := NewJSONParser(reader, BodyOptions{})
+	parser := NewJSONParser(reader, nil, BodyOptions{})
 	records, err := parser.Parse(context.Background(), 0)
 	require.NoError(t, err)
 
@@ -56,7 +56,7 @@ func TestJSONSequence_ResumeDoesNotReReportBelowOffsetError(t *testing.T) {
 	// Pass 2: resume past {"n":2}. The malformed line sits below the checkpoint, so it must
 	// not be reported again; only {"n":3} remains.
 	reader2 := NewBufferedReader(strings.NewReader(body), 4096)
-	parser2 := NewJSONParser(reader2, BodyOptions{})
+	parser2 := NewJSONParser(reader2, nil, BodyOptions{})
 	records2, err := parser2.Parse(context.Background(), resumeOffset)
 	require.NoError(t, err)
 

--- a/internal/blobstream/json_resync_streambreak_test.go
+++ b/internal/blobstream/json_resync_streambreak_test.go
@@ -1,0 +1,77 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestJSONSequence_BrokenStreamDuringResyncRetries asserts that when the source breaks
+// while the parser is scanning forward for the newline that ends a malformed line, the
+// object is reported as a broken stream (retry), not silently acked. resyncAfterNewline
+// gives up on any read error; without consulting the raw source the worker would ack an
+// incomplete object and lose every record after the break.
+func TestJSONSequence_BrokenStreamDuringResyncRetries(t *testing.T) {
+	t.Parallel()
+
+	// Good NDJSON records, then a malformed line with no terminating newline, then the
+	// stream breaks — so the resync scan hits the read error before finding a newline.
+	// The body must exceed the detection/classification window (4096 bytes) so the read
+	// error lands during the resync scan rather than during content detection.
+	var sb strings.Builder
+	for i := 0; i < 800; i++ {
+		fmt.Fprintf(&sb, `{"n":%d}`+"\n", i)
+	}
+	sb.WriteString(`{bad`)
+	body := []byte(sb.String())
+	require.Greater(t, len(body), maxRecordsSearchBytes+256, "body must exceed the classification window")
+	readErr := errors.New("connection reset by peer")
+
+	stream := LogStream{
+		Name:        "logs/object.json",
+		Body:        &cutAfter{data: body, n: len(body), err: readErr},
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+	seq, err := producer.Records(context.Background(), Offset{})
+	require.NoError(t, err)
+
+	var recs int
+	var last error
+	for _, rerr := range seq {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		recs++
+	}
+
+	require.Positive(t, recs, "records before the break are delivered")
+	require.Error(t, last, "a broken stream during resync must surface an error")
+	require.True(t, IsStreamRead(last), "a broken stream during resync must retry")
+	require.ErrorIs(t, last, readErr)
+}

--- a/internal/blobstream/json_resync_test.go
+++ b/internal/blobstream/json_resync_test.go
@@ -35,14 +35,14 @@ func TestJSONSequence_ResyncsAfterMalformedLine(t *testing.T) {
 	require.Equal(t, 1, errCount, "the malformed line is skipped and reported once")
 }
 
-// TestJSONSequence_ResyncsAcrossConsecutiveMalformedLines asserts each malformed line is
+// TestJSONSequence_ResyncsAcrossConsecutiveMalformedLines asserts each corrupted line is
 // skipped independently, so a run of bad lines does not lose the good ones after them.
 func TestJSONSequence_ResyncsAcrossConsecutiveMalformedLines(t *testing.T) {
 	t.Parallel()
 
-	got, errCount := collectRecordsAndErrors(t, "{\"n\":1}\n{bad1\nalso bad\n{\"n\":2}\n")
+	got, errCount := collectRecordsAndErrors(t, "{\"n\":1}\n{bad1\n{bad2\n{\"n\":2}\n")
 	require.Equal(t, []string{`{"n":1}`, `{"n":2}`}, got)
-	require.Equal(t, 2, errCount, "each malformed line is reported")
+	require.Equal(t, 2, errCount, "each corrupted line is reported")
 }
 
 // TestJSONSequence_ResumeAfterResyncSkipsDeliveredRecords asserts the resume offset stays

--- a/internal/blobstream/json_resync_test.go
+++ b/internal/blobstream/json_resync_test.go
@@ -1,0 +1,98 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestJSONSequence_ResyncsAfterMalformedLine asserts a malformed NDJSON line is skipped
+// and the lines after it are still delivered, rather than the malformed line stopping the
+// whole object at the first syntax error.
+func TestJSONSequence_ResyncsAfterMalformedLine(t *testing.T) {
+	t.Parallel()
+
+	got, errCount := collectRecordsAndErrors(t, "{\"n\":1}\n{bad line}\n{\"n\":2}\n{\"n\":3}\n")
+	require.Equal(t, []string{`{"n":1}`, `{"n":2}`, `{"n":3}`}, got,
+		"lines before and after the malformed line are delivered")
+	require.Equal(t, 1, errCount, "the malformed line is skipped and reported once")
+}
+
+// TestJSONSequence_ResyncsAcrossConsecutiveMalformedLines asserts each malformed line is
+// skipped independently, so a run of bad lines does not lose the good ones after them.
+func TestJSONSequence_ResyncsAcrossConsecutiveMalformedLines(t *testing.T) {
+	t.Parallel()
+
+	got, errCount := collectRecordsAndErrors(t, "{\"n\":1}\n{bad1\nalso bad\n{\"n\":2}\n")
+	require.Equal(t, []string{`{"n":1}`, `{"n":2}`}, got)
+	require.Equal(t, 2, errCount, "each malformed line is reported")
+}
+
+// TestJSONSequence_ResumeAfterResyncSkipsDeliveredRecords asserts the resume offset stays
+// absolute across a resync, so a re-run past the malformed line delivers only the records
+// that follow, never re-delivering earlier ones.
+func TestJSONSequence_ResumeAfterResyncSkipsDeliveredRecords(t *testing.T) {
+	t.Parallel()
+
+	body := "{\"n\":1}\n{bad}\n{\"n\":2}\n{\"n\":3}\n"
+
+	// Pass 1: read everything, capturing the offset right after {"n":2}.
+	reader := NewBufferedReader(strings.NewReader(body), 4096)
+	parser := NewJSONParser(reader, BodyOptions{})
+	records, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	var resumeOffset int64
+	for record, rerr := range records {
+		if rerr != nil {
+			continue
+		}
+		if string(record.(json.RawMessage)) == `{"n":2}` {
+			resumeOffset = parser.Offset()
+		}
+	}
+	require.Positive(t, resumeOffset)
+
+	// Pass 2: resume past {"n":2}; only {"n":3} should remain.
+	reader2 := NewBufferedReader(strings.NewReader(body), 4096)
+	parser2 := NewJSONParser(reader2, BodyOptions{})
+	records2, err := parser2.Parse(context.Background(), resumeOffset)
+	require.NoError(t, err)
+
+	var got []string
+	for record, rerr := range records2 {
+		if rerr != nil {
+			continue
+		}
+		got = append(got, string(record.(json.RawMessage)))
+	}
+	require.Equal(t, []string{`{"n":3}`}, got, "resume delivers only the records after the checkpoint")
+}
+
+// TestJSONSequence_ResyncGivesUpWithoutTrailingNewline asserts that when the malformed
+// tail has no terminating newline to realign to, the records before it are delivered and
+// reading stops (best-effort skip-to-EOF), rather than spinning on the same bytes.
+func TestJSONSequence_ResyncGivesUpWithoutTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	got, errCount := collectRecordsAndErrors(t, "{\"n\":1}\n{bad with no terminating newline")
+	require.Equal(t, []string{`{"n":1}`}, got, "the record before the unrecoverable tail is delivered")
+	require.Equal(t, 1, errCount, "the malformed tail is reported once, then reading stops")
+}

--- a/internal/blobstream/json_resync_test.go
+++ b/internal/blobstream/json_resync_test.go
@@ -55,7 +55,7 @@ func TestJSONSequence_ResumeAfterResyncSkipsDeliveredRecords(t *testing.T) {
 
 	// Pass 1: read everything, capturing the offset right after {"n":2}.
 	reader := NewBufferedReader(strings.NewReader(body), 4096)
-	parser := NewJSONParser(reader, BodyOptions{})
+	parser := NewJSONParser(reader, nil, BodyOptions{})
 	records, err := parser.Parse(context.Background(), 0)
 	require.NoError(t, err)
 
@@ -72,7 +72,7 @@ func TestJSONSequence_ResumeAfterResyncSkipsDeliveredRecords(t *testing.T) {
 
 	// Pass 2: resume past {"n":2}; only {"n":3} should remain.
 	reader2 := NewBufferedReader(strings.NewReader(body), 4096)
-	parser2 := NewJSONParser(reader2, BodyOptions{})
+	parser2 := NewJSONParser(reader2, nil, BodyOptions{})
 	records2, err := parser2.Parse(context.Background(), resumeOffset)
 	require.NoError(t, err)
 

--- a/internal/blobstream/json_round3_fixes_test.go
+++ b/internal/blobstream/json_round3_fixes_test.go
@@ -1,0 +1,227 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestJSONWrapper_OversizedBracketedElementRejectedRestDelivered asserts that an array
+// element larger than max_log_size is rejected (max_log_size is a hard wall) while the
+// elements after it still deliver — the decoder stays aligned, so the tail is not dropped.
+func TestJSONWrapper_OversizedBracketedElementRejectedRestDelivered(t *testing.T) {
+	t.Parallel()
+
+	big := strings.Repeat("x", 6000) // > the 4096 reader max_log_size -> over the hard wall
+	body := `{"Records":[{"n":1},{"big":"` + big + `"},{"n":2},{"n":3}]}`
+
+	records, errCount := collectRecordsAndErrors(t, body)
+
+	require.Equal(t, []string{`{"n":1}`, `{"n":2}`, `{"n":3}`}, records,
+		"the oversized element is rejected but the records after it still deliver")
+	require.Equal(t, 1, errCount, "the oversized element is one counted parse error")
+}
+
+// TestJSONWrapper_ConcatPrefixStreamBreakIsRetryable asserts that a stream break while
+// reading a concatenated document's prefix is a retryable ErrStreamRead, not a silent-ack
+// parse error that drops the recoverable tail.
+func TestJSONWrapper_ConcatPrefixStreamBreakIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("read: connection reset by peer")
+	// A complete first wrapper whose records run past the classification window (so
+	// detection and the first document succeed), then a second document whose non-Records
+	// prefix is cut mid value by a broken stream.
+	var b strings.Builder
+	b.WriteString(`{"Records":[`)
+	const delivered = 400
+	for i := 0; i < delivered; i++ {
+		fmt.Fprintf(&b, `{"host":"host-%04d"},`, i)
+	}
+	b.WriteString(`{"host":"last"}]}`)
+	require.Greater(t, b.Len(), maxRecordsSearchBytes)
+	b.WriteString(`{"pad":"` + strings.Repeat("x", 50)) // second document, cut mid value
+	body := &errAfterPrefix{prefix: []byte(b.String()), err: readErr}
+
+	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(body, testMaxLogSize), BodyOptions{}))
+
+	require.Len(t, records, delivered+1, "the first document's records are delivered")
+	require.ErrorIs(t, err, readErr)
+	require.True(t, IsStreamRead(err), "a break in a concatenated document's prefix is retryable, not a silent ack")
+	require.False(t, IsUnsupportedContent(err))
+}
+
+// countingSource counts bytes read from the underlying reader.
+type countingSource struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingSource) Read(p []byte) (int, error) {
+	m, err := c.r.Read(p)
+	c.n += int64(m)
+	return m, err
+}
+
+// TestJSONWrapper_OversizedTailTokenIsBounded asserts that token navigation (here a records
+// wrapper's oversized tail value) does not read the whole token into memory. Before the
+// fix the cap was disarmed during navigation, so a giant scalar was buffered whole (an OOM
+// vector); now the read stops at the search-window budget.
+func TestJSONWrapper_OversizedTailTokenIsBounded(t *testing.T) {
+	t.Parallel()
+
+	big := strings.Repeat("x", 8<<20) // 8 MiB tail value
+	body := `{"Records":[{"n":1}],"pad":"` + big + `"}`
+
+	src := &countingSource{r: strings.NewReader(body)}
+	parser := NewJSONParser(NewBufferedReader(src, 4096), BodyOptions{})
+
+	seq, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+	var records int
+	for _, rerr := range seq {
+		if rerr == nil {
+			records++
+		}
+	}
+
+	require.GreaterOrEqual(t, records, 1, "the record before the oversized tail is delivered")
+	require.Less(t, src.n, int64(1<<20),
+		"navigation must not read the whole oversized tail token into memory (read %d bytes)", src.n)
+}
+
+// noMaxLogSizeReader is a reader that does not report max_log_size.
+type noMaxLogSizeReader struct{ BufferedReader }
+
+// TestRecordSizeLimit_FallsBackWithoutMaxLogSize asserts a reader that reports no
+// max_log_size (a test double) falls back to the hard OOM limit.
+func TestRecordSizeLimit_FallsBackWithoutMaxLogSize(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, maxRecordBytesHardLimit, recordSizeLimit(noMaxLogSizeReader{}))
+}
+
+// TestJSONArray_ConcatStringStreamBreakIsRetryable asserts that a break while reading a
+// concatenated top-level token after an array (here a cut string) is retryable, not a
+// silent-ack parse error.
+func TestJSONArray_ConcatStringStreamBreakIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("read: connection reset by peer")
+	var b strings.Builder
+	b.WriteString("[")
+	const delivered = 400
+	for i := 0; i < delivered; i++ {
+		fmt.Fprintf(&b, `{"host":"host-%04d"},`, i)
+	}
+	b.WriteString(`{"host":"last"}]`)
+	require.Greater(t, b.Len(), maxRecordsSearchBytes)
+	b.WriteString(`"` + strings.Repeat("x", 50)) // a second top-level string, cut mid value
+	body := &errAfterPrefix{prefix: []byte(b.String()), err: readErr}
+
+	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(body, testMaxLogSize), BodyOptions{}))
+
+	require.Len(t, records, delivered+1, "the array's records are delivered")
+	require.ErrorIs(t, err, readErr)
+	require.True(t, IsStreamRead(err), "a break reading the next concatenated token is retryable")
+}
+
+// TestJSONWrapper_ConcatPrefixOversizedValueIsBounded asserts that an oversized non-Records
+// value in a concatenated document's prefix is bounded (not buffered whole) and treated as
+// a counted parse error, not the line-fallback sentinel.
+func TestJSONWrapper_ConcatPrefixOversizedValueIsBounded(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	b.WriteString(`{"Records":[`)
+	const delivered = 400
+	for i := 0; i < delivered; i++ {
+		fmt.Fprintf(&b, `{"host":"host-%04d"},`, i)
+	}
+	b.WriteString(`{"host":"last"}]}`)
+	require.Greater(t, b.Len(), maxRecordsSearchBytes)
+	// Second document: a non-Records prefix value far larger than the search window.
+	b.WriteString(`{"pad":"` + strings.Repeat("x", 8192) + `","Records":[{"n":2}]}`)
+
+	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(strings.NewReader(b.String()), 4096), BodyOptions{}))
+
+	require.Len(t, records, delivered+1, "only the first document's records are delivered")
+	require.Error(t, err)
+	require.False(t, IsStreamRead(err), "a bounded oversized prefix is a parse error, not a stream break")
+	require.NotErrorIs(t, err, ErrNotArrayOrKnownObject, "must be a non-sentinel error, not the line-fallback trigger")
+}
+
+// TestJSONSequence_OverOOMBackstopResyncs asserts that a value-sequence value too large to
+// decode within the OOM backstop is skipped and the sequence resyncs to the records after
+// it. The backstop is lowered here so the test need not allocate a real 128 MiB value.
+func TestJSONSequence_OverOOMBackstopResyncs(t *testing.T) {
+	// Not parallel: temporarily lowers maxRecordBytesHardLimit, a package var.
+	orig := maxRecordBytesHardLimit
+	maxRecordBytesHardLimit = 4096
+	defer func() { maxRecordBytesHardLimit = orig }()
+
+	big := strings.Repeat("x", 6000) // exceeds the lowered backstop, cannot be decoded
+	body := `{"n":1}` + "\n" + `{"big":"` + big + `"}` + "\n" + `{"n":2}` + "\n"
+
+	records, errCount := collectRecordsAndErrors(t, body)
+	require.Equal(t, []string{`{"n":1}`, `{"n":2}`}, records, "the over-backstop value is skipped, the sequence resyncs")
+	require.Equal(t, 1, errCount)
+}
+
+// TestJSONArray_OverOOMBackstopStops asserts that a bracketed element too large to decode
+// within the OOM backstop cannot realign, so the array stops after it (only the extreme
+// case; a merely-over-max_log_size element decodes and is rejected while the rest deliver).
+func TestJSONArray_OverOOMBackstopStops(t *testing.T) {
+	// Not parallel: temporarily lowers maxRecordBytesHardLimit, a package var.
+	orig := maxRecordBytesHardLimit
+	maxRecordBytesHardLimit = 4096
+	defer func() { maxRecordBytesHardLimit = orig }()
+
+	big := strings.Repeat("x", 6000)
+	body := `[{"n":1},{"big":"` + big + `"},{"n":2}]`
+
+	records, errCount := collectRecordsAndErrors(t, body)
+	require.Equal(t, []string{`{"n":1}`}, records, "a bracketed element over the backstop cannot realign; the array stops")
+	require.Equal(t, 1, errCount)
+}
+
+// TestJSON_ConsumerStopAtOversizedRecord asserts the parser stops cleanly when the consumer
+// breaks iteration on the parse error yielded for an over-max_log_size record.
+func TestJSON_ConsumerStopAtOversizedRecord(t *testing.T) {
+	t.Parallel()
+
+	big := strings.Repeat("x", 6000) // > 4096 max_log_size
+	body := `{"n":1}` + "\n" + `{"big":"` + big + `"}` + "\n" + `{"m":2}` + "\n"
+
+	reader := NewBufferedReader(strings.NewReader(body), 4096)
+	parser := NewJSONParser(reader, BodyOptions{})
+	seq, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	var errs int
+	for _, rerr := range seq {
+		if rerr != nil {
+			errs++
+			break // stop at the oversized-record parse error, so yield returns false
+		}
+	}
+	require.Equal(t, 1, errs)
+}

--- a/internal/blobstream/json_round3_fixes_test.go
+++ b/internal/blobstream/json_round3_fixes_test.go
@@ -62,7 +62,7 @@ func TestJSONWrapper_ConcatPrefixStreamBreakIsRetryable(t *testing.T) {
 	b.WriteString(`{"pad":"` + strings.Repeat("x", 50)) // second document, cut mid value
 	body := &errAfterPrefix{prefix: []byte(b.String()), err: readErr}
 
-	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(body, testMaxLogSize), BodyOptions{}))
+	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(body, testMaxLogSize), nil, BodyOptions{}))
 
 	require.Len(t, records, delivered+1, "the first document's records are delivered")
 	require.ErrorIs(t, err, readErr)
@@ -93,7 +93,7 @@ func TestJSONWrapper_OversizedTailTokenIsBounded(t *testing.T) {
 	body := `{"Records":[{"n":1}],"pad":"` + big + `"}`
 
 	src := &countingSource{r: strings.NewReader(body)}
-	parser := NewJSONParser(NewBufferedReader(src, 4096), BodyOptions{})
+	parser := NewJSONParser(NewBufferedReader(src, 4096), nil, BodyOptions{})
 
 	seq, err := parser.Parse(context.Background(), 0)
 	require.NoError(t, err)
@@ -137,7 +137,7 @@ func TestJSONArray_ConcatStringStreamBreakIsRetryable(t *testing.T) {
 	b.WriteString(`"` + strings.Repeat("x", 50)) // a second top-level string, cut mid value
 	body := &errAfterPrefix{prefix: []byte(b.String()), err: readErr}
 
-	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(body, testMaxLogSize), BodyOptions{}))
+	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(body, testMaxLogSize), nil, BodyOptions{}))
 
 	require.Len(t, records, delivered+1, "the array's records are delivered")
 	require.ErrorIs(t, err, readErr)
@@ -161,7 +161,7 @@ func TestJSONWrapper_ConcatPrefixOversizedValueIsBounded(t *testing.T) {
 	// Second document: a non-Records prefix value far larger than the search window.
 	b.WriteString(`{"pad":"` + strings.Repeat("x", 8192) + `","Records":[{"n":2}]}`)
 
-	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(strings.NewReader(b.String()), 4096), BodyOptions{}))
+	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(strings.NewReader(b.String()), 4096), nil, BodyOptions{}))
 
 	require.Len(t, records, delivered+1, "only the first document's records are delivered")
 	require.Error(t, err)
@@ -212,7 +212,7 @@ func TestJSON_ConsumerStopAtOversizedRecord(t *testing.T) {
 	body := `{"n":1}` + "\n" + `{"big":"` + big + `"}` + "\n" + `{"m":2}` + "\n"
 
 	reader := NewBufferedReader(strings.NewReader(body), 4096)
-	parser := NewJSONParser(reader, BodyOptions{})
+	parser := NewJSONParser(reader, nil, BodyOptions{})
 	seq, err := parser.Parse(context.Background(), 0)
 	require.NoError(t, err)
 

--- a/internal/blobstream/json_second_resync_test.go
+++ b/internal/blobstream/json_second_resync_test.go
@@ -1,0 +1,55 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestJSONSequence_SecondResyncKeepsRecords asserts that a value sequence with TWO
+// malformed lines close together (both inside one read-ahead window) still delivers
+// every good record after the second one. The first resync rebuilds the decoder on a
+// bufio.Reader that has read ahead from the source; the second resync must continue from
+// that same reader, not from the now-drained original source, or the buffered-but-unread
+// records between the two are silently dropped.
+func TestJSONSequence_SecondResyncKeepsRecords(t *testing.T) {
+	t.Parallel()
+
+	const total = 400
+	// Two malformed lines close together (indices 50 and 60) with many good records
+	// after them, so a second-resync loss shows up as missing tail records.
+	bad := map[int]bool{50: true, 60: true}
+
+	var sb strings.Builder
+	var want []string
+	for i := 0; i < total; i++ {
+		if bad[i] {
+			sb.WriteString("{bad line}\n")
+			continue
+		}
+		line := fmt.Sprintf(`{"n":%d}`, i)
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+		want = append(want, line)
+	}
+
+	got, errCount := collectRecordsAndErrors(t, sb.String())
+	require.Equal(t, want, got, "every good record survives across two resyncs")
+	require.Equal(t, len(bad), errCount, "each malformed line is reported exactly once")
+}

--- a/internal/blobstream/json_seek_test.go
+++ b/internal/blobstream/json_seek_test.go
@@ -1,0 +1,167 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// splitStreamReader answers classification from header and serves the decoder from
+// body. Classification peeks and the decoder reads, so the two can disagree. That is
+// what a stream breaking between the two stages looks like.
+type splitStreamReader struct {
+	BufferedReader
+	header  []byte
+	body    io.Reader
+	readErr error
+}
+
+func (r *splitStreamReader) Peek(n int) ([]byte, error) {
+	if n > len(r.header) {
+		return r.header, nil
+	}
+	return r.header[:n], nil
+}
+
+func (r *splitStreamReader) Read(p []byte) (int, error) {
+	if r.readErr != nil {
+		return 0, r.readErr
+	}
+	return r.body.Read(p)
+}
+
+// newSplitParser builds a parser that classifies from header and decodes from body.
+func newSplitParser(header, body string, readErr error) LogParser {
+	return NewJSONParser(&splitStreamReader{
+		BufferedReader: NewBufferedReader(strings.NewReader(""), 4096),
+		header:         []byte(header),
+		body:           strings.NewReader(body),
+		readErr:        readErr,
+	}, BodyOptions{})
+}
+
+const recordsWrapperHeader = `{"Records":[`
+
+// TestOpensRecordsArray_RejectsNonObjects asserts the window check refuses anything that
+// does not open an object. Only an object can carry a "Records" key.
+func TestOpensRecordsArray_RejectsNonObjects(t *testing.T) {
+	t.Parallel()
+
+	for _, window := range []string{`[1,2]`, `"a string"`, `42`, ``, `not json`} {
+		t.Run(window, func(t *testing.T) {
+			t.Parallel()
+			require.False(t, opensRecordsArray([]byte(window)))
+		})
+	}
+}
+
+// TestParse_ReportsAFailedArrayStep asserts an array whose first token cannot be read
+// surfaces the read error. Classification already saw the bracket, so the failure is the
+// stream breaking underneath it.
+func TestParse_ReportsAFailedArrayStep(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("connection reset by peer")
+	parser := newSplitParser(`[{"host":"a"}]`, "", readErr)
+
+	_, err := parser.Parse(context.Background(), 0)
+	require.ErrorIs(t, err, readErr)
+	require.ErrorContains(t, err, "read first token")
+}
+
+// TestSeekRecordsArray_ReportsReadFailures asserts every read failure while walking to
+// the "Records" array is reported. Classification saw the key in the peek window, so a
+// failure here is the stream breaking rather than a shape the parser refuses.
+func TestSeekRecordsArray_ReportsReadFailures(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("connection reset by peer")
+
+	testCases := []struct {
+		name    string
+		body    string
+		readErr error
+		want    string
+	}{
+		{
+			name:    "no bytes at all",
+			readErr: readErr,
+			want:    "read first token",
+		},
+		{
+			name: "cut inside a key",
+			body: `{"abc`,
+			want: "read token",
+		},
+		{
+			name: "cut inside a skipped value",
+			body: `{"meta":{"a":`,
+			want: "skip value",
+		},
+		{
+			name: "cut after the records key",
+			body: `{"Records":`,
+			want: "read token",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parser := newSplitParser(recordsWrapperHeader, tc.body, tc.readErr)
+			_, err := parser.Parse(context.Background(), 0)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+// TestSeekRecordsArray_RejectsUnusableWrappers asserts an object that classification
+// read as a wrapper but that holds no usable array is refused. The caller answers
+// ErrNotArrayOrKnownObject with a line-parse retry.
+func TestSeekRecordsArray_RejectsUnusableWrappers(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		body string
+	}{
+		{name: "empty object", body: `{}`},
+		{name: "no records key", body: `{"host":"a"}`},
+		{name: "records holding a string", body: `{"Records":"not an array"}`},
+		{name: "records holding an object", body: `{"Records":{"host":"a"}}`},
+		{
+			name: "records past the search budget",
+			body: `{"padding":"` + strings.Repeat("x", maxRecordsSearchBytes+64) +
+				`","owner":"team","Records":[{"host":"a"}]}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parser := newSplitParser(recordsWrapperHeader, tc.body, nil)
+			_, err := parser.Parse(context.Background(), 0)
+			require.ErrorIs(t, err, ErrNotArrayOrKnownObject)
+		})
+	}
+}

--- a/internal/blobstream/json_seek_test.go
+++ b/internal/blobstream/json_seek_test.go
@@ -55,7 +55,7 @@ func newSplitParser(header, body string, readErr error) LogParser {
 		header:         []byte(header),
 		body:           strings.NewReader(body),
 		readErr:        readErr,
-	}, BodyOptions{})
+	}, nil, BodyOptions{})
 }
 
 const recordsWrapperHeader = `{"Records":[`

--- a/internal/blobstream/json_stream_error_test.go
+++ b/internal/blobstream/json_stream_error_test.go
@@ -81,7 +81,7 @@ func TestJSONParser_MarksABrokenStream(t *testing.T) {
 
 	body := &errAfterPrefix{prefix: []byte(prefix.String()), err: readErr}
 
-	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(body, testMaxLogSize), BodyOptions{}))
+	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(body, testMaxLogSize), nil, BodyOptions{}))
 
 	require.Len(t, records, delivered, "records read before the break are still delivered")
 	require.ErrorIs(t, err, readErr)
@@ -96,7 +96,7 @@ func TestJSONParser_DoesNotMarkMalformedBytes(t *testing.T) {
 
 	body := io.NopCloser(strings.NewReader(`[{"host":"a"},{"host":,}]`))
 
-	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(body, testMaxLogSize), BodyOptions{}))
+	records, err := drainJSON(t, NewJSONParser(NewBufferedReader(body, testMaxLogSize), nil, BodyOptions{}))
 
 	require.Len(t, records, 1)
 	require.Error(t, err)

--- a/internal/blobstream/json_trailing_wrapper_test.go
+++ b/internal/blobstream/json_trailing_wrapper_test.go
@@ -26,7 +26,7 @@ import (
 func driveJSONRecordsAndError(t *testing.T, body string, bufSize int) ([]string, error) {
 	t.Helper()
 	reader := NewBufferedReader(strings.NewReader(body), bufSize)
-	parser := NewJSONParser(reader, BodyOptions{})
+	parser := NewJSONParser(reader, nil, BodyOptions{})
 	seq, err := parser.Parse(context.Background(), 0)
 	require.NoError(t, err)
 

--- a/internal/blobstream/json_trailing_wrapper_test.go
+++ b/internal/blobstream/json_trailing_wrapper_test.go
@@ -1,0 +1,85 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func driveJSONRecordsAndError(t *testing.T, body string, bufSize int) ([]string, error) {
+	t.Helper()
+	reader := NewBufferedReader(strings.NewReader(body), bufSize)
+	parser := NewJSONParser(reader, BodyOptions{})
+	seq, err := parser.Parse(context.Background(), 0)
+	require.NoError(t, err)
+
+	var records []string
+	var lastErr error
+	for rec, rerr := range seq {
+		if rerr != nil {
+			lastErr = rerr
+			continue
+		}
+		records = append(records, string(rec.(json.RawMessage)))
+	}
+	return records, lastErr
+}
+
+// TestJSONRecordsWrapper_TrailingNonWrapperIsNotSentinel asserts that when a records
+// wrapper is followed by a concatenated document that is not itself a records wrapper,
+// the one parsed record is delivered and the trailing document is reported as a plain
+// per-record parse error. The error must NOT unwrap to ErrNotArrayOrKnownObject: the
+// worker uses that sentinel to re-read the whole object with the line parser, which would
+// re-emit the already-delivered record as a raw line body and garble the checkpoint.
+func TestJSONRecordsWrapper_TrailingNonWrapperIsNotSentinel(t *testing.T) {
+	t.Parallel()
+
+	records, lastErr := driveJSONRecordsAndError(t, `{"Records":[{"n":"one"}]}{"not":"a wrapper"}`, 4096)
+
+	require.Equal(t, []string{`{"n":"one"}`}, records, "the one parsed record is delivered")
+	require.Error(t, lastErr, "the trailing non-wrapper document is reported")
+	require.NotErrorIs(t, lastErr, ErrNotArrayOrKnownObject,
+		"must not unwrap to the sentinel that triggers a whole-object line re-read")
+	require.False(t, IsUnsupportedContent(lastErr),
+		"a trailing non-wrapper is a counted per-record parse error, not a DLQ/fallback condition")
+}
+
+// TestJSONRecordsWrapper_OversizedTailIsCountedNotSilent asserts that when a records
+// wrapper's trailing keys exceed the search limit (so finishObject cannot reach the next
+// document), the failure is counted as one parse error rather than silently dropping the
+// documents concatenated after it. The error must not be the fallback sentinel.
+func TestJSONRecordsWrapper_OversizedTailIsCountedNotSilent(t *testing.T) {
+	t.Parallel()
+
+	// A trailing array long enough that finishObject's per-value offset bound
+	// (maxRecordsSearchBytes past the wrapper's Records array) is exceeded while skipping
+	// it, so finishObject cannot reach the concatenated document that follows.
+	tail := strings.Repeat("0,", 2600) + "0" // ~5 KB, beyond maxRecordsSearchBytes (4096)
+	body := `{"Records":[{"n":"one"}],"tail":[` + tail + `]}` + `{"Records":[{"n":"two"}]}`
+
+	records, lastErr := driveJSONRecordsAndError(t, body, 16384)
+
+	require.Equal(t, []string{`{"n":"one"}`}, records, "the parsed record before the oversized tail is delivered")
+	require.Error(t, lastErr, "the oversized tail is counted, not silently dropped")
+	require.NotErrorIs(t, lastErr, ErrNotArrayOrKnownObject,
+		"must not unwrap to the sentinel that triggers a whole-object line re-read")
+	require.False(t, IsUnsupportedContent(lastErr),
+		"an unreadable wrapper tail is a counted per-record parse error, not a DLQ/fallback condition")
+}

--- a/internal/blobstream/json_value_sequence_stream_test.go
+++ b/internal/blobstream/json_value_sequence_stream_test.go
@@ -1,0 +1,119 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestJSONValueSequence_BrokenStreamRetries asserts that a value sequence (NDJSON)
+// whose source breaks at a record boundary surfaces as a broken stream. json.Decoder's
+// More() swallows the read error from its look-ahead, so the loop ends like a clean
+// finish; without consulting the raw source the worker would deliver the records read
+// and ack, losing the rest with no retry.
+func TestJSONValueSequence_BrokenStreamRetries(t *testing.T) {
+	t.Parallel()
+
+	// Fixed-width NDJSON so the cut lands exactly on a record boundary, which is where
+	// More() ends the loop rather than a Decode returning the error.
+	var sb strings.Builder
+	for i := 0; i < 500; i++ {
+		fmt.Fprintf(&sb, `{"n":"%03d","pad":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}`+"\n", i)
+	}
+	body := []byte(sb.String())
+	lineLen := strings.Index(sb.String(), "\n") + 1
+
+	readErr := errors.New("connection reset by peer")
+	stream := LogStream{
+		Name:        "logs/object.json",
+		Body:        &cutAfter{data: body, n: 250 * lineLen, err: readErr},
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+	seq, err := producer.Records(context.Background(), Offset{})
+	require.NoError(t, err)
+
+	var recs int
+	var last error
+	for _, rerr := range seq {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		recs++
+	}
+
+	require.Positive(t, recs, "records before the break are still delivered")
+	require.Error(t, last, "a broken value-sequence stream must surface an error, not end silently")
+	require.True(t, IsStreamRead(last), "a broken stream must be retryable")
+	require.ErrorIs(t, last, readErr)
+}
+
+// TestJSONValueSequence_ShortDownloadRetries covers the size-based branch: the raw
+// source ends short of the object's known size with a clean EOF, so the download was
+// incomplete and must retry rather than being treated as a clean end.
+func TestJSONValueSequence_ShortDownloadRetries(t *testing.T) {
+	t.Parallel()
+
+	var sb strings.Builder
+	for i := 0; i < 500; i++ {
+		fmt.Fprintf(&sb, `{"n":"%03d","pad":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}`+"\n", i)
+	}
+	body := []byte(sb.String())
+	lineLen := strings.Index(sb.String(), "\n") + 1
+
+	stream := LogStream{
+		Name:        "logs/object.json",
+		Body:        &cutAfter{data: body, n: 250 * lineLen}, // clean EOF at a boundary
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+		Size:        int64(len(body)), // known size; delivered short
+	}
+
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+	seq, err := producer.Records(context.Background(), Offset{})
+	require.NoError(t, err)
+
+	var recs int
+	var last error
+	for _, rerr := range seq {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		recs++
+	}
+
+	require.Positive(t, recs, "records before the short end are delivered")
+	require.Error(t, last, "a source short of the known size must surface an error")
+	require.True(t, IsStreamRead(last), "an incomplete download must retry")
+}

--- a/internal/blobstream/json_value_sequence_test.go
+++ b/internal/blobstream/json_value_sequence_test.go
@@ -121,9 +121,10 @@ this line is not json
 	require.Equal(t, []any{
 		map[string]any{"host": "a"},
 		map[string]any{"host": "b"},
+		"this line is not json",
 		map[string]any{"host": "c"},
-	}, bodies, "the malformed line is skipped and the records after it are still delivered")
-	require.Len(t, errs, 1, "the malformed line is surfaced exactly once")
+	}, bodies, "the text line is emitted as a string body and the records after it still deliver")
+	require.Empty(t, errs, "a text line is recovered rather than surfaced as an error")
 }
 
 // TestNDJSON_DoesNotClaimSingleObjectForms asserts detection stays narrow. A one-line

--- a/internal/blobstream/json_value_sequence_test.go
+++ b/internal/blobstream/json_value_sequence_test.go
@@ -1,0 +1,242 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal test file — uses package blobstream to access unexported symbols.
+package blobstream
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+const ndjsonObject = `{"host":"a","msg":"first"}
+{"host":"b","msg":"second"}
+{"host":"c","msg":"third"}
+`
+
+// TestNDJSON_ParsesEachLineAsARecord asserts the parser parses newline-delimited JSON
+// instead of emitting text. Before, JSON detection failed and the worker re-read the
+// object with the line parser.
+func TestNDJSON_ParsesEachLineAsARecord(t *testing.T) {
+	t.Parallel()
+
+	bodies, originals := collectBodies(t, newTestStream(ndjsonObject, false, false))
+
+	require.Equal(t, []any{
+		map[string]any{"host": "a", "msg": "first"},
+		map[string]any{"host": "b", "msg": "second"},
+		map[string]any{"host": "c", "msg": "third"},
+	}, bodies)
+	require.Empty(t, originals)
+}
+
+// TestNDJSON_RawEmitsTheOriginalLines asserts the raw option overrides NDJSON parsing.
+// SecOps pipelines then receive the original line.
+func TestNDJSON_RawEmitsTheOriginalLines(t *testing.T) {
+	t.Parallel()
+
+	bodies, _ := collectBodies(t, newTestStream(ndjsonObject, true, false))
+
+	require.Equal(t, []any{
+		`{"host":"a","msg":"first"}`,
+		`{"host":"b","msg":"second"}`,
+		`{"host":"c","msg":"third"}`,
+	}, bodies)
+}
+
+// TestNDJSON_IncludeLogRecordOriginal asserts a parsed NDJSON record carries its
+// original line with the structured body.
+func TestNDJSON_IncludeLogRecordOriginal(t *testing.T) {
+	t.Parallel()
+
+	bodies, originals := collectBodies(t, newTestStream(ndjsonObject, false, true))
+
+	require.Equal(t, map[string]any{"host": "a", "msg": "first"}, bodies[0])
+	require.Equal(t, []string{
+		`{"host":"a","msg":"first"}`,
+		`{"host":"b","msg":"second"}`,
+		`{"host":"c","msg":"third"}`,
+	}, originals)
+}
+
+// TestNDJSON_MalformedRecordIsSkippedAndStreamContinues asserts a malformed line is
+// skipped and the lines after it are still delivered, instead of stopping the read.
+//
+// A json.Decoder cannot resync in place after a syntax error, so the parser rebuilds the
+// decoder past the malformed line's newline. Records before and after the bad line arrive;
+// the bad line is reported once, and the decoder never spins on the same byte.
+func TestNDJSON_MalformedRecordIsSkippedAndStreamContinues(t *testing.T) {
+	t.Parallel()
+
+	const withBadLine = `{"host":"a"}
+{"host":"b"}
+this line is not json
+{"host":"c"}
+`
+	stream := newTestStream(withBadLine, false, false)
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+
+	records, err := producer.Records(context.Background(), Offset{})
+	require.NoError(t, err)
+
+	var bodies []any
+	var errs []error
+	iterations := 0
+	exhausted := false
+	for record, err := range records {
+		iterations++
+		if iterations > 1000 {
+			exhausted = true
+			break
+		}
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		lr := plog.NewLogRecord()
+		require.NoError(t, producer.AppendLogBody(context.Background(), lr, record))
+		bodies = append(bodies, lr.Body().AsRaw())
+	}
+
+	require.False(t, exhausted, "a wedged decoder must not spin on the same error")
+	require.Equal(t, []any{
+		map[string]any{"host": "a"},
+		map[string]any{"host": "b"},
+		map[string]any{"host": "c"},
+	}, bodies, "the malformed line is skipped and the records after it are still delivered")
+	require.Len(t, errs, 1, "the malformed line is surfaced exactly once")
+}
+
+// TestNDJSON_DoesNotClaimSingleObjectForms asserts detection stays narrow. A one-line
+// Records wrapper and a pretty-printed object still use the JSON parser.
+func TestNDJSON_DoesNotClaimSingleObjectForms(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		body string
+		want []any
+	}{
+		{
+			name: "single-line Records wrapper",
+			body: `{"Records":[{"host":"a"},{"host":"b"}]}`,
+			want: []any{map[string]any{"host": "a"}, map[string]any{"host": "b"}},
+		},
+		{
+			name: "pretty-printed array of objects",
+			body: "[\n  {\"host\":\"a\"},\n  {\"host\":\"b\"}\n]\n",
+			want: []any{map[string]any{"host": "a"}, map[string]any{"host": "b"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bodies, _ := collectBodies(t, newTestStream(tc.body, false, false))
+			require.Equal(t, tc.want, bodies)
+		})
+	}
+}
+
+// TestJSONShapes covers the three layouts the parser reads. Detection previously
+// stopped at "is it an array", so some layouts fell through to line parsing.
+func TestJSONShapes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		body string
+		want []any
+	}{
+		{
+			name: "top-level array",
+			body: `[{"host":"a"},{"host":"b"}]`,
+			want: []any{map[string]any{"host": "a"}, map[string]any{"host": "b"}},
+		},
+		{
+			name: "Records wrapper",
+			body: `{"other":"ignored","Records":[{"host":"a"},{"host":"b"}]}`,
+			want: []any{map[string]any{"host": "a"}, map[string]any{"host": "b"}},
+		},
+		{
+			name: "newline-delimited objects",
+			body: "{\"host\":\"a\"}\n{\"host\":\"b\"}\n",
+			want: []any{map[string]any{"host": "a"}, map[string]any{"host": "b"}},
+		},
+		{
+			name: "concatenated pretty-printed documents",
+			body: "{\n  \"host\": \"a\"\n}\n{\n  \"host\": \"b\"\n}\n",
+			want: []any{map[string]any{"host": "a"}, map[string]any{"host": "b"}},
+		},
+		{
+			name: "single object",
+			body: `{"host":"a"}`,
+			want: []any{map[string]any{"host": "a"}},
+		},
+		{
+			// "Records" as a value must not match the wrapper key. Classification
+			// decodes instead of matching text.
+			name: "object mentioning Records as a value",
+			body: "{\"msg\":\"see Records for details\"}\n{\"msg\":\"second\"}\n",
+			want: []any{
+				map[string]any{"msg": "see Records for details"},
+				map[string]any{"msg": "second"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bodies, _ := collectBodies(t, newTestStream(tc.body, false, false))
+			require.Equal(t, tc.want, bodies)
+		})
+	}
+}
+
+// TestJSON_OversizedDocumentIsNotDecodedAsOneValue asserts the parser sends an object
+// too large for the peek window to line parsing.
+//
+// The sequence path holds each record in memory. A large document there fills memory.
+// The line parser caps each record at max_log_size.
+func TestJSON_OversizedDocumentIsNotDecodedAsOneValue(t *testing.T) {
+	t.Parallel()
+
+	// One object whose first key alone runs past the classification window.
+	padding := strings.Repeat("x", maxRecordsSearchBytes*2)
+	body := `{"padding":"` + padding + `","host":"a"}`
+
+	stream := newTestStream(body, false, false)
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+
+	// The worker reads this error as a signal to re-read the object with the line
+	// parser, which caps each record at max_log_size.
+	_, err = producer.Records(context.Background(), Offset{})
+	require.ErrorIs(t, err, ErrNotArrayOrKnownObject,
+		"an oversized document should fall through to line parsing rather than being decoded whole")
+}

--- a/internal/blobstream/parser.go
+++ b/internal/blobstream/parser.go
@@ -71,7 +71,7 @@ func newParser(stream LogStream, reader BufferedReader) (parser LogParser, err e
 	// gate below still rejects binary, so an image goes to the DLQ rather than emitting
 	// as garbled lines.
 	if isJSON(stream, reader) {
-		return NewJSONParser(reader, opts), nil
+		return NewJSONParser(reader, stream.Logger, opts), nil
 	}
 
 	// Terminal: the content is neither Avro nor JSON.

--- a/receiver/awss3eventreceiver/README.md
+++ b/receiver/awss3eventreceiver/README.md
@@ -18,8 +18,12 @@ The receiver detects the file format from the object's content, not from its nam
 | Format | Detection |
 |---|---|
 | Avro OCF | Leading `Obj\x01` magic bytes |
-| JSON | Leading `{` followed by `"`/`}`, or `[` followed by `{`/`]` (object, or array of objects) |
+| JSON | Leading `{` followed by `"`/`}`, or `[` followed by `{`/`]`. Covers arrays, `Records` wrappers, and value sequences including NDJSON |
 | Plain text | Everything else; parsed line by line |
+
+JSON covers three layouts, all read as a stream: a top-level array, an object whose `Records` key holds that array, and a sequence of top-level values one after another. That last shape is what makes newline-delimited JSON work, and it needs no format of its own: to a JSON decoder, NDJSON, a lone object, and concatenated pretty-printed documents are the same thing.
+
+A document too large to classify within the first 4 KiB is read line by line instead, so a single very large JSON object is never buffered whole.
 
 ### Compression
 
@@ -99,7 +103,7 @@ This approach ensures that:
 | visibility_timeout               | duration | 5m         | `false`  | The visibility timeout for SQS messages |
 | visibility_extension_interval    | duration | 1m         | `false`  | How often to extend message visibility during processing. Should be less than visibility_timeout.  Minimum is 10s. |
 | max_visibility_window            | duration | 1h         | `false`  | Maximum total time a message can remain invisible before becoming visible to other consumers. Must be less than SQS's 12-hour limit |
-| max_log_size                     | int      | 1048576    | `false`  | The maximum size of a log record in bytes. Logs exceeding this size will be split |
+| max_log_size                     | int      | 1048576    | `false`  | The maximum size of a log record in bytes. Logs exceeding this size will be split. The minimum is `4096`, since content detection peeks a fixed 4096-byte window; a smaller value is rejected |
 | max_logs_emitted                 | int      | 1000       | `false`  | The maximum number of log records to emit in a single batch. A higher number will result in fewer batches, but more memory |
 | raw                              | bool     | `false`    | `false`  | Emit each record's original text as the body instead of a parsed structure. Records are split as they would be when parsed — a JSON array or a `{"Records": [...]}` document yields one record per element; NDJSON and plain text yield one record per line. Content detection still runs, so unsupported binary content is routed to the dead-letter queue. Avro OCF holds no original text, so it emits the JSON encoding of each record. |
 | include_log_record_original      | bool     | `false`    | `false`  | Additionally record each parsed record's original text on the `log.record.original` attribute, leaving the structured body as-is. For a JSON array or `{"Records": [...]}` document this is each element's exact bytes. |

--- a/receiver/awss3eventreceiver/README.md
+++ b/receiver/awss3eventreceiver/README.md
@@ -25,7 +25,7 @@ JSON covers three layouts, all read as a stream: a top-level array, an object wh
 
 Classification looks only at the first 4 KiB. If the document's first JSON value fits in that window, the document is parsed as structured JSON. If the first value is larger than 4 KiB, the document cannot be classified and is read line by line instead. This can result in two files being parsed differently.
 
-Within a value sequence, a line that is not valid JSON is skipped as a parse error, and the records after it still parse. The same malformed content inside a top-level array stops parsing there, because the array cannot be realigned. A value sequence that also holds string values (mixed content) emits them as string bodies and warns once per file.
+Within a value sequence, a text line that is not JSON is emitted as a string body; only corrupted JSON structure (a broken object or array) is dropped as a parse error. The records after a dropped line still parse. A broken element inside a top-level array instead stops parsing there, because the array cannot be realigned. A value sequence that mixes object records with text lines warns once per file.
 
 ### Compression
 

--- a/receiver/awss3eventreceiver/README.md
+++ b/receiver/awss3eventreceiver/README.md
@@ -21,9 +21,11 @@ The receiver detects the file format from the object's content, not from its nam
 | JSON | Leading `{` followed by `"`/`}`, or `[` followed by `{`/`]`. Covers arrays, `Records` wrappers, and value sequences including NDJSON |
 | Plain text | Everything else; parsed line by line |
 
-JSON covers three layouts, all read as a stream: a top-level array, an object whose `Records` key holds that array, and a sequence of top-level values one after another. That last shape is what makes newline-delimited JSON work, and it needs no format of its own: to a JSON decoder, NDJSON, a lone object, and concatenated pretty-printed documents are the same thing.
+JSON covers three layouts, all read as a stream: a top-level array, an object whose `Records` key holds that array, and a sequence of top-level values one after another. That last shape is what makes newline-delimited JSON work, and it needs no format of its own: to a JSON decoder, NDJSON, a lone object, and concatenated pretty-printed documents are the same thing. A lone object and NDJSON now parse into structured record bodies. Earlier they were read line by line, as string bodies.
 
-A document too large to classify within the first 4 KiB is read line by line instead, so a single very large JSON object is never buffered whole.
+Classification looks only at the first 4 KiB. If the document's first JSON value fits in that window, the document is parsed as structured JSON. If the first value is larger than 4 KiB, the document cannot be classified and is read line by line instead. This can result in two files being parsed differently.
+
+Within a value sequence, a line that is not valid JSON is skipped as a parse error, and the records after it still parse. The same malformed content inside a top-level array stops parsing there, because the array cannot be realigned. A value sequence that also holds string values (mixed content) emits them as string bodies and warns once per file.
 
 ### Compression
 

--- a/receiver/awss3eventreceiver/config.go
+++ b/receiver/awss3eventreceiver/config.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/observiq/bindplane-otel-contrib/internal/aws/client"
+	"github.com/observiq/bindplane-otel-contrib/internal/blobstream"
 	"github.com/observiq/bindplane-otel-contrib/receiver/awss3eventreceiver/internal/constants"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configretry"
@@ -159,8 +160,10 @@ func (c *Config) Validate() error {
 		return errors.New("'workers' must be greater than 0")
 	}
 
-	if c.MaxLogSize <= 0 {
-		return errors.New("'max_log_size' must be greater than 0")
+	if c.MaxLogSize < blobstream.MinLogSize {
+		// Content detection peeks fixed windows against a buffer sized to max_log_size,
+		// so a smaller value fails every object at runtime with a buffer-full error.
+		return fmt.Errorf("'max_log_size' must be at least %d", blobstream.MinLogSize)
 	}
 
 	if err := c.ErrorBackOff.Validate(); err != nil {

--- a/receiver/awss3eventreceiver/config_test.go
+++ b/receiver/awss3eventreceiver/config_test.go
@@ -191,7 +191,15 @@ func TestConfigValidate(t *testing.T) {
 				cfg.SQSQueueURL = "https://sqs.us-west-2.amazonaws.com/123456789012/test-queue"
 				cfg.MaxLogSize = 0
 			},
-			expectedErr: "'max_log_size' must be greater than 0",
+			expectedErr: "'max_log_size' must be at least 4096",
+		},
+		{
+			desc: "max log size one below the detection window is rejected",
+			cfgMod: func(cfg *awss3eventreceiver.Config) {
+				cfg.SQSQueueURL = "https://sqs.us-west-2.amazonaws.com/123456789012/test-queue"
+				cfg.MaxLogSize = 4095
+			},
+			expectedErr: "'max_log_size' must be at least 4096",
 		},
 		{
 			desc: "Invalid max visibility window",

--- a/receiver/awss3eventreceiver/internal/worker/json_concat_fallback_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/json_concat_fallback_test.go
@@ -1,0 +1,68 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/observiq/bindplane-otel-contrib/internal/aws/client/mocks"
+)
+
+// TestProcessRecord_ConcatTrailingNonWrapperIsNotReReadAsLines asserts that a records
+// wrapper followed by a concatenated document that is not itself a records wrapper is
+// handled as a JSON object with one skipped trailing document, NOT re-read from the start
+// with the line parser. The line-parse fallback fires only for a returned
+// ErrNotArrayOrKnownObject; a trailing non-wrapper must therefore surface a different
+// error, or the already-delivered record is re-emitted as a raw line and the checkpoint
+// is garbled.
+func TestProcessRecord_ConcatTrailingNonWrapperIsNotReReadAsLines(t *testing.T) {
+	t.Parallel()
+
+	body := `{"Records":[{"n":"one"}]}{"not":"a wrapper"}`
+
+	mockS3 := &mocks.MockS3Client{}
+	mockClient := &mocks.MockClient{}
+	mockClient.EXPECT().S3().Return(mockS3)
+	mockS3.EXPECT().GetObject(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			return &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(body))}, nil
+		})
+
+	core, logs := observer.New(zap.DebugLevel)
+	w := &Worker{
+		client:         mockClient,
+		nextConsumer:   consumertest.NewNop(),
+		offsetStorage:  errStorage{},
+		obsrecv:        newTestObsReport(t),
+		metrics:        testMetrics(t),
+		maxLogSize:     4096,
+		maxLogsEmitted: 1000,
+	}
+
+	_, err := w.processRecord(context.Background(), s3RecordFor("mykey", int64(len(body))), "mykey", zap.New(core))
+	require.NoError(t, err, "the trailing non-wrapper document is skipped and the object acks")
+	require.Zero(t, logs.FilterMessage("parsing as JSON failed, trying again with line parsing").Len(),
+		"a concatenated non-wrapper document must not re-read the whole object as raw lines")
+}

--- a/receiver/awss3eventreceiver/internal/worker/worker_cancellation_test.go
+++ b/receiver/awss3eventreceiver/internal/worker/worker_cancellation_test.go
@@ -382,3 +382,64 @@ func TestProcessMessage_BodyOptionsReachTheLogRecords(t *testing.T) {
 	require.True(t, ok, "include_log_record_original should reach the emitted records")
 	require.Equal(t, lines[0], original.Str())
 }
+
+// TestProcessMessage_NDJSONIsReadOnce asserts an NDJSON object is fetched a single time.
+// Before NDJSON was recognized, the JSON parser failed with ErrNotArrayOrKnownObject and
+// the worker re-opened the object to line-parse it, so every such object was read twice.
+func TestProcessMessage_NDJSONIsReadOnce(t *testing.T) {
+	const ndjson = `{"host":"a","msg":"first"}
+{"host":"b","msg":"second"}
+{"host":"c","msg":"third"}
+`
+
+	mockSQS := &mocks.MockSQSClient{}
+	mockS3 := &mocks.MockS3Client{}
+	mockClient := &mocks.MockClient{}
+	mockClient.EXPECT().SQS().Return(mockSQS)
+	mockClient.EXPECT().S3().Return(mockS3)
+
+	var opens int
+	var mu sync.Mutex
+	mockS3.EXPECT().GetObject(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			mu.Lock()
+			opens++
+			mu.Unlock()
+			return &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(ndjson))}, nil
+		})
+	mockSQS.EXPECT().DeleteMessage(mock.Anything, mock.Anything).Return(&sqs.DeleteMessageOutput{}, nil)
+	mockSQS.EXPECT().ChangeMessageVisibility(mock.Anything, mock.Anything).Return(&sqs.ChangeMessageVisibilityOutput{}, nil)
+
+	set := componenttest.NewNopTelemetrySettings()
+	tb, err := metadata.NewTelemetryBuilder(set)
+	require.NoError(t, err)
+
+	params := receivertest.NewNopSettings(metadata.Type)
+	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		ReceiverID:             params.ID,
+		Transport:              "http",
+		ReceiverCreateSettings: params,
+	})
+	require.NoError(t, err)
+
+	sink := new(consumertest.LogsSink)
+	w := worker.New(set, sink, mockClient, obsrecv, 4096, 1000,
+		300*time.Second, 300*time.Second, 6*time.Hour, worker.WithTelemetryBuilder(tb))
+	w.SetOffsetStorage(newMemStorage())
+
+	msg := types.Message{
+		Body:          aws.String(cancelTestEvent),
+		MessageId:     aws.String("ndjson"),
+		ReceiptHandle: aws.String("receipt-handle"),
+	}
+	done := make(chan struct{})
+	go w.ProcessMessage(context.Background(), msg, "myqueue", func() { close(done) })
+	<-done
+
+	require.Equal(t, 1, opens, "an NDJSON object should be fetched once, not re-read")
+	require.Equal(t, 3, sink.LogRecordCount())
+
+	lr := sink.AllLogs()[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, map[string]any{"host": "a", "msg": "first"}, lr.Body().AsRaw(),
+		"NDJSON records are parsed rather than emitted as text")
+}

--- a/receiver/gcspubsubeventreceiver/README.md
+++ b/receiver/gcspubsubeventreceiver/README.md
@@ -49,7 +49,7 @@ JSON covers three layouts, all read as a stream: a top-level array, an object wh
 
 Classification looks only at the first 4 KiB. If the document's first JSON value fits in that window, the document is parsed as structured JSON. If the first value is larger than 4 KiB, the document cannot be classified and is read line by line instead. This can result in two files being parsed differently.
 
-Within a value sequence, a line that is not valid JSON is skipped as a parse error, and the records after it still parse. The same malformed content inside a top-level array stops parsing there, because the array cannot be realigned. A value sequence that also holds string values (mixed content) emits them as string bodies and warns once per file.
+Within a value sequence, a text line that is not JSON is emitted as a string body; only corrupted JSON structure (a broken object or array) is dropped as a parse error. The records after a dropped line still parse. A broken element inside a top-level array instead stops parsing there, because the array cannot be realigned. A value sequence that mixes object records with text lines warns once per file.
 
 ### Compression
 

--- a/receiver/gcspubsubeventreceiver/README.md
+++ b/receiver/gcspubsubeventreceiver/README.md
@@ -42,8 +42,12 @@ The receiver detects the file format from the object's content, not from its nam
 | Format | Detection |
 |---|---|
 | Avro OCF | Leading `Obj\x01` magic bytes |
-| JSON | Leading `{` followed by `"`/`}`, or `[` followed by `{`/`]` (object, or array of objects) |
+| JSON | Leading `{` followed by `"`/`}`, or `[` followed by `{`/`]`. Covers arrays, `Records` wrappers, and value sequences including NDJSON |
 | Plain text | Everything else; parsed line by line |
+
+JSON covers three layouts, all read as a stream: a top-level array, an object whose `Records` key holds that array, and a sequence of top-level values one after another. That last shape is what makes newline-delimited JSON work, and it needs no format of its own: to a JSON decoder, NDJSON, a lone object, and concatenated pretty-printed documents are the same thing.
+
+A document too large to classify within the first 4 KiB is read line by line instead, so a single very large JSON object is never buffered whole.
 
 ### Compression
 
@@ -101,7 +105,7 @@ Content that is not text, Avro, or JSON (for example an image or a PDF) is not p
 | `credentials_file` | string | | `false` | Path to a Google Cloud service account credentials JSON file. If empty, Application Default Credentials (ADC) are used |
 | `workers` | int | `5` | `false` | The number of concurrent workers to process Pub/Sub messages in parallel |
 | `max_extension` | duration | `1h` | `false` | The maximum duration for which the Pub/Sub client will extend the ack deadline for a message being processed |
-| `max_log_size` | int | `1048576` | `false` | The maximum size in bytes for a single log record. Logs exceeding this size will be split into chunks |
+| `max_log_size` | int | `1048576` | `false` | The maximum size in bytes for a single log record. Logs exceeding this size will be split into chunks. The minimum is `4096`, since content detection peeks a fixed 4096-byte window; a smaller value is rejected |
 | `max_logs_emitted` | int | `1000` | `false` | The maximum number of log records to emit in a single batch. Higher values reduce batches but increase memory usage |
 | `raw` | bool | `false` | `false` | Emit each record's original text as the body instead of a parsed structure. Records are split as they would be when parsed — a JSON array or a `{"Records": [...]}` document yields one record per element; NDJSON and plain text yield one record per line. Content detection still runs, so unsupported binary content is routed to the dead-letter queue. Avro OCF holds no original text, so it emits the JSON encoding of each record. |
 | `include_log_record_original` | bool | `false` | `false` | Additionally record each parsed record's original text on the `log.record.original` attribute, leaving the structured body as-is. For a JSON array or `{"Records": [...]}` document this is each element's exact bytes. |

--- a/receiver/gcspubsubeventreceiver/README.md
+++ b/receiver/gcspubsubeventreceiver/README.md
@@ -45,9 +45,11 @@ The receiver detects the file format from the object's content, not from its nam
 | JSON | Leading `{` followed by `"`/`}`, or `[` followed by `{`/`]`. Covers arrays, `Records` wrappers, and value sequences including NDJSON |
 | Plain text | Everything else; parsed line by line |
 
-JSON covers three layouts, all read as a stream: a top-level array, an object whose `Records` key holds that array, and a sequence of top-level values one after another. That last shape is what makes newline-delimited JSON work, and it needs no format of its own: to a JSON decoder, NDJSON, a lone object, and concatenated pretty-printed documents are the same thing.
+JSON covers three layouts, all read as a stream: a top-level array, an object whose `Records` key holds that array, and a sequence of top-level values one after another. That last shape is what makes newline-delimited JSON work, and it needs no format of its own: to a JSON decoder, NDJSON, a lone object, and concatenated pretty-printed documents are the same thing. A lone object and NDJSON now parse into structured record bodies. Earlier they were read line by line, as string bodies.
 
-A document too large to classify within the first 4 KiB is read line by line instead, so a single very large JSON object is never buffered whole.
+Classification looks only at the first 4 KiB. If the document's first JSON value fits in that window, the document is parsed as structured JSON. If the first value is larger than 4 KiB, the document cannot be classified and is read line by line instead. This can result in two files being parsed differently.
+
+Within a value sequence, a line that is not valid JSON is skipped as a parse error, and the records after it still parse. The same malformed content inside a top-level array stops parsing there, because the array cannot be realigned. A value sequence that also holds string values (mixed content) emits them as string bodies and warns once per file.
 
 ### Compression
 

--- a/receiver/gcspubsubeventreceiver/config.go
+++ b/receiver/gcspubsubeventreceiver/config.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/observiq/bindplane-otel-contrib/internal/blobstream"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configretry"
 )
@@ -118,8 +119,10 @@ func (c *Config) Validate() error {
 		return errors.New("'dedup_ttl' must be greater than 0")
 	}
 
-	if c.MaxLogSize <= 0 {
-		return errors.New("'max_log_size' must be greater than 0")
+	if c.MaxLogSize < blobstream.MinLogSize {
+		// Content detection peeks fixed windows against a buffer sized to max_log_size,
+		// so a smaller value fails every object at runtime with a buffer-full error.
+		return fmt.Errorf("'max_log_size' must be at least %d", blobstream.MinLogSize)
 	}
 
 	if c.MaxLogsEmitted <= 0 {

--- a/receiver/gcspubsubeventreceiver/config_test.go
+++ b/receiver/gcspubsubeventreceiver/config_test.go
@@ -109,6 +109,9 @@ func TestConfigValidate(t *testing.T) {
 		desc        string
 		cfgMod      func(*gcspubsubeventreceiver.Config)
 		expectedErr string
+		// contains matches expectedErr as a substring instead of exactly, for the regex
+		// validation errors whose suffix is the standard library's parse message.
+		contains bool
 	}{
 		{
 			desc: "Valid config",
@@ -173,7 +176,16 @@ func TestConfigValidate(t *testing.T) {
 				cfg.SubscriptionID = "test-subscription"
 				cfg.MaxLogSize = 0
 			},
-			expectedErr: "'max_log_size' must be greater than 0",
+			expectedErr: "'max_log_size' must be at least 4096",
+		},
+		{
+			desc: "max log size one below the detection window is rejected",
+			cfgMod: func(cfg *gcspubsubeventreceiver.Config) {
+				cfg.ProjectID = "test-project"
+				cfg.SubscriptionID = "test-subscription"
+				cfg.MaxLogSize = 4095
+			},
+			expectedErr: "'max_log_size' must be at least 4096",
 		},
 		{
 			desc: "Invalid max logs emitted",
@@ -192,6 +204,7 @@ func TestConfigValidate(t *testing.T) {
 				cfg.BucketNameFilter = "[invalid"
 			},
 			expectedErr: "'bucket_name_filter' \"[invalid\" is invalid:",
+			contains:    true,
 		},
 		{
 			desc: "Invalid object key filter regex",
@@ -201,6 +214,7 @@ func TestConfigValidate(t *testing.T) {
 				cfg.ObjectKeyFilter = "[invalid"
 			},
 			expectedErr: "'object_key_filter' \"[invalid\" is invalid:",
+			contains:    true,
 		},
 		{
 			desc: "Valid config with filters",
@@ -222,7 +236,11 @@ func TestConfigValidate(t *testing.T) {
 			err := cfg.Validate()
 			if tc.expectedErr != "" {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedErr)
+				if tc.contains {
+					assert.Contains(t, err.Error(), tc.expectedErr)
+				} else {
+					assert.EqualError(t, err, tc.expectedErr)
+				}
 			} else {
 				assert.NoError(t, err)
 			}

--- a/receiver/gcspubsubeventreceiver/internal/worker/classification_coverage_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/classification_coverage_test.go
@@ -109,14 +109,21 @@ func newGCSConsumeWorker(t *testing.T, client *storage.Client, store storageclie
 // TestProcessRecord_RetriesWithLineParsingWhenNotJSON asserts an object that is valid
 // JSON but not an array or known-records object is retried as line-delimited text rather
 // than failing, so a plain JSON document is still ingested.
+//
+// The input is an oversized non-wrapper object: a small lone object now parses as a value
+// sequence, so the fallback to line parsing is only reached by content that still
+// classifies as ErrNotArrayOrKnownObject. The Debug log asserts the fallback actually ran.
 func TestProcessRecord_RetriesWithLineParsingWhenNotJSON(t *testing.T) {
 	t.Parallel()
 
-	body := []byte(`{"foo":"bar"}`)
+	body := []byte(`{"data":"` + strings.Repeat("x", 5000) + `"}`)
+	core, logs := observer.New(zap.DebugLevel)
 	w := newGCSConsumeWorker(t, gcsClient(t, plainMeta, body, false), nil)
 
-	_, err := w.processRecord(context.Background(), "mybucket", "myobject", zap.NewNop())
-	require.NoError(t, err, "a non-array JSON object falls back to line parsing")
+	_, err := w.processRecord(context.Background(), "mybucket", "myobject", zap.New(core))
+	require.NoError(t, err, "an oversized non-array JSON object falls back to line parsing")
+	require.Positive(t, logs.FilterMessage("parsing as JSON failed, trying again with line parsing").Len(),
+		"the JSON->line fallback must be exercised")
 }
 
 // TestConsumeGCS_NewReaderFailureFailsObject asserts a missing object fails at reader

--- a/receiver/gcspubsubeventreceiver/internal/worker/json_concat_fallback_test.go
+++ b/receiver/gcspubsubeventreceiver/internal/worker/json_concat_fallback_test.go
@@ -1,0 +1,44 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestProcessRecord_ConcatTrailingNonWrapperIsNotReReadAsLines asserts that a records
+// wrapper followed by a concatenated document that is not itself a records wrapper is
+// handled as a JSON object with one skipped trailing document, NOT re-read from the start
+// with the line parser. The line-parse fallback fires only for a returned
+// ErrNotArrayOrKnownObject; a trailing non-wrapper must therefore surface a different
+// error, or the already-delivered record is re-emitted as a raw line and the checkpoint
+// is garbled.
+func TestProcessRecord_ConcatTrailingNonWrapperIsNotReReadAsLines(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"Records":[{"n":"one"}]}{"not":"a wrapper"}`)
+	core, logs := observer.New(zap.DebugLevel)
+	w := newGCSConsumeWorker(t, gcsClient(t, plainMeta, body, false), nil)
+
+	_, err := w.processRecord(context.Background(), "mybucket", "myobject", zap.New(core))
+	require.NoError(t, err, "the trailing non-wrapper document is skipped and the object acks")
+	require.Zero(t, logs.FilterMessage("parsing as JSON failed, trying again with line parsing").Len(),
+		"a concatenated non-wrapper document must not re-read the whole object as raw lines")
+}


### PR DESCRIPTION
### Proposed Change

The receiver read every NDJSON object twice. JSON detection failed, so the worker re-opened the object and parsed it as text lines rather than records.

The JSON parser now handles a sequence of top-level values, so NDJSON needs no detection of its own. A `json.Decoder` reads NDJSON, a lone object, and concatenated documents the same way.

A throwaway decoder classifies the peeked bytes and consumes nothing. A `json.Decoder` cannot rewind, so a `Records` search would commit the real one.

A document too large to classify inside the window uses line parsing instead, where `max_log_size` caps each record. The sequence path holds each record in memory, so the parser never buffers a very large object whole.

A malformed record now stops the object. Line parsing previously skipped it and emitted the rest as text.

`raw` still takes precedence, so a SecOps pipeline keeps the original line.

The upstream `jsonlogencodingextension` cannot serve this. Its `UnmarshalLogs` takes the whole object as a `[]byte`, so it has no streaming and no mid-object resume.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
