### PR TITLE
fix(gcspubsubeventreceiver,awss3eventreceiver): report the error that ends an avro scan

### DIFF
--- a/internal/blobstream/avro_header_stream_error_test.go
+++ b/internal/blobstream/avro_header_stream_error_test.go
@@ -1,0 +1,72 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/linkedin/goavro/v2"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// largeHeaderAvro builds an Avro OCF whose schema carries a long doc, so the container
+// header exceeds detectionPeekBytes. A read failure while decoding the header then lands
+// in Parse's NewOCFReader rather than during content detection.
+func largeHeaderAvro(t *testing.T) []byte {
+	t.Helper()
+	schema := `{"type":"record","name":"r","doc":"` + strings.Repeat("x", 5000) +
+		`","fields":[{"name":"msg","type":"string"}]}`
+	var buf bytes.Buffer
+	w, err := goavro.NewOCFWriter(goavro.OCFConfig{W: &buf, Schema: schema})
+	require.NoError(t, err)
+	require.NoError(t, w.Append([]interface{}{map[string]interface{}{"msg": "hello"}}))
+	return buf.Bytes()
+}
+
+// TestAvro_BrokenStreamInHeaderRetries asserts a connection failure while the Avro
+// container header is still being read is reported as a broken stream (retry), not a
+// corrupt container (DLQ). A transient blip must not permanently dead-letter the object.
+func TestAvro_BrokenStreamInHeaderRetries(t *testing.T) {
+	t.Parallel()
+
+	body := largeHeaderAvro(t)
+	require.Greater(t, len(body), detectionPeekBytes+256, "header must exceed the detection window")
+	readErr := errors.New("read: connection reset by peer")
+
+	// Cut inside the header but past the detection window, so detection succeeds and the
+	// failure lands in NewOCFReader.
+	stream := LogStream{
+		Name:        "logs/object.avro",
+		Body:        &cutAfter{data: body, n: detectionPeekBytes + 128, err: readErr},
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+	reader, err := stream.BufferedReader(context.Background())
+	require.NoError(t, err)
+	producer, err := NewRecordProducer(context.Background(), stream, reader, nil)
+	require.NoError(t, err)
+	_, err = producer.Records(context.Background(), Offset{})
+
+	require.Error(t, err, "a broken stream mid-header must reach the caller")
+	require.True(t, IsStreamRead(err), "a broken stream mid-header must retry")
+	require.False(t, IsUnsupportedContent(err), "a broken stream is not a corrupt container")
+	require.ErrorIs(t, err, readErr)
+}

--- a/internal/blobstream/avro_ocf_parser.go
+++ b/internal/blobstream/avro_ocf_parser.go
@@ -76,7 +76,17 @@ func StartsWithAvroOcfMagic(reader BufferedReader) (bool, error) {
 func (p *avroOcfParser) Parse(_ context.Context, startOffset int64) (logs iter.Seq2[any, error], err error) {
 	ocfReader, err := goavro.NewOCFReader(p.reader)
 	if err != nil {
-		return nil, fmt.Errorf("create ocf reader: %w", err)
+		// The header failed to decode. Classify it the same way the scan end does: a
+		// broken stream retries, a header cut short is a truncated object, and anything
+		// else is a container this decoder cannot read. A header larger than the detection
+		// window can break mid-read here, so the raw failure is not always caught earlier.
+		if p.reader.ReadErr() != nil {
+			return nil, ErrStreamRead{Err: p.reader.ReadErr()}
+		}
+		if p.reader.AtEOF() {
+			return nil, ErrTruncatedObject{Err: err}
+		}
+		return nil, ErrCorruptContainer{Format: "avro", Err: err}
 	}
 
 	// yield a sequence of records from the ocf reader
@@ -120,9 +130,33 @@ func (p *avroOcfParser) Parse(_ context.Context, startOffset int64) (logs iter.S
 			}
 
 			// yield the avro record
-			if !yield(record, err) {
+			if !yield(record, nil) {
 				return
 			}
+		}
+
+		// Scan stops at the end of the object and on failure alike, and keeps the
+		// reason to itself. Without this check a broken stream looks like a clean
+		// finish, and every record after the break is lost with no report.
+		//
+		// The reader tells the three cases apart. A recorded failure means the
+		// stream broke. Reaching the end of the object means the scan finished,
+		// because the decoder reports its own end-of-input the same way it reports
+		// a fault. Anything else stopped early on content it could not decode.
+		scanErr := ocfReader.Err()
+		switch {
+		case scanErr == nil:
+			// The decoder read the object to its end.
+		case p.reader.ReadErr() != nil:
+			// The stream broke, so a later attempt can still read the object.
+			yield(nil, ErrStreamRead{Err: p.reader.ReadErr()})
+		case p.reader.AtEOF():
+			// The bytes ran out part way through. They were never written, so a
+			// later attempt reads the same object again.
+			yield(nil, ErrTruncatedObject{Err: scanErr})
+		default:
+			// The decoder stopped early on content it cannot read.
+			yield(nil, ErrCorruptContainer{Format: "avro", Err: scanErr})
 		}
 	}, nil
 }

--- a/internal/blobstream/avro_ocf_parser_test.go
+++ b/internal/blobstream/avro_ocf_parser_test.go
@@ -51,7 +51,7 @@ func TestParseAvroOcfLogs(t *testing.T) {
 		{filePath: "testdata/sample_logs.avro.gz", expectLogs: 900, startOffset: 100},
 		{filePath: "testdata/sample_logs.avro.gz", expectLogs: 1, startOffset: 999},
 		{filePath: "testdata/sample_logs.avro.gz", expectLogs: 0, startOffset: 1000},
-		{filePath: "testdata/sample_logs_corrupt.avro", expectLogs: 50}, // no error expected, just aborts
+		{filePath: "testdata/sample_logs_corrupt.avro", expectLogs: 50, expectReadError: "object ends mid-record"}, // truncated: the scan-end classifier reports the unexpected EOF
 		{filePath: "testdata/sample_logs_corrupt_schema.avro", expectLogs: 0, expectParseError: "cannot read OCF header with invalid avro.schema"},
 		{filePath: "testdata/sample_logs_corrupt_record.avro", expectLogs: 999, expectReadError: "cannot decode binary record", expectOffsets: thousandOffsets},
 		{filePath: "testdata/sample_logs_corrupt_block.avro", expectLogs: 982, expectReadError: "cannot decode binary record", expectOffsets: []int64{18, 19, 20, 21}},

--- a/internal/blobstream/avro_stream_error_test.go
+++ b/internal/blobstream/avro_stream_error_test.go
@@ -1,0 +1,217 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// cutAfter serves the first n bytes of data and then fails every read.
+type cutAfter struct {
+	data []byte
+	n    int
+	pos  int
+	err  error
+}
+
+func (r *cutAfter) Read(p []byte) (int, error) {
+	if r.pos >= r.n {
+		if r.err != nil {
+			return 0, r.err
+		}
+		return 0, io.EOF
+	}
+	end := min(r.pos+len(p), r.n)
+	c := copy(p, r.data[r.pos:end])
+	r.pos += c
+	return c, nil
+}
+
+func (r *cutAfter) Close() error { return nil }
+
+// multiBlockAvro builds an Avro object large enough to hold several blocks, so a read
+// can break part way through rather than during detection.
+func multiBlockAvro(t *testing.T) []byte {
+	t.Helper()
+
+	msgs := make([]string, 0, 4000)
+	for i := 0; i < 4000; i++ {
+		msgs = append(msgs, fmt.Sprintf("record-%04d-padding-padding-padding", i))
+	}
+	return avroOcfBytes(t, msgs)
+}
+
+// driveAvro reads an Avro object and returns the record count and the final error.
+func driveAvro(t *testing.T, body []byte, cut int, readErr error) (int, error) {
+	t.Helper()
+	ctx := context.Background()
+
+	stream := LogStream{
+		Name:        "logs/object.avro",
+		Body:        &cutAfter{data: body, n: cut, err: readErr},
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+	reader, err := stream.BufferedReader(ctx)
+	require.NoError(t, err)
+
+	producer, err := NewRecordProducer(ctx, stream, reader, nil)
+	require.NoError(t, err)
+
+	seq, err := producer.Records(ctx, Offset{})
+	require.NoError(t, err)
+
+	var records int
+	var last error
+	for _, rerr := range seq {
+		if rerr != nil {
+			last = rerr
+			continue
+		}
+		records++
+	}
+	return records, last
+}
+
+// TestAvro_FailsTheObjectOnABrokenStream asserts a read failure part way through an
+// Avro object is reported. Ending quietly makes the worker ack a partial read and drop
+// every record after the break.
+func TestAvro_FailsTheObjectOnABrokenStream(t *testing.T) {
+	t.Parallel()
+
+	body := multiBlockAvro(t)
+	readErr := errors.New("read: connection reset by peer")
+
+	records, err := driveAvro(t, body, len(body)/2, readErr)
+
+	require.Positive(t, records, "records read before the break are still delivered")
+	require.Error(t, err, "a broken stream must reach the caller")
+	require.True(t, IsStreamRead(err), "a broken stream must be marked for retry")
+	require.ErrorIs(t, err, readErr)
+	require.False(t, IsUnsupportedContent(err), "a broken stream is retryable")
+}
+
+// TestAvro_DeadLettersACorruptContainer asserts an object whose structure will not
+// decode routes to the dead-letter queue. A retry reads the same bytes, so requeuing it
+// would redeliver it forever.
+func TestAvro_DeadLettersACorruptContainer(t *testing.T) {
+	t.Parallel()
+
+	body := multiBlockAvro(t)
+	// Break a sync marker part way in, which ends the scan without any read failing.
+	corrupt := append([]byte{}, body...)
+	for i := len(corrupt) / 2; i < len(corrupt)/2+16; i++ {
+		corrupt[i] ^= 0xff
+	}
+
+	_, err := driveAvro(t, corrupt, len(corrupt), nil)
+
+	require.Error(t, err, "a corrupt container must reach the caller")
+	require.True(t, IsUnsupportedContent(err), "a corrupt container belongs in the dead-letter queue")
+	require.False(t, IsStreamRead(err), "a corrupt container is not retryable")
+}
+
+// TestAvro_CleanObjectReportsNoError asserts the check adds no error to a healthy read.
+func TestAvro_CleanObjectReportsNoError(t *testing.T) {
+	t.Parallel()
+
+	body := multiBlockAvro(t)
+
+	records, err := driveAvro(t, body, len(body), nil)
+
+	require.NoError(t, err)
+	require.Equal(t, 4000, records)
+}
+
+// TestAvro_TruncatedObjectRoutesToDLQ asserts an Avro object that simply runs out of
+// bytes reports the truncation. Ending quietly makes the worker ack the object and drop
+// every record after the cut, which is the same loss the text and JSON paths avoid.
+func TestAvro_TruncatedObjectRoutesToDLQ(t *testing.T) {
+	t.Parallel()
+
+	body := multiBlockAvro(t)
+
+	// No transport error: the reader simply reaches the end early.
+	records, err := driveAvro(t, body, len(body)/2, nil)
+
+	require.Positive(t, records, "records before the cut are still delivered")
+	require.Error(t, err, "a truncated object must reach the caller")
+	require.True(t, IsTruncatedObject(err))
+	require.False(t, IsStreamRead(err), "truncation is not a broken connection")
+	require.True(t, IsUnsupportedContent(err), "it must route to the dead-letter queue")
+}
+
+// driveAvroParse returns the error from establishing the record sequence. A header-time
+// failure (NewOCFReader) surfaces here rather than during iteration.
+func driveAvroParse(t *testing.T, body []byte, cut int) error {
+	t.Helper()
+	ctx := context.Background()
+
+	stream := LogStream{
+		Name:        "logs/object.avro",
+		Body:        &cutAfter{data: body, n: cut},
+		MaxLogSize:  testMaxLogSize,
+		Logger:      zap.NewNop(),
+		TryDecoding: true,
+	}
+	reader, err := stream.BufferedReader(ctx)
+	require.NoError(t, err)
+
+	producer, err := NewRecordProducer(ctx, stream, reader, nil)
+	require.NoError(t, err)
+
+	_, err = producer.Records(ctx, Offset{})
+	return err
+}
+
+// TestAvro_CorruptHeaderDeadLetters asserts an object whose Avro magic matches but whose
+// container header will not decode routes to the dead-letter queue, rather than a bare
+// error that redelivers the unreadable object forever. Garbage after the magic keeps
+// bytes available, so the failure is classified as corrupt content, not truncation.
+func TestAvro_CorruptHeaderDeadLetters(t *testing.T) {
+	t.Parallel()
+
+	body := append([]byte(avroOcfMagicString), bytes.Repeat([]byte("not-a-valid-avro-header-"), 300)...)
+
+	err := driveAvroParse(t, body, len(body))
+
+	require.Error(t, err, "a corrupt header must reach the caller")
+	require.True(t, IsUnsupportedContent(err), "a corrupt container belongs in the dead-letter queue")
+	require.False(t, IsStreamRead(err), "a corrupt container is not retryable")
+	require.False(t, IsTruncatedObject(err))
+}
+
+// TestAvro_TruncatedHeaderRoutesToDLQ asserts an Avro object cut off before its header
+// finishes is reported as truncated rather than acked as an empty read.
+func TestAvro_TruncatedHeaderRoutesToDLQ(t *testing.T) {
+	t.Parallel()
+
+	// Cut just past the magic, before the header can be read in full.
+	err := driveAvroParse(t, multiBlockAvro(t), 8)
+
+	require.Error(t, err, "a truncated header must reach the caller")
+	require.True(t, IsTruncatedObject(err))
+	require.True(t, IsUnsupportedContent(err), "it must route to the dead-letter queue")
+	require.False(t, IsStreamRead(err))
+}

--- a/internal/blobstream/buffered_reader.go
+++ b/internal/blobstream/buffered_reader.go
@@ -28,6 +28,10 @@ type BufferedReader interface {
 	ReadSlice(delim byte) (line []byte, err error)
 	UnreadByte() error
 	Peek(n int) ([]byte, error)
+	// ReadErr returns the last failure the underlying reader reported, or nil.
+	ReadErr() error
+	// AtEOF reports that the underlying reader reached the end of the object.
+	AtEOF() bool
 	io.Reader
 }
 
@@ -80,4 +84,14 @@ func (r *bufferedReader) Read(p []byte) (n int, err error) {
 // Peek peeks the given number of bytes.
 func (r *bufferedReader) Peek(n int) ([]byte, error) {
 	return r.reader.Peek(n)
+}
+
+// ReadErr returns the last failure the underlying reader reported, or nil.
+func (r *bufferedReader) ReadErr() error {
+	return r.countingReader.ReadErr()
+}
+
+// AtEOF reports that the underlying reader reached the end of the object.
+func (r *bufferedReader) AtEOF() bool {
+	return r.countingReader.AtEOF()
 }

--- a/internal/blobstream/content_errors.go
+++ b/internal/blobstream/content_errors.go
@@ -14,7 +14,10 @@
 
 package blobstream
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // IsUnsupportedContent reports that this package can never parse the object. The
 // content type is unknown, the archive structure failed to decode, or the archive
@@ -49,6 +52,24 @@ func isUnusableContent(err error) bool {
 	if errors.As(err, &corruptArchive) {
 		return true
 	}
+	var corruptContainer ErrCorruptContainer
+	if errors.As(err, &corruptContainer) {
+		return true
+	}
 	var decompressLimit ErrDecompressLimitExceeded
 	return errors.As(err, &decompressLimit)
 }
+
+// ErrCorruptContainer indicates an object matched a known format but its structure
+// would not decode. A retry reads the same bytes, so the object goes to the dead-letter
+// queue instead of being redelivered.
+type ErrCorruptContainer struct {
+	Format string
+	Err    error
+}
+
+func (e ErrCorruptContainer) Error() string {
+	return fmt.Sprintf("corrupt %s object: %v", e.Format, e.Err)
+}
+
+func (e ErrCorruptContainer) Unwrap() error { return e.Err }

--- a/internal/blobstream/counting_reader.go
+++ b/internal/blobstream/counting_reader.go
@@ -53,6 +53,9 @@ func (r *countingReader) Read(p []byte) (n int, err error) {
 	r.offset += int64(n)
 	switch {
 	case err == nil:
+		// A successful read clears any earlier error, so only a terminal failure — one with
+		// no successful read after it — is reported as the cause of a broken stream.
+		r.readErr = nil
 	case errors.Is(err, io.EOF):
 		r.atEOF = true
 	default:

--- a/internal/blobstream/counting_reader.go
+++ b/internal/blobstream/counting_reader.go
@@ -14,12 +14,17 @@
 
 package blobstream
 
-import "io"
+import (
+	"errors"
+	"io"
+)
 
 // countingReader is a reader that counts the number of bytes read.
 type countingReader struct {
-	reader io.Reader
-	offset int64
+	reader  io.Reader
+	offset  int64
+	readErr error
+	atEOF   bool
 }
 
 // Offset returns the number of bytes read.
@@ -27,9 +32,31 @@ func (r *countingReader) Offset() int64 {
 	return r.offset
 }
 
+// ReadErr returns the last failure the underlying reader reported, or nil. End of
+// stream is not a failure, so it is not recorded.
+//
+// A decoder that hides the cause of its own failure uses this to tell a broken stream
+// from content it cannot decode.
+func (r *countingReader) ReadErr() error {
+	return r.readErr
+}
+
+// AtEOF reports that the underlying reader reached the end of the object. A decoder
+// that stops without it stopped early.
+func (r *countingReader) AtEOF() bool {
+	return r.atEOF
+}
+
 // Read reads the given number of bytes and updates the offset.
 func (r *countingReader) Read(p []byte) (n int, err error) {
 	n, err = r.reader.Read(p)
 	r.offset += int64(n)
+	switch {
+	case err == nil:
+	case errors.Is(err, io.EOF):
+		r.atEOF = true
+	default:
+		r.readErr = err
+	}
 	return n, err
 }

--- a/internal/blobstream/counting_reader_test.go
+++ b/internal/blobstream/counting_reader_test.go
@@ -1,0 +1,54 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstream
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// transientThenEOF hiccups with a non-EOF error on the first read, then serves data, then
+// ends cleanly — modelling a reader that recovers from a transient error.
+type transientThenEOF struct{ step int }
+
+func (r *transientThenEOF) Read(p []byte) (int, error) {
+	r.step++
+	switch r.step {
+	case 1:
+		return 0, errors.New("transient")
+	case 2:
+		return copy(p, []byte("data")), nil
+	default:
+		return 0, io.EOF
+	}
+}
+
+// TestCountingReader_TransientErrorClearedOnSuccess asserts a transient read error that a
+// later successful read recovers from does not linger and misclassify a clean EOF as a
+// broken stream.
+func TestCountingReader_TransientErrorClearedOnSuccess(t *testing.T) {
+	r := &countingReader{reader: &transientThenEOF{}}
+	buf := make([]byte, 8)
+	for {
+		if _, err := r.Read(buf); errors.Is(err, io.EOF) {
+			break
+		}
+	}
+	require.NoError(t, r.ReadErr(), "a transient error recovered by a later read must not persist")
+	require.True(t, r.AtEOF())
+}

--- a/internal/blobstream/error_types_test.go
+++ b/internal/blobstream/error_types_test.go
@@ -54,6 +54,11 @@ func TestErrorMessages(t *testing.T) {
 			want: "object ends mid-record: unexpected EOF",
 		},
 		{
+			name: "corrupt container",
+			err:  ErrCorruptContainer{Format: "avro", Err: errors.New("sync marker mismatch")},
+			want: "corrupt avro object: sync marker mismatch",
+		},
+		{
 			name: "corrupt archive with a type",
 			err:  ErrCorruptArchive{Type: "zip", Err: errors.New("bad header")},
 			want: "corrupt zip archive: bad header",
@@ -116,6 +121,16 @@ func TestIsUnsupportedContent(t *testing.T) {
 			want: true,
 		},
 		{name: "corrupt archive", err: ErrCorruptArchive{Type: "tar", Err: errors.New("bad header")}, want: true},
+		{
+			name: "corrupt container",
+			err:  ErrCorruptContainer{Format: "avro", Err: errors.New("sync marker mismatch")},
+			want: true,
+		},
+		{
+			name: "wrapped corrupt container",
+			err:  fmt.Errorf("read object: %w", ErrCorruptContainer{Format: "avro", Err: errors.New("bad")}),
+			want: true,
+		},
 		{
 			name: "wrapped corrupt archive",
 			err:  fmt.Errorf("open archive: %w", ErrCorruptArchive{Type: "tar", Err: errors.New("bad header")}),


### PR DESCRIPTION
### Proposed Change

Currently, `goavro`'s OCF reader reports failures on two channels. `Read()` fails for a record inside a block it already holds, and the parser skips that block and continues. A failure of the underlying stream stops `Scan()` instead. It leaves the reason on `ocfReader.Err()`, which nothing reads.

Using a 204 KB sample object holding 4,000 records, with the read failing halfway, results in 1,998 records and no errors. This ends like a clean finish, so the worker sends the partial batch, acks the message, and deletes the saved offset. After which, the other 2,002 records are gone and nothing reaches the log.

The parser now reports whatever ended the scan. `Err()` is set after a clean read as well, so the reader decides what it means. A recorded read failure is a broken stream. The object fails, so the message stays queued for retry. Reaching the end of the object is a clean finish. Anything else is content the decoder cannot read, and that routes to the dead-letter queue. Inside an archive, the parser drops only the corrupt entry. The remaining entries still read.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed

