### PR TITLE
feat(restapireceiver): Custom auth header prefix

### DIFF
--- a/receiver/restapireceiver/README.md
+++ b/receiver/restapireceiver/README.md
@@ -64,9 +64,10 @@ Use `auth_mode: none` for public APIs that don't require authentication. No addi
 
 #### Bearer Token
 
-| Field   | Type   | Default | Required | Description                                              |
-| ------- | ------ | ------- | -------- | -------------------------------------------------------- |
-| `token` | string |         | `true`   | Bearer token value (required if `auth_mode` is `bearer`) |
+| Field           | Type   | Default    | Required | Description                                                                        |
+| --------------- | ------ | ---------- | -------- | ---------------------------------------------------------------------------------- |
+| `token`         | string |            | `true`   | Bearer token value (required if `auth_mode` is `bearer`)                           |
+| `header_prefix` | string | `Bearer `  | `false`  | Prefix placed before the token in the `Authorization` header. See the note below.   |
 
 #### Basic Auth
 
@@ -84,6 +85,21 @@ Use `auth_mode: none` for public APIs that don't require authentication. No addi
 | `token_url`       | string            |         | `true`   | OAuth2 token endpoint URL (required if `auth_mode` is `oauth2`) |
 | `scopes`          | []string          |         | `false`  | OAuth2 scopes to request                                        |
 | `endpoint_params` | map[string]string |         | `false`  | Additional parameters to send to the token endpoint             |
+| `header_prefix`   | string            | `Bearer ` | `false` | Prefix placed before the access token in the `Authorization` header. See the note below. |
+
+##### Custom Authorization Header Prefix
+
+Some APIs expect a token under a non-standard `Authorization` scheme. `header_prefix` (available
+for both `bearer` and `oauth2`) replaces the default `Bearer ` prefix. Citrix Cloud, for example,
+expects `Authorization: CwsAuth Bearer=<token>`, which is `header_prefix: "CwsAuth Bearer="`.
+
+Two things to watch, because both produce a silently malformed header rather than an error:
+
+- **No separator is inserted.** The prefix is concatenated directly onto the token, so include the
+  trailing space yourself if the scheme needs one. `header_prefix: "Token"` yields
+  `Authorization: Token<token>`, not `Token <token>`.
+- **Quote the value in YAML.** Unquoted YAML strips trailing whitespace, so `header_prefix: Bearer `
+  becomes `Bearer` and produces `Authorization: Bearer<token>`. Always quote: `"Bearer "`.
 
 #### Akamai EdgeGrid
 
@@ -268,6 +284,27 @@ receivers:
       endpoint_params:
         audience: "https://api.example.com"
         resource: "https://api.example.com"
+```
+
+### Citrix Cloud API (Custom Authorization Prefix)
+
+Citrix Cloud uses a standard OAuth2 client credentials exchange but sends the token under its own
+`CwsAuth Bearer=` scheme, and requires the customer ID as a separate header. The token URL embeds
+your customer ID.
+
+```yaml
+receivers:
+  restapi:
+    url: "https://api.cloud.com/systemlog/records"
+    max_poll_interval: 5m
+    auth_mode: oauth2
+    oauth2:
+      client_id: "your-client-id"
+      client_secret: "your-client-secret"
+      token_url: "https://api.cloud.com/cctrustoauth2/your-customer-id/tokens/clients"
+      header_prefix: "CwsAuth Bearer="
+    headers:
+      Citrix-CustomerId: "your-customer-id"
 ```
 
 ### Akamai EdgeGrid Authentication

--- a/receiver/restapireceiver/client.go
+++ b/receiver/restapireceiver/client.go
@@ -459,7 +459,7 @@ func (c *defaultRESTAPIClient) applyAuth(req *http.Request) error {
 		if string(c.cfg.BearerConfig.Token) == "" {
 			return fmt.Errorf("bearer token is required")
 		}
-		req.Header.Set("Authorization", "Bearer "+string(c.cfg.BearerConfig.Token))
+		req.Header.Set("Authorization", authHeaderPrefix(c.cfg.BearerConfig.HeaderPrefix)+string(c.cfg.BearerConfig.Token))
 		return nil
 
 	case authModeBasic:
@@ -479,7 +479,7 @@ func (c *defaultRESTAPIClient) applyAuth(req *http.Request) error {
 		if err != nil {
 			return fmt.Errorf("failed to get OAuth2 token: %w", err)
 		}
-		req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+		req.Header.Set("Authorization", authHeaderPrefix(c.cfg.OAuth2Config.HeaderPrefix)+token.AccessToken)
 		return nil
 
 	case authModeAkamaiEdgeGrid:

--- a/receiver/restapireceiver/client_test.go
+++ b/receiver/restapireceiver/client_test.go
@@ -223,6 +223,69 @@ func TestRESTAPIClient_GetJSON_BearerAuth(t *testing.T) {
 	require.Len(t, data, 1)
 }
 
+func TestRESTAPIClient_GetJSON_BearerAuth_HeaderPrefix(t *testing.T) {
+	// The prefix is used verbatim: nothing is inserted between it and the token.
+	testCases := []struct {
+		name           string
+		headerPrefix   string
+		expectedHeader string
+	}{
+		{
+			name:           "unset falls back to the default",
+			headerPrefix:   "",
+			expectedHeader: "Bearer test-token",
+		},
+		{
+			name:           "citrix cloud scheme",
+			headerPrefix:   "CwsAuth Bearer=",
+			expectedHeader: "CwsAuth Bearer=test-token",
+		},
+		{
+			name:           "casing is preserved exactly",
+			headerPrefix:   "CWSAuth bearer=",
+			expectedHeader: "CWSAuth bearer=test-token",
+		},
+		{
+			name:           "no separator is inserted",
+			headerPrefix:   "Token",
+			expectedHeader: "Tokentest-token",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, tc.expectedHeader, r.Header.Get("Authorization"))
+
+				response := []map[string]any{
+					{"id": "1"},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+
+			cfg := &Config{
+				URL:      server.URL,
+				AuthMode: authModeBearer,
+				BearerConfig: BearerConfig{
+					Token:        "test-token",
+					HeaderPrefix: tc.headerPrefix,
+				},
+				ClientConfig: confighttp.ClientConfig{},
+			}
+
+			ctx := context.Background()
+			client, err := newRESTAPIClient(ctx, componenttest.NewNopTelemetrySettings(), cfg, componenttest.NewNopHost())
+			require.NoError(t, err)
+
+			data, err := client.GetJSON(ctx, server.URL, url.Values{})
+			require.NoError(t, err)
+			require.Len(t, data, 1)
+		})
+	}
+}
+
 func TestRESTAPIClient_GetJSON_BasicAuth(t *testing.T) {
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -334,6 +397,62 @@ func TestRESTAPIClient_GetJSON_OAuth2Auth(t *testing.T) {
 
 	params := url.Values{}
 	data, err := client.GetJSON(ctx, apiServer.URL, params)
+	require.NoError(t, err)
+	require.Len(t, data, 1)
+}
+
+func TestRESTAPIClient_GetJSON_OAuth2Auth_HeaderPrefix(t *testing.T) {
+	// Mirrors the Citrix Cloud API: a standard client_credentials exchange whose
+	// token is then sent under the non-standard "CwsAuth Bearer=" scheme.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "POST", r.Method)
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "client_credentials", r.Form.Get("grant_type"))
+
+		// Citrix documents expires_in as a JSON string rather than a number.
+		response := map[string]any{
+			"access_token": "test-oauth2-token",
+			"token_type":   "bearer",
+			"expires_in":   "3600",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer tokenServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "CwsAuth Bearer=test-oauth2-token", r.Header.Get("Authorization"))
+		// Citrix also requires the customer ID, supplied via the headers map.
+		require.Equal(t, "test-customer-id", r.Header.Get("Citrix-CustomerId"))
+
+		response := []map[string]any{
+			{"id": "1"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer apiServer.Close()
+
+	cfg := &Config{
+		URL:      apiServer.URL,
+		AuthMode: authModeOAuth2,
+		OAuth2Config: OAuth2Config{
+			ClientID:     "test-client-id",
+			ClientSecret: "test-client-secret",
+			TokenURL:     tokenServer.URL + "/token",
+			HeaderPrefix: "CwsAuth Bearer=",
+		},
+		Headers: map[string]string{
+			"Citrix-CustomerId": "test-customer-id",
+		},
+		ClientConfig: confighttp.ClientConfig{},
+	}
+
+	ctx := context.Background()
+	client, err := newRESTAPIClient(ctx, componenttest.NewNopTelemetrySettings(), cfg, componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	data, err := client.GetJSON(ctx, apiServer.URL, url.Values{})
 	require.NoError(t, err)
 	require.Len(t, data, 1)
 }

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -49,6 +49,20 @@ const (
 	authModeAkamaiEdgeGrid AuthMode = "akamai_edgegrid"
 )
 
+// defaultAuthHeaderPrefix is the Authorization header prefix used when
+// header_prefix is not configured. The trailing space is significant.
+const defaultAuthHeaderPrefix = "Bearer "
+
+// authHeaderPrefix returns the configured Authorization header prefix, falling
+// back to the default when unset. The prefix is used verbatim: no separator is
+// inserted between it and the token.
+func authHeaderPrefix(prefix string) string {
+	if prefix == "" {
+		return defaultAuthHeaderPrefix
+	}
+	return prefix
+}
+
 // UnmarshalText implements the encoding.TextUnmarshaler interface
 func (m *AuthMode) UnmarshalText(text []byte) error {
 	mode := AuthMode(text)
@@ -268,6 +282,10 @@ type APIKeyConfig struct {
 // BearerConfig defines bearer token authentication configuration.
 type BearerConfig struct {
 	Token configopaque.String `mapstructure:"token"`
+	// HeaderPrefix is prepended verbatim to the token to form the Authorization
+	// header value. No separator is inserted, so a prefix meant to be followed by
+	// a space must include it (e.g. "Bearer "). Defaults to "Bearer " when unset.
+	HeaderPrefix string `mapstructure:"header_prefix"`
 }
 
 // BasicConfig defines basic authentication configuration.
@@ -283,6 +301,12 @@ type OAuth2Config struct {
 	TokenURL       string              `mapstructure:"token_url"`
 	Scopes         []string            `mapstructure:"scopes"`
 	EndpointParams map[string]string   `mapstructure:"endpoint_params"`
+	// HeaderPrefix is prepended verbatim to the access token to form the
+	// Authorization header value. No separator is inserted, so a prefix meant to be
+	// followed by a space must include it (e.g. "Bearer "). Defaults to "Bearer "
+	// when unset. Set this for APIs using a non-standard scheme, such as Citrix
+	// Cloud's "CwsAuth Bearer=".
+	HeaderPrefix string `mapstructure:"header_prefix"`
 }
 
 // AkamaiEdgeGridConfig defines Akamai EdgeGrid authentication configuration.
@@ -477,6 +501,9 @@ func (c *Config) Validate() error {
 		if string(c.BearerConfig.Token) == "" {
 			return fmt.Errorf("token is required when auth_mode is bearer")
 		}
+		if err := validateHeaderValue(c.BearerConfig.HeaderPrefix); err != nil {
+			return fmt.Errorf("invalid bearer header_prefix: %w", err)
+		}
 	case authModeBasic:
 		if c.BasicConfig.Username == "" {
 			return fmt.Errorf("username is required when auth_mode is basic")
@@ -493,6 +520,9 @@ func (c *Config) Validate() error {
 		}
 		if c.OAuth2Config.TokenURL == "" {
 			return fmt.Errorf("token_url is required when auth_mode is oauth2")
+		}
+		if err := validateHeaderValue(c.OAuth2Config.HeaderPrefix); err != nil {
+			return fmt.Errorf("invalid oauth2 header_prefix: %w", err)
 		}
 	case authModeAkamaiEdgeGrid:
 		if string(c.AkamaiEdgeGridConfig.AccessToken) == "" {

--- a/receiver/restapireceiver/config_test.go
+++ b/receiver/restapireceiver/config_test.go
@@ -162,6 +162,36 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			name: "valid bearer auth with header_prefix",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeBearer,
+				BearerConfig: BearerConfig{
+					Token:        "test-token",
+					HeaderPrefix: "CwsAuth Bearer=",
+				},
+				Pagination: PaginationConfig{
+					Mode: paginationModeNone,
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "bearer auth header_prefix with CRLF",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeBearer,
+				BearerConfig: BearerConfig{
+					Token:        "test-token",
+					HeaderPrefix: "Bearer \r\nX-Injected: evil",
+				},
+				Pagination: PaginationConfig{
+					Mode: paginationModeNone,
+				},
+			},
+			expectedErr: "invalid bearer header_prefix",
+		},
+		{
 			name: "basic auth missing username",
 			config: &Config{
 				URL:      "https://api.example.com/data",
@@ -305,6 +335,40 @@ func TestConfig_Validate(t *testing.T) {
 				},
 			},
 			expectedErr: "",
+		},
+		{
+			name: "valid oauth2 auth with header_prefix",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeOAuth2,
+				OAuth2Config: OAuth2Config{
+					ClientID:     "test-client-id",
+					ClientSecret: "test-client-secret",
+					TokenURL:     "https://oauth.example.com/token",
+					HeaderPrefix: "CwsAuth Bearer=",
+				},
+				Pagination: PaginationConfig{
+					Mode: paginationModeNone,
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "oauth2 auth header_prefix with newline",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeOAuth2,
+				OAuth2Config: OAuth2Config{
+					ClientID:     "test-client-id",
+					ClientSecret: "test-client-secret",
+					TokenURL:     "https://oauth.example.com/token",
+					HeaderPrefix: "CwsAuth\nBearer=",
+				},
+				Pagination: PaginationConfig{
+					Mode: paginationModeNone,
+				},
+			},
+			expectedErr: "invalid oauth2 header_prefix",
 		},
 		{
 			name: "akamai edgegrid auth missing access token",

--- a/receiver/restapireceiver/integration_test.go
+++ b/receiver/restapireceiver/integration_test.go
@@ -245,6 +245,69 @@ func TestIntegration_WithPaginationAndAuth(t *testing.T) {
 	require.GreaterOrEqual(t, totalRecords, 4)
 }
 
+// TestIntegration_CustomAuthHeaderPrefix verifies that a custom Authorization
+// header prefix is applied to every request across a paginated poll cycle.
+func TestIntegration_CustomAuthHeaderPrefix(t *testing.T) {
+	var requestCount atomic.Int32
+	expectedAuthHeader := "CwsAuth Bearer=test-token-123"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, expectedAuthHeader, r.Header.Get("Authorization"))
+		requestCount.Add(1)
+
+		var data []map[string]any
+		switch r.URL.Query().Get("offset") {
+		case "0", "":
+			data = []map[string]any{{"id": "1"}, {"id": "2"}}
+		case "2":
+			data = []map[string]any{{"id": "3"}, {"id": "4"}}
+		default:
+			data = []map[string]any{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"data": data, "total": 4})
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:           server.URL,
+		ResponseField: "data",
+		AuthMode:      authModeBearer,
+		BearerConfig: BearerConfig{
+			Token:        "test-token-123",
+			HeaderPrefix: "CwsAuth Bearer=",
+		},
+		Pagination: PaginationConfig{
+			Mode: paginationModeOffsetLimit,
+			OffsetLimit: OffsetLimitPagination{
+				OffsetFieldName: "offset",
+				LimitFieldName:  "limit",
+				StartingOffset:  0,
+			},
+			TotalRecordCountField: "total",
+		},
+		MaxPollInterval: 100 * time.Millisecond,
+		ClientConfig:    confighttp.ClientConfig{},
+	}
+
+	sink := new(consumertest.LogsSink)
+	receiver, err := newRESTAPILogsReceiver(receivertest.NewNopSettings(metadata.Type), cfg, sink)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, receiver.Start(ctx, componenttest.NewNopHost()))
+
+	require.Eventually(t, func() bool {
+		return logRecordCount(sink) >= 4
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, receiver.Shutdown(ctx))
+
+	// More than one request means the prefix survived pagination, not just the first call.
+	require.Greater(t, requestCount.Load(), int32(1))
+}
+
 // TestIntegration_TimestampPagination tests timestamp-based pagination.
 func TestIntegration_TimestampPagination(t *testing.T) {
 	var mu sync.Mutex


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

### Proposed Change
<!-- Please provide a description of the change here. -->
Adds a new field to the bearer and oauth auth configurations: `header_prefix`. This optionally replaces the `Bearer <token>` authentication header for `<header_prefix><token>`.
Mainly implemented for the Citrix Cloud API, which requires the header to be formatted like `CWSAuth Bearer=<token>`.
Citrix uses OAuth, but decided to add this to Bearer auth as well to be proactive for any other potential weird API patterns with Bearer auth.

Note: still testing against Citrix free trial

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed