### PR TITLE
feat: Log type detection processor Matcher implementation

### DIFF
--- a/processor/logtypedetectionprocessor/config.go
+++ b/processor/logtypedetectionprocessor/config.go
@@ -15,17 +15,45 @@
 package logtypedetectionprocessor
 
 import (
+	"errors"
+
 	"go.opentelemetry.io/collector/component"
 )
 
+const (
+	defaultFingerprintField = "fingerprint"
+	defaultLogTypeField     = "log_type"
+)
+
+var errMissingLogTypeFieldError = errors.New("log_type_field is required")
+
 // Config is the config of the processor.
-type Config struct{}
+type Config struct {
+	Matchers         []MatcherConfig `mapstructure:"matchers"`
+	FingerprintField string          `mapstructure:"fingerprint_field"`
+	LogTypeField     string          `mapstructure:"log_type_field"`
+}
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{
+		Matchers:         []MatcherConfig{},
+		FingerprintField: defaultFingerprintField,
+		LogTypeField:     defaultLogTypeField,
+	}
 }
 
 // Validate validates the processor configuration
 func (c Config) Validate() error {
+	if c.LogTypeField == "" {
+		return errMissingLogTypeFieldError
+	}
+
+	if c.Matchers != nil {
+		for _, m := range c.Matchers {
+			if err := m.Validate(); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }

--- a/processor/logtypedetectionprocessor/config.go
+++ b/processor/logtypedetectionprocessor/config.go
@@ -23,6 +23,7 @@ import (
 const (
 	defaultFingerprintField = "fingerprint"
 	defaultLogTypeField     = "log_type"
+	unknownLogType          = "unknown"
 )
 
 var errMissingLogTypeFieldError = errors.New("log_type_field is required")

--- a/processor/logtypedetectionprocessor/config.go
+++ b/processor/logtypedetectionprocessor/config.go
@@ -26,7 +26,7 @@ const (
 	unknownLogType          = "unknown"
 )
 
-var errMissingLogTypeFieldError = errors.New("log_type_field is required")
+var errMissingLogTypeField = errors.New("log_type_field is required")
 
 // Config is the config of the processor.
 type Config struct {
@@ -46,14 +46,12 @@ func createDefaultConfig() component.Config {
 // Validate validates the processor configuration
 func (c Config) Validate() error {
 	if c.LogTypeField == "" {
-		return errMissingLogTypeFieldError
+		return errMissingLogTypeField
 	}
 
-	if c.Matchers != nil {
-		for _, m := range c.Matchers {
-			if err := m.Validate(); err != nil {
-				return err
-			}
+	for _, m := range c.Matchers {
+		if err := m.Validate(); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/processor/logtypedetectionprocessor/config_test.go
+++ b/processor/logtypedetectionprocessor/config_test.go
@@ -1,0 +1,64 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logtypedetectionprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateDefaultProcessorConfig(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	require.Equal(t, defaultFingerprintField, cfg.FingerprintField)
+	require.Equal(t, defaultLogTypeField, cfg.LogTypeField)
+	require.Len(t, cfg.Matchers, 0)
+}
+
+func TestConfig_Validate(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config *Config
+		err    error
+	}{
+		{
+			name:   "default",
+			config: createDefaultConfig().(*Config),
+		},
+		{
+			name: "missing fingerprint field is accepted",
+			config: &Config{
+				LogTypeField: "log_type_field",
+			},
+		},
+		{
+			name: "missing log type field",
+			config: &Config{
+				FingerprintField: "fingerprint_field",
+			},
+			err: errMissingLogTypeFieldError,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.Validate()
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/processor/logtypedetectionprocessor/config_test.go
+++ b/processor/logtypedetectionprocessor/config_test.go
@@ -48,7 +48,7 @@ func TestConfig_Validate(t *testing.T) {
 			config: &Config{
 				FingerprintField: "fingerprint_field",
 			},
-			err: errMissingLogTypeFieldError,
+			err: errMissingLogTypeField,
 		},
 	}
 	for _, tc := range testCases {

--- a/processor/logtypedetectionprocessor/documentation.md
+++ b/processor/logtypedetectionprocessor/documentation.md
@@ -6,6 +6,14 @@
 
 The following telemetry is emitted by this component.
 
+### otelcol_log_type_detection_matches
+
+Number of log type detection matches, one per log type match.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {match} | Sum | Int | true | Alpha |
+
 ### otelcol_log_type_detection_runs
 
 Number of log type detections run, one per newly seen log structure.
@@ -13,3 +21,11 @@ Number of log type detections run, one per newly seen log structure.
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
 | {detection} | Sum | Int | true | Alpha |
+
+### otelcol_log_types
+
+The number of hashes with a detected log type.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {type} | Sum | Int | true | Alpha |

--- a/processor/logtypedetectionprocessor/documentation.md
+++ b/processor/logtypedetectionprocessor/documentation.md
@@ -22,6 +22,14 @@ Number of log type detections run, one per newly seen log structure.
 | ---- | ----------- | ---------- | --------- | --------- |
 | {detection} | Sum | Int | true | Alpha |
 
+### otelcol_log_type_detection_unknown
+
+Number of logs with no detected log type.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {log} | Sum | Int | true | Alpha |
+
 ### otelcol_log_types
 
 The number of hashes with a detected log type.

--- a/processor/logtypedetectionprocessor/documentation.md
+++ b/processor/logtypedetectionprocessor/documentation.md
@@ -6,34 +6,40 @@
 
 The following telemetry is emitted by this component.
 
-### otelcol_log_type_detection_matches
+### otelcol_processor_log_type_detection_attempts
 
-Number of log type detection matches, one per log type match.
-
-| Unit | Metric Type | Value Type | Monotonic | Stability |
-| ---- | ----------- | ---------- | --------- | --------- |
-| {match} | Sum | Int | true | Alpha |
-
-### otelcol_log_type_detection_runs
-
-Number of log type detections run, one per newly seen log structure.
+Number of log type detections attempted, one per newly seen log structure.
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
 | {detection} | Sum | Int | true | Alpha |
 
-### otelcol_log_type_detection_unknown
+### otelcol_processor_log_type_detection_attempts_matched
 
-Number of logs with no detected log type.
+Number of log type detection attempts that matched, one per newly seen log structure.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {detection} | Sum | Int | true | Alpha |
+
+### otelcol_processor_log_type_detection_logs_classified
+
+Number of log records assigned a log type.
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
 | {log} | Sum | Int | true | Alpha |
 
-### otelcol_log_types
+#### Attributes
 
-The number of hashes with a detected log type.
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| log_type | The log type that matched. | Any Str | - |
+
+### otelcol_processor_log_type_detection_logs_unclassified
+
+Number of log records with no detected log type.
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
-| {type} | Sum | Int | true | Alpha |
+| {log} | Sum | Int | true | Alpha |

--- a/processor/logtypedetectionprocessor/factory.go
+++ b/processor/logtypedetectionprocessor/factory.go
@@ -45,7 +45,10 @@ func createLogsProcessor(
 	if err != nil {
 		return nil, fmt.Errorf("create telemetry builder: %w", err)
 	}
-	p := newLogTypeDetectionProcessor(oCfg, telemetry)
+	p, err := newLogTypeDetectionProcessor(oCfg, telemetry)
+	if err != nil {
+		return nil, err
+	}
 
 	return processorhelper.NewLogs(
 		ctx,

--- a/processor/logtypedetectionprocessor/generated_package_test.go
+++ b/processor/logtypedetectionprocessor/generated_package_test.go
@@ -3,8 +3,9 @@
 package logtypedetectionprocessor
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/processor/logtypedetectionprocessor/generated_package_test.go
+++ b/processor/logtypedetectionprocessor/generated_package_test.go
@@ -3,9 +3,8 @@
 package logtypedetectionprocessor
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/processor/logtypedetectionprocessor/go.mod
+++ b/processor/logtypedetectionprocessor/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/processor v1.65.0
 	go.opentelemetry.io/collector/processor/processorhelper v0.159.0
 	go.opentelemetry.io/collector/processor/processortest v0.159.0
+	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk/metric v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
@@ -45,7 +46,6 @@ require (
 	go.opentelemetry.io/collector/pdata/testdata v0.159.0 // indirect
 	go.opentelemetry.io/collector/pipeline v1.65.0 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.159.0 // indirect
-	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.45.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect

--- a/processor/logtypedetectionprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/logtypedetectionprocessor/internal/metadata/generated_telemetry.go
@@ -28,6 +28,7 @@ type TelemetryBuilder struct {
 	registrations           []metric.Registration
 	LogTypeDetectionMatches metric.Int64Counter
 	LogTypeDetectionRuns    metric.Int64Counter
+	LogTypeDetectionUnknown metric.Int64Counter
 	LogTypes                metric.Int64Counter
 }
 
@@ -70,6 +71,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_log_type_detection_runs",
 		metric.WithDescription("Number of log type detections run, one per newly seen log structure. [Alpha]"),
 		metric.WithUnit("{detection}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LogTypeDetectionUnknown, err = builder.meter.Int64Counter(
+		"otelcol_log_type_detection_unknown",
+		metric.WithDescription("Number of logs with no detected log type. [Alpha]"),
+		metric.WithUnit("{log}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.LogTypes, err = builder.meter.Int64Counter(

--- a/processor/logtypedetectionprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/logtypedetectionprocessor/internal/metadata/generated_telemetry.go
@@ -23,13 +23,13 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
-	meter                   metric.Meter
-	mu                      sync.Mutex
-	registrations           []metric.Registration
-	LogTypeDetectionMatches metric.Int64Counter
-	LogTypeDetectionRuns    metric.Int64Counter
-	LogTypeDetectionUnknown metric.Int64Counter
-	LogTypes                metric.Int64Counter
+	meter                                     metric.Meter
+	mu                                        sync.Mutex
+	registrations                             []metric.Registration
+	ProcessorLogTypeDetectionAttempts         metric.Int64Counter
+	ProcessorLogTypeDetectionAttemptsMatched  metric.Int64Counter
+	ProcessorLogTypeDetectionLogsClassified   metric.Int64Counter
+	ProcessorLogTypeDetectionLogsUnclassified metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -61,28 +61,28 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meter = Meter(settings)
 	var err, errs error
-	builder.LogTypeDetectionMatches, err = builder.meter.Int64Counter(
-		"otelcol_log_type_detection_matches",
-		metric.WithDescription("Number of log type detection matches, one per log type match. [Alpha]"),
-		metric.WithUnit("{match}"),
-	)
-	errs = errors.Join(errs, err)
-	builder.LogTypeDetectionRuns, err = builder.meter.Int64Counter(
-		"otelcol_log_type_detection_runs",
-		metric.WithDescription("Number of log type detections run, one per newly seen log structure. [Alpha]"),
+	builder.ProcessorLogTypeDetectionAttempts, err = builder.meter.Int64Counter(
+		"otelcol_processor_log_type_detection_attempts",
+		metric.WithDescription("Number of log type detections attempted, one per newly seen log structure. [Alpha]"),
 		metric.WithUnit("{detection}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.LogTypeDetectionUnknown, err = builder.meter.Int64Counter(
-		"otelcol_log_type_detection_unknown",
-		metric.WithDescription("Number of logs with no detected log type. [Alpha]"),
+	builder.ProcessorLogTypeDetectionAttemptsMatched, err = builder.meter.Int64Counter(
+		"otelcol_processor_log_type_detection_attempts_matched",
+		metric.WithDescription("Number of log type detection attempts that matched, one per newly seen log structure. [Alpha]"),
+		metric.WithUnit("{detection}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ProcessorLogTypeDetectionLogsClassified, err = builder.meter.Int64Counter(
+		"otelcol_processor_log_type_detection_logs_classified",
+		metric.WithDescription("Number of log records assigned a log type. [Alpha]"),
 		metric.WithUnit("{log}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.LogTypes, err = builder.meter.Int64Counter(
-		"otelcol_log_types",
-		metric.WithDescription("The number of hashes with a detected log type. [Alpha]"),
-		metric.WithUnit("{type}"),
+	builder.ProcessorLogTypeDetectionLogsUnclassified, err = builder.meter.Int64Counter(
+		"otelcol_processor_log_type_detection_logs_unclassified",
+		metric.WithDescription("Number of log records with no detected log type. [Alpha]"),
+		metric.WithUnit("{log}"),
 	)
 	errs = errors.Join(errs, err)
 	return &builder, errs

--- a/processor/logtypedetectionprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/logtypedetectionprocessor/internal/metadata/generated_telemetry.go
@@ -23,10 +23,12 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
-	meter                metric.Meter
-	mu                   sync.Mutex
-	registrations        []metric.Registration
-	LogTypeDetectionRuns metric.Int64Counter
+	meter                   metric.Meter
+	mu                      sync.Mutex
+	registrations           []metric.Registration
+	LogTypeDetectionMatches metric.Int64Counter
+	LogTypeDetectionRuns    metric.Int64Counter
+	LogTypes                metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -58,10 +60,22 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meter = Meter(settings)
 	var err, errs error
+	builder.LogTypeDetectionMatches, err = builder.meter.Int64Counter(
+		"otelcol_log_type_detection_matches",
+		metric.WithDescription("Number of log type detection matches, one per log type match. [Alpha]"),
+		metric.WithUnit("{match}"),
+	)
+	errs = errors.Join(errs, err)
 	builder.LogTypeDetectionRuns, err = builder.meter.Int64Counter(
 		"otelcol_log_type_detection_runs",
 		metric.WithDescription("Number of log type detections run, one per newly seen log structure. [Alpha]"),
 		metric.WithUnit("{detection}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LogTypes, err = builder.meter.Int64Counter(
+		"otelcol_log_types",
+		metric.WithDescription("The number of hashes with a detected log type. [Alpha]"),
+		metric.WithUnit("{type}"),
 	)
 	errs = errors.Join(errs, err)
 	return &builder, errs

--- a/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -21,26 +21,10 @@ func NewSettings(tt *componenttest.Telemetry) processor.Settings {
 	return set
 }
 
-func AssertEqualLogTypeDetectionMatches(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorLogTypeDetectionAttempts(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol_log_type_detection_matches",
-		Description: "Number of log type detection matches, one per log type match. [Alpha]",
-		Unit:        "{match}",
-		Data: metricdata.Sum[int64]{
-			Temporality: metricdata.CumulativeTemporality,
-			IsMonotonic: true,
-			DataPoints:  dps,
-		},
-	}
-	got, err := tt.GetMetric("otelcol_log_type_detection_matches")
-	require.NoError(t, err)
-	metricdatatest.AssertEqual(t, want, got, opts...)
-}
-
-func AssertEqualLogTypeDetectionRuns(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
-	want := metricdata.Metrics{
-		Name:        "otelcol_log_type_detection_runs",
-		Description: "Number of log type detections run, one per newly seen log structure. [Alpha]",
+		Name:        "otelcol_processor_log_type_detection_attempts",
+		Description: "Number of log type detections attempted, one per newly seen log structure. [Alpha]",
 		Unit:        "{detection}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -48,15 +32,31 @@ func AssertEqualLogTypeDetectionRuns(t *testing.T, tt *componenttest.Telemetry, 
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol_log_type_detection_runs")
+	got, err := tt.GetMetric("otelcol_processor_log_type_detection_attempts")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualLogTypeDetectionUnknown(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorLogTypeDetectionAttemptsMatched(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol_log_type_detection_unknown",
-		Description: "Number of logs with no detected log type. [Alpha]",
+		Name:        "otelcol_processor_log_type_detection_attempts_matched",
+		Description: "Number of log type detection attempts that matched, one per newly seen log structure. [Alpha]",
+		Unit:        "{detection}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_processor_log_type_detection_attempts_matched")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualProcessorLogTypeDetectionLogsClassified(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_processor_log_type_detection_logs_classified",
+		Description: "Number of log records assigned a log type. [Alpha]",
 		Unit:        "{log}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -64,23 +64,23 @@ func AssertEqualLogTypeDetectionUnknown(t *testing.T, tt *componenttest.Telemetr
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol_log_type_detection_unknown")
+	got, err := tt.GetMetric("otelcol_processor_log_type_detection_logs_classified")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualLogTypes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualProcessorLogTypeDetectionLogsUnclassified(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol_log_types",
-		Description: "The number of hashes with a detected log type. [Alpha]",
-		Unit:        "{type}",
+		Name:        "otelcol_processor_log_type_detection_logs_unclassified",
+		Description: "Number of log records with no detected log type. [Alpha]",
+		Unit:        "{log}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
 			IsMonotonic: true,
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol_log_types")
+	got, err := tt.GetMetric("otelcol_processor_log_type_detection_logs_unclassified")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -21,6 +21,22 @@ func NewSettings(tt *componenttest.Telemetry) processor.Settings {
 	return set
 }
 
+func AssertEqualLogTypeDetectionMatches(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_log_type_detection_matches",
+		Description: "Number of log type detection matches, one per log type match. [Alpha]",
+		Unit:        "{match}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_log_type_detection_matches")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualLogTypeDetectionRuns(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_log_type_detection_runs",
@@ -33,6 +49,22 @@ func AssertEqualLogTypeDetectionRuns(t *testing.T, tt *componenttest.Telemetry, 
 		},
 	}
 	got, err := tt.GetMetric("otelcol_log_type_detection_runs")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLogTypes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_log_types",
+		Description: "The number of hashes with a detected log type. [Alpha]",
+		Unit:        "{type}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_log_types")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -53,6 +53,22 @@ func AssertEqualLogTypeDetectionRuns(t *testing.T, tt *componenttest.Telemetry, 
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualLogTypeDetectionUnknown(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_log_type_detection_unknown",
+		Description: "Number of logs with no detected log type. [Alpha]",
+		Unit:        "{log}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_log_type_detection_unknown")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualLogTypes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_log_types",

--- a/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -19,20 +19,20 @@ func TestSetupTelemetry(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
 	require.NoError(t, err)
 	defer tb.Shutdown()
-	tb.LogTypeDetectionMatches.Add(context.Background(), 1)
-	tb.LogTypeDetectionRuns.Add(context.Background(), 1)
-	tb.LogTypeDetectionUnknown.Add(context.Background(), 1)
-	tb.LogTypes.Add(context.Background(), 1)
-	AssertEqualLogTypeDetectionMatches(t, testTel,
+	tb.ProcessorLogTypeDetectionAttempts.Add(context.Background(), 1)
+	tb.ProcessorLogTypeDetectionAttemptsMatched.Add(context.Background(), 1)
+	tb.ProcessorLogTypeDetectionLogsClassified.Add(context.Background(), 1)
+	tb.ProcessorLogTypeDetectionLogsUnclassified.Add(context.Background(), 1)
+	AssertEqualProcessorLogTypeDetectionAttempts(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
-	AssertEqualLogTypeDetectionRuns(t, testTel,
+	AssertEqualProcessorLogTypeDetectionAttemptsMatched(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
-	AssertEqualLogTypeDetectionUnknown(t, testTel,
+	AssertEqualProcessorLogTypeDetectionLogsClassified(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
-	AssertEqualLogTypes(t, testTel,
+	AssertEqualProcessorLogTypeDetectionLogsUnclassified(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 

--- a/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -21,11 +21,15 @@ func TestSetupTelemetry(t *testing.T) {
 	defer tb.Shutdown()
 	tb.LogTypeDetectionMatches.Add(context.Background(), 1)
 	tb.LogTypeDetectionRuns.Add(context.Background(), 1)
+	tb.LogTypeDetectionUnknown.Add(context.Background(), 1)
 	tb.LogTypes.Add(context.Background(), 1)
 	AssertEqualLogTypeDetectionMatches(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualLogTypeDetectionRuns(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLogTypeDetectionUnknown(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualLogTypes(t, testTel,

--- a/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/logtypedetectionprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -19,8 +19,16 @@ func TestSetupTelemetry(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
 	require.NoError(t, err)
 	defer tb.Shutdown()
+	tb.LogTypeDetectionMatches.Add(context.Background(), 1)
 	tb.LogTypeDetectionRuns.Add(context.Background(), 1)
+	tb.LogTypes.Add(context.Background(), 1)
+	AssertEqualLogTypeDetectionMatches(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualLogTypeDetectionRuns(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLogTypes(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 

--- a/processor/logtypedetectionprocessor/matcher.go
+++ b/processor/logtypedetectionprocessor/matcher.go
@@ -20,8 +20,10 @@ import (
 	"strings"
 )
 
+// MatcherType identifies how a matcher tests a log body.
 type MatcherType string
 
+// Supported matcher methods.
 const (
 	MatcherTypeRegex      MatcherType = "regex"
 	MatcherTypeStartsWith MatcherType = "starts_with"
@@ -41,6 +43,7 @@ type Matcher interface {
 	Name() string
 }
 
+// Validate validates the matcher configuration.
 func (c MatcherConfig) Validate() error {
 	if c.Name == "" {
 		return fmt.Errorf("name is required")

--- a/processor/logtypedetectionprocessor/matcher.go
+++ b/processor/logtypedetectionprocessor/matcher.go
@@ -1,0 +1,127 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logtypedetectionprocessor
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type MatcherType string
+
+const (
+	MatcherTypeRegex      MatcherType = "regex"
+	MatcherTypeStartsWith MatcherType = "starts_with"
+)
+
+// MatcherConfig is the user-facing config, unmarshalled from YAML.
+type MatcherConfig struct {
+	Name     string      `mapstructure:"name"`
+	Priority int         `mapstructure:"priority"`
+	Method   MatcherType `mapstructure:"method"`
+	Value    string      `mapstructure:"value"`
+}
+
+// Matcher is the compiled runtime form.
+type Matcher interface {
+	Test(s string) bool
+	Name() string
+}
+
+func (c MatcherConfig) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if c.Priority < 0 {
+		return fmt.Errorf("priority must be >= 0")
+	}
+
+	switch c.Method {
+	case MatcherTypeRegex:
+		if _, err := regexp.Compile(c.Value); err != nil {
+			return fmt.Errorf("invalid regex %q: %w", c.Value, err)
+		}
+		return nil
+	case MatcherTypeStartsWith:
+		if c.Value == "" {
+			return fmt.Errorf("starts with matcher requires a value")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown matcher method %q", c.Method)
+	}
+}
+
+// Build compiles the config into a Matcher.
+func (c MatcherConfig) Build() (Matcher, error) {
+	matcherBase := matcherBase{
+		name:     c.Name,
+		priority: c.Priority,
+	}
+	switch c.Method {
+	case MatcherTypeRegex:
+		return newRegexMatcher(matcherBase, c.Value)
+	case MatcherTypeStartsWith:
+		return newStartsWithMatcher(matcherBase, c.Value)
+	default:
+		return nil, fmt.Errorf("unknown matcher method %q", c.Method)
+	}
+}
+
+type matcherBase struct {
+	name     string
+	priority int
+}
+
+func (m *matcherBase) Name() string {
+	return m.name
+}
+
+type regexMatcher struct {
+	matcherBase
+	regex *regexp.Regexp
+}
+
+func newRegexMatcher(matcherBase matcherBase, pattern string) (*regexMatcher, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("compiling regex %q: %w", pattern, err)
+	}
+	return &regexMatcher{
+		matcherBase: matcherBase,
+		regex:       re,
+	}, nil
+}
+
+func (m *regexMatcher) Test(s string) bool {
+	return m.regex.MatchString(s)
+}
+
+type startsWithMatcher struct {
+	matcherBase
+	prefix string
+}
+
+func newStartsWithMatcher(matcherBase matcherBase, prefix string) (*startsWithMatcher, error) {
+	return &startsWithMatcher{
+		matcherBase: matcherBase,
+		prefix:      prefix,
+	}, nil
+}
+
+func (m *startsWithMatcher) Test(s string) bool {
+	return strings.HasPrefix(s, m.prefix)
+}

--- a/processor/logtypedetectionprocessor/matcher.go
+++ b/processor/logtypedetectionprocessor/matcher.go
@@ -32,7 +32,7 @@ const (
 // MatcherConfig is the user-facing config, unmarshalled from YAML.
 type MatcherConfig struct {
 	Name     string      `mapstructure:"name"`
-	Priority int         `mapstructure:"priority"`
+	Priority *int        `mapstructure:"priority"`
 	Method   MatcherType `mapstructure:"method"`
 	Value    string      `mapstructure:"value"`
 }
@@ -48,7 +48,7 @@ func (c MatcherConfig) Validate() error {
 	if c.Name == "" {
 		return fmt.Errorf("name is required")
 	}
-	if c.Priority < 0 {
+	if c.Priority != nil && *c.Priority < 0 {
 		return fmt.Errorf("priority must be >= 0")
 	}
 
@@ -73,23 +73,19 @@ func (c MatcherConfig) Validate() error {
 
 // Build compiles the config into a Matcher.
 func (c MatcherConfig) Build() (Matcher, error) {
-	matcherBase := matcherBase{
-		name:     c.Name,
-		priority: c.Priority,
-	}
+	matcherBase := matcherBase{name: c.Name}
 	switch c.Method {
 	case MatcherTypeRegex:
 		return newRegexMatcher(matcherBase, c.Value)
 	case MatcherTypeStartsWith:
-		return newStartsWithMatcher(matcherBase, c.Value)
+		return newStartsWithMatcher(matcherBase, c.Value), nil
 	default:
 		return nil, fmt.Errorf("unknown matcher method %q", c.Method)
 	}
 }
 
 type matcherBase struct {
-	name     string
-	priority int
+	name string
 }
 
 func (m *matcherBase) Name() string {
@@ -121,11 +117,11 @@ type startsWithMatcher struct {
 	prefix string
 }
 
-func newStartsWithMatcher(matcherBase matcherBase, prefix string) (*startsWithMatcher, error) {
+func newStartsWithMatcher(matcherBase matcherBase, prefix string) *startsWithMatcher {
 	return &startsWithMatcher{
 		matcherBase: matcherBase,
 		prefix:      prefix,
-	}, nil
+	}
 }
 
 func (m *startsWithMatcher) Test(s string) bool {

--- a/processor/logtypedetectionprocessor/matcher.go
+++ b/processor/logtypedetectionprocessor/matcher.go
@@ -51,6 +51,9 @@ func (c MatcherConfig) Validate() error {
 
 	switch c.Method {
 	case MatcherTypeRegex:
+		if c.Value == "" {
+			return fmt.Errorf("regex matcher requires a value")
+		}
 		if _, err := regexp.Compile(c.Value); err != nil {
 			return fmt.Errorf("invalid regex %q: %w", c.Value, err)
 		}

--- a/processor/logtypedetectionprocessor/matcher_test.go
+++ b/processor/logtypedetectionprocessor/matcher_test.go
@@ -1,0 +1,77 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logtypedetectionprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegexMatcher(t *testing.T) {
+	testCases := []struct {
+		name        string
+		matcherType MatcherType
+		value       string
+		log         string
+		expected    bool
+	}{
+		{
+			name:        "regex matcher matches",
+			matcherType: MatcherTypeRegex,
+			value:       `^2026-08-13T10:00:00Z task completed in 42ms$`,
+			log:         "2026-08-13T10:00:00Z task completed in 42ms",
+			expected:    true,
+		},
+		{
+			name:        "regex matcher does not match",
+			matcherType: MatcherTypeRegex,
+			value:       `^2026-08-13T10:00:00Z task completed in 42ms$`,
+			log:         "2026-08-13T10:00:00Z task completed in 42ms, but not this one",
+			expected:    false,
+		},
+		{
+			name:        "starts with matcher matches",
+			matcherType: MatcherTypeStartsWith,
+			value:       "2026-08-13T10:00:00Z task completed in 42ms",
+			log:         "2026-08-13T10:00:00Z task completed in 42ms",
+			expected:    true,
+		},
+		{
+			name:        "starts with matcher does not match",
+			matcherType: MatcherTypeStartsWith,
+			value:       "2026-08-13T10:00:00Z task completed in 43ms",
+			log:         "2026-08-13T10:00:00Z task completed in 42ms, but not this one",
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var matcher Matcher
+			switch tc.matcherType {
+			case MatcherTypeRegex:
+				regexMatcher, err := newRegexMatcher(matcherBase{name: "test", priority: 0}, tc.value)
+				require.NoError(t, err)
+				matcher = regexMatcher
+			case MatcherTypeStartsWith:
+				startsWithMatcher, err := newStartsWithMatcher(matcherBase{name: "test", priority: 0}, tc.value)
+				require.NoError(t, err)
+				matcher = startsWithMatcher
+			}
+			require.Equal(t, tc.expected, matcher.Test(tc.log))
+		})
+	}
+}

--- a/processor/logtypedetectionprocessor/matcher_test.go
+++ b/processor/logtypedetectionprocessor/matcher_test.go
@@ -63,12 +63,11 @@ func TestRegexMatcher(t *testing.T) {
 			var matcher Matcher
 			switch tc.matcherType {
 			case MatcherTypeRegex:
-				regexMatcher, err := newRegexMatcher(matcherBase{name: "test", priority: 0}, tc.value)
+				regexMatcher, err := newRegexMatcher(matcherBase{name: "test"}, tc.value)
 				require.NoError(t, err)
 				matcher = regexMatcher
 			case MatcherTypeStartsWith:
-				startsWithMatcher, err := newStartsWithMatcher(matcherBase{name: "test", priority: 0}, tc.value)
-				require.NoError(t, err)
+				startsWithMatcher := newStartsWithMatcher(matcherBase{name: "test"}, tc.value)
 				matcher = startsWithMatcher
 			}
 			require.Equal(t, tc.expected, matcher.Test(tc.log))

--- a/processor/logtypedetectionprocessor/matcher_test.go
+++ b/processor/logtypedetectionprocessor/matcher_test.go
@@ -74,3 +74,70 @@ func TestRegexMatcher(t *testing.T) {
 		})
 	}
 }
+
+func TestMatcherConfigValidate(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config MatcherConfig
+		expect string
+	}{
+		{
+			name:   "valid regex",
+			config: MatcherConfig{Name: "a", Method: MatcherTypeRegex, Value: `^foo`},
+		},
+		{
+			name:   "valid starts with",
+			config: MatcherConfig{Name: "a", Method: MatcherTypeStartsWith, Value: "foo"},
+		},
+		{
+			name:   "valid with zero priority",
+			config: MatcherConfig{Name: "a", Priority: new(0), Method: MatcherTypeStartsWith, Value: "foo"},
+		},
+		{
+			name:   "missing name",
+			config: MatcherConfig{Method: MatcherTypeStartsWith, Value: "foo"},
+			expect: "name is required",
+		},
+		{
+			name:   "negative priority",
+			config: MatcherConfig{Name: "a", Priority: new(-1), Method: MatcherTypeStartsWith, Value: "foo"},
+			expect: "priority must be >= 0",
+		},
+		{
+			name:   "regex missing value",
+			config: MatcherConfig{Name: "a", Method: MatcherTypeRegex},
+			expect: "regex matcher requires a value",
+		},
+		{
+			name:   "invalid regex",
+			config: MatcherConfig{Name: "a", Method: MatcherTypeRegex, Value: "("},
+			expect: `invalid regex "("`,
+		},
+		{
+			name:   "starts with missing value",
+			config: MatcherConfig{Name: "a", Method: MatcherTypeStartsWith},
+			expect: "starts with matcher requires a value",
+		},
+		{
+			name:   "unknown method",
+			config: MatcherConfig{Name: "a", Method: "contains", Value: "foo"},
+			expect: `unknown matcher method "contains"`,
+		},
+		{
+			name:   "empty method",
+			config: MatcherConfig{Name: "a", Value: "foo"},
+			expect: `unknown matcher method ""`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.Validate()
+			if tc.expect == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.expect)
+		})
+	}
+}

--- a/processor/logtypedetectionprocessor/metadata.yaml
+++ b/processor/logtypedetectionprocessor/metadata.yaml
@@ -8,37 +8,43 @@ status:
   codeowners:
     active: [observIQ/ai]
 
+attributes:
+  log_type:
+    description: The log type that matched.
+    type: string
+
 telemetry:
   metrics:
-    log_type_detection_matches:
+    processor_log_type_detection_attempts:
       enabled: true
-      description: "Number of log type detection matches, one per log type match."
-      stability: alpha
-      unit: "{match}"
-      sum:
-        value_type: int
-        monotonic: true
-    log_type_detection_runs:
-      enabled: true
-      description: "Number of log type detections run, one per newly seen log structure."
+      description: "Number of log type detections attempted, one per newly seen log structure."
       stability: alpha
       unit: "{detection}"
       sum:
         value_type: int
         monotonic: true
-    log_type_detection_unknown:
+    processor_log_type_detection_attempts_matched:
       enabled: true
-      description: "Number of logs with no detected log type."
+      description: "Number of log type detection attempts that matched, one per newly seen log structure."
       stability: alpha
-      unit: "{log}"
+      unit: "{detection}"
       sum:
         value_type: int
         monotonic: true
-    log_types:
+    processor_log_type_detection_logs_classified:
       enabled: true
-      description: "The number of hashes with a detected log type."
+      description: "Number of log records assigned a log type."
       stability: alpha
-      unit: "{type}"
+      unit: "{log}"
+      attributes: [log_type]
+      sum:
+        value_type: int
+        monotonic: true
+    processor_log_type_detection_logs_unclassified:
+      enabled: true
+      description: "Number of log records with no detected log type."
+      stability: alpha
+      unit: "{log}"
       sum:
         value_type: int
         monotonic: true

--- a/processor/logtypedetectionprocessor/metadata.yaml
+++ b/processor/logtypedetectionprocessor/metadata.yaml
@@ -10,11 +10,27 @@ status:
 
 telemetry:
   metrics:
+    log_type_detection_matches:
+      enabled: true
+      description: "Number of log type detection matches, one per log type match."
+      stability: alpha
+      unit: "{match}"
+      sum:
+        value_type: int
+        monotonic: true
     log_type_detection_runs:
       enabled: true
       description: "Number of log type detections run, one per newly seen log structure."
       stability: alpha
       unit: "{detection}"
+      sum:
+        value_type: int
+        monotonic: true
+    log_types:
+      enabled: true
+      description: "The number of hashes with a detected log type."
+      stability: alpha
+      unit: "{type}"
       sum:
         value_type: int
         monotonic: true

--- a/processor/logtypedetectionprocessor/metadata.yaml
+++ b/processor/logtypedetectionprocessor/metadata.yaml
@@ -26,6 +26,14 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
+    log_type_detection_unknown:
+      enabled: true
+      description: "Number of logs with no detected log type."
+      stability: alpha
+      unit: "{log}"
+      sum:
+        value_type: int
+        monotonic: true
     log_types:
       enabled: true
       description: "The number of hashes with a detected log type."

--- a/processor/logtypedetectionprocessor/processor.go
+++ b/processor/logtypedetectionprocessor/processor.go
@@ -16,6 +16,7 @@ package logtypedetectionprocessor
 
 import (
 	"context"
+	"math"
 	"sort"
 	"strconv"
 	"sync"
@@ -47,11 +48,13 @@ func newLogTypeDetectionProcessor(cfg *Config, telemetry *metadata.TelemetryBuil
 	}
 
 	if cfg.Matchers != nil {
-		sort.SliceStable(cfg.Matchers, func(i, j int) bool {
-			return cfg.Matchers[i].Priority < cfg.Matchers[j].Priority
+		matchers := make([]MatcherConfig, len(cfg.Matchers))
+		copy(matchers, cfg.Matchers)
+		sort.SliceStable(matchers, func(i, j int) bool {
+			return priorityRank(matchers[i].Priority) < priorityRank(matchers[j].Priority)
 		})
 
-		for _, m := range cfg.Matchers {
+		for _, m := range matchers {
 			matcher, err := m.Build()
 			if err != nil {
 				return nil, err
@@ -61,6 +64,14 @@ func newLogTypeDetectionProcessor(cfg *Config, telemetry *metadata.TelemetryBuil
 	}
 
 	return p, nil
+}
+
+// priorityRank orders unset priority (0) last.
+func priorityRank(priority int) int {
+	if priority == 0 {
+		return math.MaxInt
+	}
+	return priority
 }
 
 func (p *logTypeDetectionProcessor) start(_ context.Context, _ component.Host) error {

--- a/processor/logtypedetectionprocessor/processor.go
+++ b/processor/logtypedetectionprocessor/processor.go
@@ -81,7 +81,9 @@ func (p *logTypeDetectionProcessor) processLogs(ctx context.Context, ld plog.Log
 				logRecord := scopeLogs.LogRecords().At(k)
 				body := logRecord.Body().AsString()
 				logFingerprint := fingerprint.HashLog(body)
-				if logFingerprint <= 0 {
+				if logFingerprint == 0 {
+					p.telemetry.LogTypeDetectionUnknown.Add(ctx, 1)
+					logRecord.Attributes().PutStr(p.logTypeField, unknownLogType)
 					continue
 				}
 				if p.fingerprintField != "" {
@@ -106,10 +108,14 @@ func (p *logTypeDetectionProcessor) processLogs(ctx context.Context, ld plog.Log
 					}
 					logType = newLogType.(string)
 				}
-				if lt, ok := logType.(string); ok && lt != "" {
+				lt, _ := logType.(string)
+				if lt == "" {
+					lt = unknownLogType
+					p.telemetry.LogTypeDetectionUnknown.Add(ctx, 1)
+				} else {
 					p.telemetry.LogTypeDetectionMatches.Add(ctx, 1)
-					logRecord.Attributes().PutStr(p.logTypeField, lt)
 				}
+				logRecord.Attributes().PutStr(p.logTypeField, lt)
 			}
 		}
 	}

--- a/processor/logtypedetectionprocessor/processor.go
+++ b/processor/logtypedetectionprocessor/processor.go
@@ -25,6 +25,8 @@ import (
 	"github.com/observiq/bindplane-otel-contrib/processor/logtypedetectionprocessor/internal/metadata"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -66,12 +68,12 @@ func newLogTypeDetectionProcessor(cfg *Config, telemetry *metadata.TelemetryBuil
 	return p, nil
 }
 
-// priorityRank orders unset priority (0) last.
-func priorityRank(priority int) int {
-	if priority == 0 {
+// priorityRank orders unset priority last.
+func priorityRank(priority *int) int {
+	if priority == nil {
 		return math.MaxInt
 	}
-	return priority
+	return *priority
 }
 
 func (p *logTypeDetectionProcessor) start(_ context.Context, _ component.Host) error {
@@ -93,7 +95,7 @@ func (p *logTypeDetectionProcessor) processLogs(ctx context.Context, ld plog.Log
 				body := logRecord.Body().AsString()
 				logFingerprint := fingerprint.HashLog(body)
 				if logFingerprint == 0 {
-					p.telemetry.LogTypeDetectionUnknown.Add(ctx, 1)
+					p.telemetry.ProcessorLogTypeDetectionLogsUnclassified.Add(ctx, 1)
 					logRecord.Attributes().PutStr(p.logTypeField, unknownLogType)
 					continue
 				}
@@ -122,9 +124,10 @@ func (p *logTypeDetectionProcessor) processLogs(ctx context.Context, ld plog.Log
 				lt, _ := logType.(string)
 				if lt == "" {
 					lt = unknownLogType
-					p.telemetry.LogTypeDetectionUnknown.Add(ctx, 1)
+					p.telemetry.ProcessorLogTypeDetectionLogsUnclassified.Add(ctx, 1)
 				} else {
-					p.telemetry.LogTypeDetectionMatches.Add(ctx, 1)
+					p.telemetry.ProcessorLogTypeDetectionLogsClassified.Add(ctx, 1,
+						metric.WithAttributes(attribute.String("log_type", lt)))
 				}
 				logRecord.Attributes().PutStr(p.logTypeField, lt)
 			}
@@ -134,10 +137,10 @@ func (p *logTypeDetectionProcessor) processLogs(ctx context.Context, ld plog.Log
 }
 
 func (p *logTypeDetectionProcessor) logType(ctx context.Context, logData string) string {
-	p.telemetry.LogTypeDetectionRuns.Add(ctx, 1)
+	p.telemetry.ProcessorLogTypeDetectionAttempts.Add(ctx, 1)
 	for _, m := range p.matchers {
 		if m.Test(logData) {
-			p.telemetry.LogTypes.Add(ctx, 1)
+			p.telemetry.ProcessorLogTypeDetectionAttemptsMatched.Add(ctx, 1)
 			return m.Name()
 		}
 	}

--- a/processor/logtypedetectionprocessor/processor.go
+++ b/processor/logtypedetectionprocessor/processor.go
@@ -17,7 +17,7 @@ package logtypedetectionprocessor
 import (
 	"context"
 	"math"
-	"sort"
+	"slices"
 	"strconv"
 	"sync"
 
@@ -52,8 +52,8 @@ func newLogTypeDetectionProcessor(cfg *Config, telemetry *metadata.TelemetryBuil
 	if cfg.Matchers != nil {
 		matchers := make([]MatcherConfig, len(cfg.Matchers))
 		copy(matchers, cfg.Matchers)
-		sort.SliceStable(matchers, func(i, j int) bool {
-			return priorityRank(matchers[i].Priority) < priorityRank(matchers[j].Priority)
+		slices.SortStableFunc(matchers, func(i, j MatcherConfig) int {
+			return priorityRank(i.Priority) - priorityRank(j.Priority)
 		})
 
 		for _, m := range matchers {

--- a/processor/logtypedetectionprocessor/processor.go
+++ b/processor/logtypedetectionprocessor/processor.go
@@ -16,6 +16,7 @@ package logtypedetectionprocessor
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"sync"
 
@@ -27,18 +28,39 @@ import (
 )
 
 type logTypeDetectionProcessor struct {
-	cfg            *Config
 	logTypes       sync.Map
 	detectionGroup singleflight.Group
+
+	logTypeField     string
+	fingerprintField string
+
+	matchers []Matcher
 
 	telemetry *metadata.TelemetryBuilder
 }
 
-func newLogTypeDetectionProcessor(cfg *Config, telemetry *metadata.TelemetryBuilder) *logTypeDetectionProcessor {
-	return &logTypeDetectionProcessor{
-		cfg:       cfg,
-		telemetry: telemetry,
+func newLogTypeDetectionProcessor(cfg *Config, telemetry *metadata.TelemetryBuilder) (*logTypeDetectionProcessor, error) {
+	p := &logTypeDetectionProcessor{
+		telemetry:        telemetry,
+		logTypeField:     cfg.LogTypeField,
+		fingerprintField: cfg.FingerprintField,
 	}
+
+	if cfg.Matchers != nil {
+		sort.SliceStable(cfg.Matchers, func(i, j int) bool {
+			return cfg.Matchers[i].Priority < cfg.Matchers[j].Priority
+		})
+
+		for _, m := range cfg.Matchers {
+			matcher, err := m.Build()
+			if err != nil {
+				return nil, err
+			}
+			p.matchers = append(p.matchers, matcher)
+		}
+	}
+
+	return p, nil
 }
 
 func (p *logTypeDetectionProcessor) start(_ context.Context, _ component.Host) error {
@@ -62,6 +84,9 @@ func (p *logTypeDetectionProcessor) processLogs(ctx context.Context, ld plog.Log
 				if logFingerprint <= 0 {
 					continue
 				}
+				if p.fingerprintField != "" {
+					logRecord.Attributes().PutStr(p.fingerprintField, strconv.FormatUint(logFingerprint, 16))
+				}
 				logType, ok := p.logTypes.Load(logFingerprint)
 				if !ok {
 					newLogType, err, _ := p.detectionGroup.Do(
@@ -81,9 +106,9 @@ func (p *logTypeDetectionProcessor) processLogs(ctx context.Context, ld plog.Log
 					}
 					logType = newLogType.(string)
 				}
-				logRecord.Attributes().PutStr("fingerprint", strconv.FormatUint(logFingerprint, 16))
 				if lt, ok := logType.(string); ok && lt != "" {
-					logRecord.Attributes().PutStr("logType", lt)
+					p.telemetry.LogTypeDetectionMatches.Add(ctx, 1)
+					logRecord.Attributes().PutStr(p.logTypeField, lt)
 				}
 			}
 		}
@@ -91,7 +116,13 @@ func (p *logTypeDetectionProcessor) processLogs(ctx context.Context, ld plog.Log
 	return ld, nil
 }
 
-func (p *logTypeDetectionProcessor) logType(ctx context.Context, _ string) string {
+func (p *logTypeDetectionProcessor) logType(ctx context.Context, logData string) string {
 	p.telemetry.LogTypeDetectionRuns.Add(ctx, 1)
+	for _, m := range p.matchers {
+		if m.Test(logData) {
+			p.telemetry.LogTypes.Add(ctx, 1)
+			return m.Name()
+		}
+	}
 	return ""
 }

--- a/processor/logtypedetectionprocessor/processor_test.go
+++ b/processor/logtypedetectionprocessor/processor_test.go
@@ -164,9 +164,9 @@ func TestPriorityOfMatchers(t *testing.T) {
 
 	config := createDefaultConfig().(*Config)
 	config.Matchers = []MatcherConfig{
-		{Name: "priority-10", Priority: 10, Value: `test`, Method: MatcherTypeStartsWith},
-		{Name: "priority-1", Priority: 1, Value: `test`, Method: MatcherTypeStartsWith},
-		{Name: "priority-2", Priority: 2, Value: `test`, Method: MatcherTypeStartsWith},
+		{Name: "priority-10", Priority: 10, Value: `{"a"`, Method: MatcherTypeStartsWith},
+		{Name: "priority-1", Priority: 1, Value: `{"a"`, Method: MatcherTypeStartsWith},
+		{Name: "priority-2", Priority: 2, Value: `{"a"`, Method: MatcherTypeStartsWith},
 	}
 	p, err := newLogTypeDetectionProcessor(config, tb)
 	require.NoError(t, err)
@@ -177,9 +177,38 @@ func TestPriorityOfMatchers(t *testing.T) {
 	records := out.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
 	require.Len(t, config.Matchers, len(p.matchers))
 
-	for i := 0; i < records.Len(); i++ {
-		if record, ok := records.At(i).Attributes().Get(defaultLogTypeField); ok {
-			require.Equal(t, "priority-1", record.AsString())
-		}
+	require.Equal(t, 1, records.Len())
+	logType, ok := records.At(0).Attributes().Get(defaultLogTypeField)
+	require.True(t, ok)
+	require.Equal(t, "priority-1", logType.AsString())
+}
+
+func TestUnknownLogType(t *testing.T) {
+	tel := componenttest.NewTelemetry()
+	t.Cleanup(func() { require.NoError(t, tel.Shutdown(context.Background())) })
+
+	tb, err := metadata.NewTelemetryBuilder(metadatatest.NewSettings(tel).TelemetrySettings)
+	require.NoError(t, err)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Matchers = []MatcherConfig{{Name: "json_a", Method: MatcherTypeStartsWith, Value: `{"a"`}}
+	p, err := newLogTypeDetectionProcessor(cfg, tb)
+	require.NoError(t, err)
+
+	out, err := p.processLogs(context.Background(), logsFromBodies(`{"a":1}`, `{"z":1}`, "plain text line"))
+	require.NoError(t, err)
+
+	records := out.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	for i, want := range []string{"json_a", unknownLogType, unknownLogType} {
+		got, ok := records.At(i).Attributes().Get(defaultLogTypeField)
+		require.True(t, ok, "record %d has no log type", i)
+		require.Equal(t, want, got.Str())
 	}
+
+	metadatatest.AssertEqualLogTypeDetectionUnknown(t, tel,
+		[]metricdata.DataPoint[int64]{{Value: 2}},
+		metricdatatest.IgnoreTimestamp())
+	metadatatest.AssertEqualLogTypeDetectionMatches(t, tel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
 }

--- a/processor/logtypedetectionprocessor/processor_test.go
+++ b/processor/logtypedetectionprocessor/processor_test.go
@@ -156,8 +156,6 @@ func TestProcessLogsConcurrentSameStructure(t *testing.T) {
 	require.Equal(t, int64(1), runs, "each fingerprint should only be detected once")
 }
 
-func intPtr(i int) *int { return &i }
-
 func TestPriorityOfMatchers(t *testing.T) {
 	tel := componenttest.NewTelemetry()
 	t.Cleanup(func() { require.NoError(t, tel.Shutdown(context.Background())) })
@@ -168,10 +166,10 @@ func TestPriorityOfMatchers(t *testing.T) {
 	config := createDefaultConfig().(*Config)
 	config.Matchers = []MatcherConfig{
 		{Name: "priority-unset", Value: `{"a"`, Method: MatcherTypeStartsWith},
-		{Name: "priority-10", Priority: intPtr(10), Value: `{"a"`, Method: MatcherTypeStartsWith},
-		{Name: "priority-1", Priority: intPtr(1), Value: `{"a"`, Method: MatcherTypeStartsWith},
-		{Name: "priority-0", Priority: intPtr(0), Value: `{"a"`, Method: MatcherTypeStartsWith},
-		{Name: "priority-2", Priority: intPtr(2), Value: `{"a"`, Method: MatcherTypeStartsWith},
+		{Name: "priority-10", Priority: new(10), Value: `{"a"`, Method: MatcherTypeStartsWith},
+		{Name: "priority-1", Priority: new(1), Value: `{"a"`, Method: MatcherTypeStartsWith},
+		{Name: "priority-0", Priority: new(0), Value: `{"a"`, Method: MatcherTypeStartsWith},
+		{Name: "priority-2", Priority: new(2), Value: `{"a"`, Method: MatcherTypeStartsWith},
 	}
 	p, err := newLogTypeDetectionProcessor(config, tb)
 	require.NoError(t, err)

--- a/processor/logtypedetectionprocessor/processor_test.go
+++ b/processor/logtypedetectionprocessor/processor_test.go
@@ -195,7 +195,7 @@ func TestUnknownLogType(t *testing.T) {
 	p, err := newLogTypeDetectionProcessor(cfg, tb)
 	require.NoError(t, err)
 
-	out, err := p.processLogs(context.Background(), logsFromBodies(`{"a":1}`, `{"z":1}`, "plain text line"))
+	out, err := p.processLogs(context.Background(), logsFromBodies(`{"a":1,"b":2}`, `{"z":1,"y":2}`, "plain text line"))
 	require.NoError(t, err)
 
 	records := out.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()

--- a/processor/logtypedetectionprocessor/processor_test.go
+++ b/processor/logtypedetectionprocessor/processor_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 )
@@ -96,11 +97,11 @@ func TestProcessLogs(t *testing.T) {
 			require.Equal(t, tc.fingerprints, withFingerprint)
 
 			if tc.expectedRuns == 0 {
-				_, err := tel.GetMetric("otelcol_log_type_detection_runs")
+				_, err := tel.GetMetric("otelcol_processor_log_type_detection_attempts")
 				require.Error(t, err)
 				return
 			}
-			metadatatest.AssertEqualLogTypeDetectionRuns(t, tel,
+			metadatatest.AssertEqualProcessorLogTypeDetectionAttempts(t, tel,
 				[]metricdata.DataPoint[int64]{{Value: tc.expectedRuns}},
 				metricdatatest.IgnoreTimestamp())
 		})
@@ -122,7 +123,7 @@ func TestProcessLogsCachesAcrossCalls(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	metadatatest.AssertEqualLogTypeDetectionRuns(t, tel,
+	metadatatest.AssertEqualProcessorLogTypeDetectionAttempts(t, tel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 }
@@ -149,11 +150,13 @@ func TestProcessLogsConcurrentSameStructure(t *testing.T) {
 	close(start)
 	wg.Wait()
 
-	got, err := tel.GetMetric("otelcol_log_type_detection_runs")
+	got, err := tel.GetMetric("otelcol_processor_log_type_detection_attempts")
 	require.NoError(t, err)
 	runs := got.Data.(metricdata.Sum[int64]).DataPoints[0].Value
 	require.Equal(t, int64(1), runs, "each fingerprint should only be detected once")
 }
+
+func intPtr(i int) *int { return &i }
 
 func TestPriorityOfMatchers(t *testing.T) {
 	tel := componenttest.NewTelemetry()
@@ -164,9 +167,11 @@ func TestPriorityOfMatchers(t *testing.T) {
 
 	config := createDefaultConfig().(*Config)
 	config.Matchers = []MatcherConfig{
-		{Name: "priority-10", Priority: 10, Value: `{"a"`, Method: MatcherTypeStartsWith},
-		{Name: "priority-1", Priority: 1, Value: `{"a"`, Method: MatcherTypeStartsWith},
-		{Name: "priority-2", Priority: 2, Value: `{"a"`, Method: MatcherTypeStartsWith},
+		{Name: "priority-unset", Value: `{"a"`, Method: MatcherTypeStartsWith},
+		{Name: "priority-10", Priority: intPtr(10), Value: `{"a"`, Method: MatcherTypeStartsWith},
+		{Name: "priority-1", Priority: intPtr(1), Value: `{"a"`, Method: MatcherTypeStartsWith},
+		{Name: "priority-0", Priority: intPtr(0), Value: `{"a"`, Method: MatcherTypeStartsWith},
+		{Name: "priority-2", Priority: intPtr(2), Value: `{"a"`, Method: MatcherTypeStartsWith},
 	}
 	p, err := newLogTypeDetectionProcessor(config, tb)
 	require.NoError(t, err)
@@ -180,7 +185,7 @@ func TestPriorityOfMatchers(t *testing.T) {
 	require.Equal(t, 1, records.Len())
 	logType, ok := records.At(0).Attributes().Get(defaultLogTypeField)
 	require.True(t, ok)
-	require.Equal(t, "priority-1", logType.AsString())
+	require.Equal(t, "priority-0", logType.AsString())
 }
 
 func TestUnknownLogType(t *testing.T) {
@@ -205,10 +210,13 @@ func TestUnknownLogType(t *testing.T) {
 		require.Equal(t, want, got.Str())
 	}
 
-	metadatatest.AssertEqualLogTypeDetectionUnknown(t, tel,
+	metadatatest.AssertEqualProcessorLogTypeDetectionLogsUnclassified(t, tel,
 		[]metricdata.DataPoint[int64]{{Value: 2}},
 		metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualLogTypeDetectionMatches(t, tel,
-		[]metricdata.DataPoint[int64]{{Value: 1}},
+	metadatatest.AssertEqualProcessorLogTypeDetectionLogsClassified(t, tel,
+		[]metricdata.DataPoint[int64]{{
+			Value:      1,
+			Attributes: attribute.NewSet(attribute.String("log_type", "json_a")),
+		}},
 		metricdatatest.IgnoreTimestamp())
 }

--- a/processor/logtypedetectionprocessor/processor_test.go
+++ b/processor/logtypedetectionprocessor/processor_test.go
@@ -78,7 +78,8 @@ func TestProcessLogs(t *testing.T) {
 			tb, err := metadata.NewTelemetryBuilder(metadatatest.NewSettings(tel).TelemetrySettings)
 			require.NoError(t, err)
 
-			p := newLogTypeDetectionProcessor(createDefaultConfig().(*Config), tb)
+			p, err := newLogTypeDetectionProcessor(createDefaultConfig().(*Config), tb)
+			require.NoError(t, err)
 
 			out, err := p.processLogs(context.Background(), logsFromBodies(tc.bodies...))
 			require.NoError(t, err)
@@ -113,7 +114,8 @@ func TestProcessLogsCachesAcrossCalls(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(metadatatest.NewSettings(tel).TelemetrySettings)
 	require.NoError(t, err)
 
-	p := newLogTypeDetectionProcessor(createDefaultConfig().(*Config), tb)
+	p, err := newLogTypeDetectionProcessor(createDefaultConfig().(*Config), tb)
+	require.NoError(t, err)
 
 	for range 3 {
 		_, err := p.processLogs(context.Background(), logsFromBodies(`{"alpha":1}`))
@@ -132,7 +134,8 @@ func TestProcessLogsConcurrentSameStructure(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(metadatatest.NewSettings(tel).TelemetrySettings)
 	require.NoError(t, err)
 
-	p := newLogTypeDetectionProcessor(createDefaultConfig().(*Config), tb)
+	p, err := newLogTypeDetectionProcessor(createDefaultConfig().(*Config), tb)
+	require.NoError(t, err)
 
 	start := make(chan struct{})
 	var wg sync.WaitGroup
@@ -150,4 +153,33 @@ func TestProcessLogsConcurrentSameStructure(t *testing.T) {
 	require.NoError(t, err)
 	runs := got.Data.(metricdata.Sum[int64]).DataPoints[0].Value
 	require.Equal(t, int64(1), runs, "each fingerprint should only be detected once")
+}
+
+func TestPriorityOfMatchers(t *testing.T) {
+	tel := componenttest.NewTelemetry()
+	t.Cleanup(func() { require.NoError(t, tel.Shutdown(context.Background())) })
+
+	tb, err := metadata.NewTelemetryBuilder(metadatatest.NewSettings(tel).TelemetrySettings)
+	require.NoError(t, err)
+
+	config := createDefaultConfig().(*Config)
+	config.Matchers = []MatcherConfig{
+		{Name: "priority-10", Priority: 10, Value: `test`, Method: MatcherTypeStartsWith},
+		{Name: "priority-1", Priority: 1, Value: `test`, Method: MatcherTypeStartsWith},
+		{Name: "priority-2", Priority: 2, Value: `test`, Method: MatcherTypeStartsWith},
+	}
+	p, err := newLogTypeDetectionProcessor(config, tb)
+	require.NoError(t, err)
+
+	out, err := p.processLogs(context.Background(), logsFromBodies(`{"a":1,"b":"x"}`))
+	require.NoError(t, err)
+
+	records := out.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	require.Len(t, config.Matchers, len(p.matchers))
+
+	for i := 0; i < records.Len(); i++ {
+		if record, ok := records.At(i).Attributes().Get(defaultLogTypeField); ok {
+			require.Equal(t, "priority-1", record.AsString())
+		}
+	}
 }

--- a/processor/logtypedetectionprocessor/testdata/example-configs/basic.yaml
+++ b/processor/logtypedetectionprocessor/testdata/example-configs/basic.yaml
@@ -1,0 +1,8 @@
+logtypedetectionprocessor:
+  fingerprint_field: fingerprint
+  log_type_field: log_type
+  matchers:
+    - name: win_event_log
+      method: regex
+      priority: 1
+      value: ^\s*(?:<\?xml[^>]*\?>\s*)?<Event\b[^>]*\bxmlns="http://schemas\.microsoft\.com/win/2004/08/events/event"[^>]*>

--- a/processor/logtypedetectionprocessor/testdata/example-configs/basic.yaml
+++ b/processor/logtypedetectionprocessor/testdata/example-configs/basic.yaml
@@ -1,8 +1,9 @@
-logtypedetectionprocessor:
-  fingerprint_field: fingerprint
-  log_type_field: log_type
-  matchers:
-    - name: win_event_log
-      method: regex
-      priority: 1
-      value: ^\s*(?:<\?xml[^>]*\?>\s*)?<Event\b[^>]*\bxmlns="http://schemas\.microsoft\.com/win/2004/08/events/event"[^>]*>
+processors:
+  log_type_detection:
+    fingerprint_field: fingerprint
+    log_type_field: log_type
+    matchers:
+      - name: win_event_log
+        method: regex
+        priority: 1
+        value: (?s)^\s*(?:<\?xml[^>]*\?>\s*)?<Event\b[^>]*>\s*<System>.*?<Provider\b[^>]*\bGuid=.*?<EventRecordID>


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Adds the matcher interface into the log type detection processor. Matchers have a priority attached to them and get run in that order. There are 2 matcher types to start
- regex
- starts with

A few additional notes:
- Log types that do not match any matchers get the `unknown` log type. There are metrics for tracking various different things. 
- The config also allows you to specify the fingerprint and log type attribute
- I will generate some documentation in a follow up PR.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed