### PR TITLE
fix: Add configurable size for page size pagination (PIPE-1442)

### DIFF
--- a/receiver/restapireceiver/README.md
+++ b/receiver/restapireceiver/README.md
@@ -213,6 +213,7 @@ from a `request_body` template — see [Request Body Templating](#request-body-t
 | --------------------------------------------- | ------ | ------- | -------- | ------------------------------------------------------- |
 | `pagination.page_size.page_num_field_name`    | string |         | `false`  | Request parameter name for page number                    |
 | `pagination.page_size.page_size_field_name`   | string |         | `false`  | Request parameter name for page size                      |
+| `pagination.page_size.page_size`              | int    | `20`    | `false`  | Value sent for `page_size_field_name`. Also the expected page size for the "a full page means there may be more" heuristic, so it should match the page size the API actually returns. |
 | `pagination.page_size.starting_page`          | int    | `1`     | `false`  | Starting page number                                    |
 | `pagination.page_size.total_pages_field_name` | string |         | `false`  | Name of the field or header containing total page count |
 
@@ -740,12 +741,12 @@ The checkpoint includes:
 - Current pagination state (offset/page number/timestamp depending on mode)
 - A config fingerprint used to detect when the receiver configuration has changed
 
-### Pagination limit and checkpoints
+### Page size and checkpoints
 
-`pagination.offset_limit.limit` is a throughput knob rather than part of the query, so
-changing it does **not** discard a stored checkpoint. The configured value is re-applied over
-the one in the checkpoint on startup, so a limit change takes effect on the next poll while
-the cursor or offset already reached is preserved.
+`pagination.offset_limit.limit` and `pagination.page_size.page_size` are throughput knobs
+rather than part of the query, so changing either does **not** discard a stored checkpoint.
+The configured value is re-applied over the one in the checkpoint on startup, so the change
+takes effect on the next poll while the cursor, offset, or page already reached is preserved.
 
 ### Config change detection
 

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -434,8 +434,13 @@ type PageSizePagination struct {
 	// StartingPage is the starting page number.
 	StartingPage int `mapstructure:"starting_page"`
 
-	// PageSizeFieldName is the name of the query parameter for page size.
+	// PageSizeFieldName is the name of the request parameter for page size.
 	PageSizeFieldName string `mapstructure:"page_size_field_name"`
+
+	// PageSize is the value sent for PageSizeFieldName, and the expected page
+	// size for the "a full page means there may be more" heuristic in
+	// parsePageSizeResponse — so it should match what the API actually returns.
+	PageSize int `mapstructure:"page_size"`
 
 	// TotalPagesFieldName is the name of the field in the response that contains the total page count.
 	TotalPagesFieldName string `mapstructure:"total_pages_field_name"`
@@ -688,6 +693,10 @@ func (c *Config) Validate() error {
 
 	if c.Pagination.OffsetLimit.Limit < 0 {
 		return fmt.Errorf("limit must be greater than or equal to 0")
+	}
+
+	if c.Pagination.PageSize.PageSize < 0 {
+		return fmt.Errorf("page_size must be greater than or equal to 0")
 	}
 
 	// Validate start_time_value format if provided

--- a/receiver/restapireceiver/config_test.go
+++ b/receiver/restapireceiver/config_test.go
@@ -1405,6 +1405,38 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: "limit must be greater than or equal to 0",
 		},
 		{
+			name: "negative page_size",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeNone,
+				Pagination: PaginationConfig{
+					Mode: paginationModePageSize,
+					PageSize: PageSizePagination{
+						PageNumFieldName:  "page",
+						PageSizeFieldName: "size",
+						PageSize:          -1,
+					},
+				},
+			},
+			expectedErr: "page_size must be greater than or equal to 0",
+		},
+		{
+			name: "zero page_size is accepted and defaults",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeNone,
+				Pagination: PaginationConfig{
+					Mode: paginationModePageSize,
+					PageSize: PageSizePagination{
+						PageNumFieldName:  "page",
+						PageSizeFieldName: "size",
+						PageSize:          0,
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
 			name: "epoch start_time_value with a leading plus",
 			config: &Config{
 				URL:                "https://api.example.com/data",

--- a/receiver/restapireceiver/pagination.go
+++ b/receiver/restapireceiver/pagination.go
@@ -89,9 +89,10 @@ func newPaginationState(cfg *Config) *paginationState {
 		} else {
 			state.CurrentPage = cfg.Pagination.PageSize.StartingPage
 		}
-		if cfg.Pagination.PageSize.PageSizeFieldName != "" {
-			// Use a default page size if not specified
-			state.PageSize = 20
+		// Zero means unset: fall back to the default rather than disable paging.
+		state.PageSize = 20
+		if cfg.Pagination.PageSize.PageSize > 0 {
+			state.PageSize = cfg.Pagination.PageSize.PageSize
 		}
 
 	case paginationModeTimestamp:

--- a/receiver/restapireceiver/pagination_test.go
+++ b/receiver/restapireceiver/pagination_test.go
@@ -17,6 +17,7 @@ package restapireceiver
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -1901,4 +1902,40 @@ func TestNewRequestBodyData(t *testing.T) {
 		state.PagesFetched = 1
 		require.Equal(t, requestStartTime(cfg, state), newRequestBodyData(cfg, state).StartTime)
 	})
+}
+
+func TestNewPaginationState_PageSize_ConfiguredPageSize(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pageSize int
+		expected int
+	}{
+		{name: "unset falls back to the historical default", pageSize: 0, expected: 20},
+		{name: "configured page size is used", pageSize: 100, expected: 100},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Pagination: PaginationConfig{
+					Mode: paginationModePageSize,
+					PageSize: PageSizePagination{
+						PageNumFieldName:  "page",
+						PageSizeFieldName: "size",
+						StartingPage:      1,
+						PageSize:          tc.pageSize,
+					},
+				},
+			}
+			state := newPaginationState(cfg)
+			require.Equal(t, tc.expected, state.PageSize)
+
+			// The value sent and the full-page threshold are the same variable.
+			require.Equal(t, strconv.Itoa(tc.expected), buildPaginationParams(cfg, state).Get("size"))
+			full := make([]map[string]any, tc.expected)
+			more, err := parsePageSizeResponse(cfg, map[string]any{}, full, state)
+			require.NoError(t, err)
+			require.True(t, more, "a full page should report more pages")
+		})
+	}
 }

--- a/receiver/restapireceiver/receiver.go
+++ b/receiver/restapireceiver/receiver.go
@@ -158,6 +158,16 @@ func (b *baseReceiver) reconcileCheckpointWithConfig() {
 		}
 	}
 
+	if b.cfg.Pagination.Mode == paginationModePageSize {
+		configuredPageSize := newPaginationState(b.cfg).PageSize
+		if b.paginationState.PageSize != configuredPageSize {
+			b.logger.Info("applying configured page size over the value in the stored checkpoint",
+				zap.Int("checkpoint_page_size", b.paginationState.PageSize),
+				zap.Int("configured_page_size", configuredPageSize))
+			b.paginationState.PageSize = configuredPageSize
+		}
+	}
+
 	if b.cfg.Pagination.Mode == paginationModeTimestamp {
 		configState := newPaginationState(b.cfg)
 
@@ -250,7 +260,8 @@ func (b *baseReceiver) adjustPollInterval(result pollResult) {
 //   - Auth, headers, poll intervals, storage ID, response format, metrics config.
 //   - method — changes how the same values are transmitted, not what is
 //     fetched; same rationale as the param names.
-//   - pagination.offset_limit.limit — a throughput knob, like page_size.
+//   - pagination.offset_limit.limit and pagination.page_size.page_size — throughput
+//     knobs, like page_limit.
 //
 // It DOES include request_body, which is query-defining.
 func configFingerprint(cfg *Config) string {

--- a/receiver/restapireceiver/receiver_test.go
+++ b/receiver/restapireceiver/receiver_test.go
@@ -1816,3 +1816,62 @@ func TestInitializePagination_ChangedLimitSurvivesCheckpointLoad(t *testing.T) {
 	require.Equal(t, "cursor-7", b.paginationState.CurrentOffsetToken,
 		"the stored cursor must be preserved")
 }
+
+// TestReconcileCheckpointWithConfig_AppliesConfiguredPageSize mirrors the limit
+// case: page_size is excluded from configFingerprint, so a change to it must be
+// re-applied over the value restored from a checkpoint.
+func TestReconcileCheckpointWithConfig_AppliesConfiguredPageSize(t *testing.T) {
+	testCases := []struct {
+		name       string
+		configured int
+		checkpoint int
+		expected   int
+	}{
+		{name: "raised page size takes effect", configured: 100, checkpoint: 20, expected: 100},
+		{name: "lowered page size takes effect", configured: 5, checkpoint: 20, expected: 5},
+		{name: "unset falls back to the default", configured: 0, checkpoint: 250, expected: 20},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				URL: "https://api.example.com/data",
+				Pagination: PaginationConfig{
+					Mode: paginationModePageSize,
+					PageSize: PageSizePagination{
+						PageNumFieldName:  "page",
+						PageSizeFieldName: "size",
+						PageSize:          tc.configured,
+					},
+				},
+			}
+			b := &baseReceiver{
+				cfg:             cfg,
+				logger:          zap.NewNop(),
+				paginationState: &paginationState{PageSize: tc.checkpoint, CurrentPage: 7},
+			}
+
+			b.reconcileCheckpointWithConfig()
+
+			require.Equal(t, tc.expected, b.paginationState.PageSize)
+			// Polling progress survives reconciliation.
+			require.Equal(t, 7, b.paginationState.CurrentPage)
+		})
+	}
+}
+
+func TestConfigFingerprint_PageSizeExcluded(t *testing.T) {
+	cfg := &Config{
+		URL: "https://api.example.com/data",
+		Pagination: PaginationConfig{
+			Mode:     paginationModePageSize,
+			PageSize: PageSizePagination{PageNumFieldName: "page", PageSizeFieldName: "size"},
+		},
+	}
+	base := configFingerprint(cfg)
+
+	changed := *cfg
+	changed.Pagination.PageSize.PageSize = 500
+	require.Equal(t, base, configFingerprint(&changed),
+		"page_size is a throughput knob and must not invalidate a checkpoint")
+}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Adds a `page_size` parameter for the Page/Size pagination mode. Not sure how this ended up this way, but the size was always set to 20 with no way to configure it for that specific pagination mode.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed