### PR TITLE
feat(chronicleexporter): add rbac_enabled_labels for Data RBAC ingestion labels

### DIFF
--- a/exporter/chronicleexporter/README.md
+++ b/exporter/chronicleexporter/README.md
@@ -49,6 +49,7 @@ The exporter can be configured using the following fields:
 | `namespace`                     | string            |                                        | `false`  | User-configured environment namespace to identify the data domain the logs originated from.                                                                                              |
 | `compression`                   | string            | `none`                                 | `false`  | The compression type to use when sending logs. Valid values are `none` and `gzip`.                                                                                                       |
 | `ingestion_labels`              | map[string]string |                                        | `false`  | Key-value pairs of labels to be applied to the logs when sent to Chronicle.                                                                                                              |
+| `rbac_enabled_labels`           | []string          |                                        | `false`  | Ingestion label keys that are eligible for Data RBAC. Labels not listed are sent with `rbac_enabled: false`. Only supported with the `https` protocol; rejected at startup with `gRPC`. |
 | `collect_agent_metrics`         | bool              | `true`                                 | `false`  | Enables collecting metrics about the agent's process and log ingestion metrics.                                                                                                          |
 | `metrics_interval`              | duration          | `5m`                                   | `false`  | The interval at which agent metrics are collected and sent. Only applies when `collect_agent_metrics` is `true`.                                                                         |
 | `batch_request_size_limit_grpc` | int               | `4000000`                              | `false`  | The maximum size, in bytes, allowed for a gRPC batch creation request.                                                                                                                   |
@@ -74,6 +75,14 @@ If the `attributes["chronicle_log_type"]` field is present in the log, its value
 If the `attributes["chronicle_namespace"]` field is present in the log, its value will be used in the payload instead of the `namespace` in the config.
 
 Any labels defined by key value pairs in a nested map at `attributes["chronicle_ingestion_label"]` are merged with the `ingestion_labels` in the config. When the same label key is set in both places, the value from the attribute takes precedence over that from the config.
+
+### Data RBAC
+
+Google SecOps can restrict access to ingested data based on ingestion labels, but only labels marked as RBAC-eligible at ingestion time are considered. List the label keys that should be eligible in `rbac_enabled_labels`; every other label is sent with `rbac_enabled: false`. The flag is matched by label key, so it also applies to labels supplied through `attributes["chronicle_ingestion_label"]`.
+
+Sending `rbac_enabled: true` is necessary but not sufficient. Data RBAC only takes effect once the SecOps tenant is set up for it: Google must enable ingestion-label based Data RBAC for the tenant (log-level ingestion labels are not generally available and are enabled per tenant), and an administrator must define the [Data RBAC scopes](https://cloud.google.com/chronicle/docs/administration/datarbac-overview) and assign the Restricted Data Access role to the affected users. Until then the flag is carried on the ingested logs but has no visible effect.
+
+This option is only supported with the `https` protocol (v1alpha, v1beta and v1). The legacy `gRPC` protocol has no equivalent field, so the exporter fails validation at startup if `rbac_enabled_labels` is set together with `protocol: gRPC`.
 
 ## Credentials
 
@@ -190,4 +199,20 @@ chronicle:
   ingestion_labels:
     env: dev
     zone: USA
+```
+
+### Configuration with Data RBAC Ingestion Labels
+
+```yaml
+chronicle:
+  protocol: https
+  location: us
+  project: my-project
+  creds_file_path: "/path/to/google/creds.json"
+  customer_id: "customer-123"
+  ingestion_labels:
+    env: dev
+    zone: USA
+  rbac_enabled_labels:
+    - zone
 ```

--- a/exporter/chronicleexporter/config.go
+++ b/exporter/chronicleexporter/config.go
@@ -78,6 +78,11 @@ type Config struct {
 	// IngestionLabels are the labels that will be attached to logs when sent to Chronicle.
 	IngestionLabels map[string]string `mapstructure:"ingestion_labels"`
 
+	// RBACEnabledLabels lists the ingestion label keys that are eligible for Data RBAC.
+	// Labels not listed here are sent with rbac_enabled=false. Only supported by the https
+	// protocol; Validate rejects it when the protocol is gRPC.
+	RBACEnabledLabels []string `mapstructure:"rbac_enabled_labels"`
+
 	// CollectAgentMetrics is a flag that determines whether or not to collect agent metrics.
 	CollectAgentMetrics bool `mapstructure:"collect_agent_metrics"`
 
@@ -181,6 +186,9 @@ func (cfg *Config) Validate() error {
 	}
 
 	if cfg.Protocol == protocolGRPC {
+		if len(cfg.RBACEnabledLabels) > 0 {
+			return errors.New("rbac_enabled_labels is only supported when protocol is https")
+		}
 		if cfg.BatchRequestSizeLimitGRPC <= 0 {
 			return errors.New("positive batch request size limit is required when protocol is grpc")
 		}

--- a/exporter/chronicleexporter/config_test.go
+++ b/exporter/chronicleexporter/config_test.go
@@ -243,6 +243,36 @@ func TestConfigValidate(t *testing.T) {
 			},
 			expectedErr: "positive HTTP response header timeout is required when protocol is https",
 		},
+		{
+			desc: "rbac_enabled_labels rejected with gRPC protocol",
+			config: &Config{
+				Creds:                     "creds_example",
+				LogType:                   "log_type_example",
+				Compression:               noCompression,
+				Protocol:                  protocolGRPC,
+				BatchRequestSizeLimitGRPC: defaultBatchRequestSizeLimitGRPC,
+				IngestionLabels:           map[string]string{"team": "blue"},
+				RBACEnabledLabels:         []string{"team"},
+			},
+			expectedErr: "rbac_enabled_labels is only supported when protocol is https",
+		},
+		{
+			desc: "rbac_enabled_labels accepted with https protocol",
+			config: &Config{
+				Creds:                     "creds_example",
+				LogType:                   "log_type_example",
+				Compression:               noCompression,
+				Protocol:                  protocolHTTPS,
+				Location:                  "us",
+				Endpoint:                  "chronicle.googleapis.com",
+				Project:                   "project_example",
+				BatchRequestSizeLimitHTTP: defaultBatchRequestSizeLimitHTTP,
+				HTTPResponseHeaderTimeout: defaultHTTPResponseHeaderTimeout,
+				IngestionLabels:           map[string]string{"team": "blue"},
+				RBACEnabledLabels:         []string{"team"},
+			},
+			expectedErr: "",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/exporter/chronicleexporter/http_exporter_test.go
+++ b/exporter/chronicleexporter/http_exporter_test.go
@@ -16,6 +16,7 @@ package chronicleexporter
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -1023,6 +1024,81 @@ func TestHTTPExporterTelemetry(t *testing.T) {
 				require.Error(t, err, "Metric should not exist when no bytes are counted")
 				require.Contains(t, err.Error(), "not found", "Error should indicate metric was not found")
 			}
+		})
+	}
+}
+
+// TestHTTPExporterRBACLabelsOnTheWire asserts the JSON body sent to the import
+// endpoint carries rbacEnabled only for the configured label keys.
+func TestHTTPExporterRBACLabelsOnTheWire(t *testing.T) {
+	secureTokenSource := tokenSource
+	defer func() { tokenSource = secureTokenSource }()
+	tokenSource = func(context.Context, *Config) (oauth2.TokenSource, error) {
+		return &emptyTokenSource{}, nil
+	}
+
+	var body []byte
+	srv := newMockHTTPServer(map[string]http.HandlerFunc{
+		"FAKE": func(w http.ResponseWriter, r *http.Request) {
+			var err error
+			body, err = io.ReadAll(r.Body)
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+		},
+	})
+	defer srv.srv.Close()
+
+	secureHTTPEndpoint := httpEndpoint
+	defer func() { httpEndpoint = secureHTTPEndpoint }()
+	httpEndpoint = func(_ *Config, logType string) string {
+		return fmt.Sprintf("%s/logTypes/%s/logs:import", srv.srv.URL, logType)
+	}
+
+	for _, apiVersion := range []string{apiVersionV1Alpha, apiVersionV1Beta, apiVersionV1} {
+		t.Run(apiVersion, func(t *testing.T) {
+			body = nil
+			f := NewFactory()
+			cfg := f.CreateDefaultConfig().(*Config)
+			cfg.Protocol = protocolHTTPS
+			cfg.Location = "us"
+			cfg.CustomerID = "00000000-1111-2222-3333-444444444444"
+			cfg.Project = "fake"
+			cfg.LogType = "FAKE"
+			cfg.APIVersion = apiVersion
+			cfg.IngestionLabels = map[string]string{"env": "prod", "team": "blue"}
+			cfg.RBACEnabledLabels = []string{"team"}
+			cfg.QueueBatchConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+			cfg.BackOffConfig.Enabled = false
+			require.NoError(t, cfg.Validate())
+
+			ctx := context.Background()
+			exp, err := f.CreateLogs(ctx, exportertest.NewNopSettings(typ), cfg)
+			require.NoError(t, err)
+			require.NoError(t, exp.Start(ctx, componenttest.NewNopHost()))
+			defer func() { require.NoError(t, exp.Shutdown(ctx)) }()
+
+			logs := plog.NewLogs()
+			logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("Test")
+			require.NoError(t, exp.ConsumeLogs(ctx, logs))
+
+			var req struct {
+				InlineSource struct {
+					Logs []struct {
+						Labels map[string]struct {
+							Value       string `json:"value"`
+							RbacEnabled bool   `json:"rbacEnabled"`
+						} `json:"labels"`
+					} `json:"logs"`
+				} `json:"inlineSource"`
+			}
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.Len(t, req.InlineSource.Logs, 1)
+			labels := req.InlineSource.Logs[0].Labels
+			require.Equal(t, "blue", labels["team"].Value)
+			require.True(t, labels["team"].RbacEnabled)
+			require.Equal(t, "prod", labels["env"].Value)
+			require.False(t, labels["env"].RbacEnabled)
+			require.Contains(t, string(body), `"rbacEnabled":true`)
 		})
 	}
 }

--- a/exporter/chronicleexporter/marshal.go
+++ b/exporter/chronicleexporter/marshal.go
@@ -93,6 +93,7 @@ type protoMarshaler struct {
 	collectorIDString string
 	telemetry         *metadata.TelemetryBuilder
 	logTypes          map[string]exists
+	rbacLabels        map[string]exists
 	logger            *zap.Logger
 }
 
@@ -101,9 +102,14 @@ func newProtoMarshaler(cfg Config, teleSettings component.TelemetrySettings, tel
 	if err != nil {
 		return nil, fmt.Errorf("parse customer ID: %w", err)
 	}
+	rbacLabels := make(map[string]exists, len(cfg.RBACEnabledLabels))
+	for _, key := range cfg.RBACEnabledLabels {
+		rbacLabels[key] = exists{}
+	}
 	return &protoMarshaler{
 		startTime:         time.Now(),
 		cfg:               cfg,
+		rbacLabels:        rbacLabels,
 		teleSettings:      teleSettings,
 		customerID:        customerID[:],
 		collectorID:       getCollectorID(cfg.LicenseType),
@@ -311,8 +317,10 @@ func (m *protoMarshaler) getHTTPIngestionLabels(logRecord plog.LogRecord) map[st
 	mergedLabels := m.aggregateIngestionLabels(logRecord)
 	labels := make(map[string]*api.Log_LogLabel, len(mergedLabels))
 	for k, v := range mergedLabels {
+		_, rbacEnabled := m.rbacLabels[k]
 		labels[k] = &api.Log_LogLabel{
-			Value: v,
+			Value:       v,
+			RbacEnabled: rbacEnabled,
 		}
 	}
 	return labels

--- a/exporter/chronicleexporter/marshal_test.go
+++ b/exporter/chronicleexporter/marshal_test.go
@@ -1530,6 +1530,161 @@ func TestProtoMarshaler_MarshalRawLogsForHTTP(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "RBAC enabled labels are flagged per key (v1alpha)",
+			cfg: Config{
+				CustomerID:      uuid.New().String(),
+				LogType:         "WINEVTLOG",
+				RawLogField:     "body",
+				OverrideLogType: false,
+				Protocol:        protocolHTTPS,
+				Project:         "test-project",
+				Location:        "us",
+				APIVersion:      "v1alpha",
+				IngestionLabels: map[string]string{
+					"env":  "prod",
+					"team": "blue",
+				},
+				RBACEnabledLabels:         []string{"team", "region", "unused"},
+				BatchRequestSizeLimitHTTP: 5242880,
+			},
+			logRecords: func() plog.Logs {
+				return mockLogs(mockLogRecord("Test log message", map[string]any{
+					`chronicle_ingestion_label["region"]`: "us-east1",
+					`chronicle_ingestion_label["env"]`:    "staging",
+				}))
+			},
+			expectations: func(t *testing.T, requests map[string][]*api.ImportLogsRequest) {
+				require.Len(t, requests, 1)
+				logs := requests["WINEVTLOG"][0].GetInlineSource().Logs
+				require.Len(t, logs, 1)
+				labels := logs[0].Labels
+				require.Len(t, labels, 3)
+				// config label not listed: value kept, rbac off
+				require.Equal(t, "staging", labels["env"].Value)
+				require.False(t, labels["env"].RbacEnabled)
+				// config label listed
+				require.Equal(t, "blue", labels["team"].Value)
+				require.True(t, labels["team"].RbacEnabled)
+				// attribute-sourced label listed: matched by key
+				require.Equal(t, "us-east1", labels["region"].Value)
+				require.True(t, labels["region"].RbacEnabled)
+				// listed key with no label present does not create a label
+				require.NotContains(t, labels, "unused")
+			},
+		},
+		{
+			name: "RBAC enabled labels are flagged per key (v1beta)",
+			cfg: Config{
+				CustomerID:      uuid.New().String(),
+				LogType:         "WINEVTLOG",
+				RawLogField:     "body",
+				OverrideLogType: false,
+				Protocol:        protocolHTTPS,
+				Project:         "test-project",
+				Location:        "us",
+				APIVersion:      "v1beta",
+				IngestionLabels: map[string]string{
+					"env":  "prod",
+					"team": "blue",
+				},
+				RBACEnabledLabels:         []string{"team", "region", "unused"},
+				BatchRequestSizeLimitHTTP: 5242880,
+			},
+			logRecords: func() plog.Logs {
+				return mockLogs(mockLogRecord("Test log message", map[string]any{
+					`chronicle_ingestion_label["region"]`: "us-east1",
+					`chronicle_ingestion_label["env"]`:    "staging",
+				}))
+			},
+			expectations: func(t *testing.T, requests map[string][]*api.ImportLogsRequest) {
+				require.Len(t, requests, 1)
+				logs := requests["WINEVTLOG"][0].GetInlineSource().Logs
+				require.Len(t, logs, 1)
+				labels := logs[0].Labels
+				require.Len(t, labels, 3)
+				// config label not listed: value kept, rbac off
+				require.Equal(t, "staging", labels["env"].Value)
+				require.False(t, labels["env"].RbacEnabled)
+				// config label listed
+				require.Equal(t, "blue", labels["team"].Value)
+				require.True(t, labels["team"].RbacEnabled)
+				// attribute-sourced label listed: matched by key
+				require.Equal(t, "us-east1", labels["region"].Value)
+				require.True(t, labels["region"].RbacEnabled)
+				// listed key with no label present does not create a label
+				require.NotContains(t, labels, "unused")
+			},
+		},
+		{
+			name: "RBAC enabled labels are flagged per key (v1)",
+			cfg: Config{
+				CustomerID:      uuid.New().String(),
+				LogType:         "WINEVTLOG",
+				RawLogField:     "body",
+				OverrideLogType: false,
+				Protocol:        protocolHTTPS,
+				Project:         "test-project",
+				Location:        "us",
+				APIVersion:      "v1",
+				IngestionLabels: map[string]string{
+					"env":  "prod",
+					"team": "blue",
+				},
+				RBACEnabledLabels:         []string{"team", "region", "unused"},
+				BatchRequestSizeLimitHTTP: 5242880,
+			},
+			logRecords: func() plog.Logs {
+				return mockLogs(mockLogRecord("Test log message", map[string]any{
+					`chronicle_ingestion_label["region"]`: "us-east1",
+					`chronicle_ingestion_label["env"]`:    "staging",
+				}))
+			},
+			expectations: func(t *testing.T, requests map[string][]*api.ImportLogsRequest) {
+				require.Len(t, requests, 1)
+				logs := requests["WINEVTLOG"][0].GetInlineSource().Logs
+				require.Len(t, logs, 1)
+				labels := logs[0].Labels
+				require.Len(t, labels, 3)
+				// config label not listed: value kept, rbac off
+				require.Equal(t, "staging", labels["env"].Value)
+				require.False(t, labels["env"].RbacEnabled)
+				// config label listed
+				require.Equal(t, "blue", labels["team"].Value)
+				require.True(t, labels["team"].RbacEnabled)
+				// attribute-sourced label listed: matched by key
+				require.Equal(t, "us-east1", labels["region"].Value)
+				require.True(t, labels["region"].RbacEnabled)
+				// listed key with no label present does not create a label
+				require.NotContains(t, labels, "unused")
+			},
+		},
+		{
+			name: "Labels default to rbac disabled when rbac_enabled_labels is unset",
+			cfg: Config{
+				CustomerID:      uuid.New().String(),
+				LogType:         "WINEVTLOG",
+				RawLogField:     "body",
+				OverrideLogType: false,
+				Protocol:        protocolHTTPS,
+				Project:         "test-project",
+				Location:        "us",
+				IngestionLabels: map[string]string{
+					"env": "prod",
+				},
+				BatchRequestSizeLimitHTTP: 5242880,
+			},
+			logRecords: func() plog.Logs {
+				return mockLogs(mockLogRecord("Test log message", nil))
+			},
+			expectations: func(t *testing.T, requests map[string][]*api.ImportLogsRequest) {
+				logs := requests["WINEVTLOG"][0].GetInlineSource().Logs
+				require.Len(t, logs, 1)
+				require.Len(t, logs[0].Labels, 1)
+				require.Equal(t, "prod", logs[0].Labels["env"].Value)
+				require.False(t, logs[0].Labels["env"].RbacEnabled)
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Proposed Change

Google SecOps only honors ingestion labels for Data RBAC when the label is sent with `rbac_enabled=true`. The https path (v1alpha, v1beta, v1) already carries `Log.LogLabel.rbac_enabled` in the proto but the exporter never set it, so customers using label-based Data RBAC saw no data.

Add `rbac_enabled_labels`, a list of ingestion label keys that should be marked RBAC-eligible. The existing `ingestion_labels` map is unchanged, so current configs keep working and every label defaults to `rbac_enabled=false`. Matching is by key, so labels supplied through the `chronicle_ingestion_label` attributes are flagged too. The legacy gRPC API has no equivalent field, so `Validate()` rejects `rbac_enabled_labels` when `protocol` is `gRPC` instead of silently ignoring it.

The README notes that `rbac_enabled` is necessary but not sufficient: the tenant still needs Google to enable ingestion-label Data RBAC, plus Data RBAC scopes and the Restricted Data Access role configured.

```yaml
chronicle:
  protocol: https
  ingestion_labels:
    env: dev
    zone: USA
  rbac_enabled_labels:
    - zone
```

Tests: marshaler cases for v1alpha/v1beta/v1 plus a default-off case, and an HTTP exporter test asserting the JSON body carries `"rbacEnabled":true` only for the listed keys. README updated. Bindplane destination side: observIQ/bindplane-op-enterprise#9996.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed

