### PR TITLE
feat(opampgateway): set the User-Agent header on upstream connections (FLEET-605)

### DIFF
--- a/extension/opampgateway/README.md
+++ b/extension/opampgateway/README.md
@@ -66,11 +66,34 @@ graph LR
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `server.endpoint` | string | *(required)* | WebSocket URL of the upstream OpAMP server. Must use `ws://` or `wss://` scheme. |
-| `server.headers` | map | *(none)* | HTTP headers sent on upstream connections (e.g. `Authorization`). |
+| `server.headers` | map | *(none)* | HTTP headers sent on upstream connections (e.g. `Authorization`). Setting `User-Agent` here overrides the default described below. |
 | `server.tls` | [TLS config](https://pkg.go.dev/go.opentelemetry.io/collector/config/configtls#ClientConfig) | *(none)* | TLS configuration for the upstream client connection. |
 | `server.connections` | int | `1` | Number of persistent WebSocket connections to maintain to the upstream server. |
 | `listener.endpoint` | string | `"0.0.0.0:0"` | Address the downstream server listens on for agent connections. |
 | `listener.tls` | [TLS config](https://pkg.go.dev/go.opentelemetry.io/collector/config/configtls#ServerConfig) | *(none)* | TLS configuration for the downstream server. |
+
+### User agent
+
+Upstream connections identify themselves with an [RFC 9110][rfc9110] product
+list naming the gateway, the collector distribution hosting it, and the
+platform:
+
+```
+opamp-gateway/v1.9.0 bindplane-otel-collector/v2.0.1-beta.3 (linux/amd64)
+```
+
+- `opamp-gateway/<version>` is the version of the `opampgateway` extension
+  module, read from the binary's build information. It is `unknown` for builds
+  that replace the module with a local directory, such as
+  `make build-collector`.
+- `<collector>/<version>` comes from the collector's `BuildInfo`, using the base
+  name of its command. It is omitted when the build information does not name
+  both. `BuildInfo.Description` is not used because it is prose rather than a
+  valid product token.
+
+Set `server.headers.User-Agent` to send a different value instead.
+
+[rfc9110]: https://www.rfc-editor.org/rfc/rfc9110#field.user-agent
 
 ### Example
 

--- a/extension/opampgateway/factory.go
+++ b/extension/opampgateway/factory.go
@@ -63,6 +63,7 @@ func createOpAMPGateway(ctx context.Context, cs extension.Settings, cfg componen
 		TLSConfig:            tlsConfig,
 		UpstreamConnections:  oCfg.Server.Connections,
 		OpAMPServer:          oCfg.Listener,
+		BuildInfo:            cs.BuildInfo,
 	}
 
 	gw := gateway.New(cs.Logger, settings, t)

--- a/extension/opampgateway/internal/gateway/client.go
+++ b/extension/opampgateway/internal/gateway/client.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/observiq/bindplane-otel-contrib/extension/opampgateway/internal/metadata"
+	"github.com/observiq/bindplane-otel-contrib/extension/opampgateway/internal/version"
 	"go.uber.org/zap"
 )
 
@@ -44,6 +45,7 @@ type client struct {
 	callbacks ConnectionCallbacks[*upstreamConnection]
 
 	headers          http.Header
+	userAgent        string
 	upstreamEndpoint string
 	connectionCount  int
 
@@ -68,6 +70,7 @@ func newClient(settings Settings, telemetry *metadata.TelemetryBuilder, callback
 		connectionAssignments: connectionAssignments,
 		callbacks:             callbacks,
 		headers:               settings.Headers,
+		userAgent:             version.UserAgent(settings.BuildInfo),
 		upstreamEndpoint:      settings.UpstreamOpAMPAddress,
 		connectionCount:       settings.UpstreamConnections,
 		clientConnectionsWg:   &sync.WaitGroup{},
@@ -96,8 +99,9 @@ func (c *client) startClientConnections(ctx context.Context) {
 		id := fmt.Sprintf("upstream-%d", i)
 
 		clientConnection := newUpstreamConnection(c.dialer, c.telemetry, upstreamConnectionSettings{
-			endpoint: c.upstreamEndpoint,
-			headers:  c.headers,
+			endpoint:  c.upstreamEndpoint,
+			headers:   c.headers,
+			userAgent: c.userAgent,
 		}, id, c.logger)
 
 		c.pool.add(clientConnection)

--- a/extension/opampgateway/internal/gateway/gateway.go
+++ b/extension/opampgateway/internal/gateway/gateway.go
@@ -49,6 +49,7 @@ type Settings struct {
 	UpstreamConnections  int
 	OpAMPServer          confighttp.ServerConfig
 	AuthTimeout          time.Duration
+	BuildInfo            component.BuildInfo
 }
 
 // Gateway is the core OpAMP gateway implementation that manages upstream and downstream

--- a/extension/opampgateway/internal/gateway/gateway_test.go
+++ b/extension/opampgateway/internal/gateway/gateway_test.go
@@ -29,6 +29,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -39,8 +40,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/observiq/bindplane-otel-contrib/extension/opampgateway/internal/metadata"
+	"github.com/observiq/bindplane-otel-contrib/extension/opampgateway/internal/version"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
@@ -168,6 +171,23 @@ func TestGatewayUpstreamConnectionAffinity(t *testing.T) {
 	// }
 }
 
+func TestGatewayUpstreamUserAgent(t *testing.T) {
+	t.Parallel()
+
+	h := newGatewayTestHarness(t, 2)
+
+	// the module version is "unknown" under test because the extension is the
+	// main module, but the collector product and platform come through.
+	expected := fmt.Sprintf("opamp-gateway/unknown test-collector/v1.2.3 (%s/%s)", runtime.GOOS, runtime.GOARCH)
+	require.Equal(t, map[string]string{
+		"upstream-0": expected,
+		"upstream-1": expected,
+	}, h.upstream.UserAgents())
+
+	// the value must match what the version package builds for the same build info
+	require.Equal(t, version.UserAgent(testBuildInfo), expected)
+}
+
 func TestGatewayRestartAfterShutdown(t *testing.T) {
 	t.Parallel()
 
@@ -286,6 +306,13 @@ func TestGatewayDoubleShutdown(t *testing.T) {
 // --------------------------------------------------------------------------------------
 // test harness
 
+// testBuildInfo stands in for the collector distribution hosting the gateway.
+var testBuildInfo = component.BuildInfo{
+	Command:     "test-collector",
+	Description: "Test Collector Distribution",
+	Version:     "v1.2.3",
+}
+
 type gatewayTestHarness struct {
 	t        *testing.T
 	ctx      context.Context
@@ -318,6 +345,7 @@ func newGatewayTestHarness(t *testing.T, upstreamConnections int) *gatewayTestHa
 		},
 		UpstreamConnections: upstreamConnections,
 		OpAMPServer:         confighttp.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: "127.0.0.1:0", Transport: confignet.TransportTypeTCP}},
+		BuildInfo:           testBuildInfo,
 	}
 
 	logger := zaptest.NewLogger(t)
@@ -395,8 +423,9 @@ type upstreamMessage struct {
 }
 
 type testUpstreamConnection struct {
-	id   string
-	conn *websocket.Conn
+	id        string
+	userAgent string
+	conn      *websocket.Conn
 }
 
 type testOpAMPServer struct {
@@ -489,6 +518,7 @@ func newTestOpAMPServerTLS(t *testing.T, certPEM, keyPEM string) *testOpAMPServe
 func (s *testOpAMPServer) handle(w http.ResponseWriter, r *http.Request) {
 	// extract the connection id from the request
 	id := r.Header.Get("X-Opamp-Gateway-Connection-Id")
+	userAgent := r.Header.Get("User-Agent")
 
 	conn, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -497,7 +527,7 @@ func (s *testOpAMPServer) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mu.Lock()
-	s.connections = append(s.connections, &testUpstreamConnection{id: id, conn: conn})
+	s.connections = append(s.connections, &testUpstreamConnection{id: id, userAgent: userAgent, conn: conn})
 	s.mu.Unlock()
 	s.connectionCount.Add(1)
 
@@ -671,6 +701,18 @@ func (s *testOpAMPServer) WaitForAgentMessage(t *testing.T, agentID string, time
 			t.Fatalf("timed out waiting for message for agent %s", agentID)
 		}
 	}
+}
+
+// UserAgents returns the User-Agent header of every open upstream connection,
+// keyed by connection id.
+func (s *testOpAMPServer) UserAgents() map[string]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	agents := make(map[string]string, len(s.connections))
+	for _, c := range s.connections {
+		agents[c.id] = c.userAgent
+	}
+	return agents
 }
 
 func (s *testOpAMPServer) removeConnection(id string) {
@@ -1511,6 +1553,7 @@ func newGatewayTestHarnessWithCapabilities(t *testing.T, upstreamConnections int
 		},
 		UpstreamConnections: upstreamConnections,
 		OpAMPServer:         confighttp.ServerConfig{NetAddr: confignet.AddrConfig{Endpoint: "127.0.0.1:0", Transport: confignet.TransportTypeTCP}},
+		BuildInfo:           testBuildInfo,
 	}
 
 	logger := zaptest.NewLogger(t)

--- a/extension/opampgateway/internal/gateway/upstream_connection.go
+++ b/extension/opampgateway/internal/gateway/upstream_connection.go
@@ -56,8 +56,9 @@ type upstreamConnection struct {
 }
 
 type upstreamConnectionSettings struct {
-	endpoint string
-	headers  http.Header
+	endpoint  string
+	headers   http.Header
+	userAgent string
 }
 
 func newUpstreamConnection(dialer websocket.Dialer, telemetry *metadata.TelemetryBuilder, settings upstreamConnectionSettings, id string, logger *zap.Logger) *upstreamConnection {
@@ -354,5 +355,10 @@ func (c *upstreamConnection) header(id string) http.Header {
 		h = make(http.Header)
 	}
 	h.Set("X-Opamp-Gateway-Connection-Id", id)
+	// identify the gateway to the upstream server, leaving a configured
+	// User-Agent in place so it can be overridden.
+	if h.Get("User-Agent") == "" {
+		h.Set("User-Agent", c.settings.userAgent)
+	}
 	return h
 }

--- a/extension/opampgateway/internal/gateway/upstream_connection_test.go
+++ b/extension/opampgateway/internal/gateway/upstream_connection_test.go
@@ -1,0 +1,67 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestUpstreamConnectionHeader(t *testing.T) {
+	const userAgent = "opamp-gateway/v1.9.0 bindplane-otel-collector/v2.0.1 (linux/amd64)"
+
+	testCases := []struct {
+		name            string
+		headers         http.Header
+		expectUserAgent string
+	}{
+		{
+			name:            "no configured headers",
+			headers:         nil,
+			expectUserAgent: userAgent,
+		},
+		{
+			name:            "unrelated configured header",
+			headers:         http.Header{"Authorization": []string{"Secret-Key secret"}},
+			expectUserAgent: userAgent,
+		},
+		{
+			name:            "configured User-Agent takes precedence",
+			headers:         http.Header{"User-Agent": []string{"custom/1.0.0"}},
+			expectUserAgent: "custom/1.0.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newUpstreamConnection(*websocket.DefaultDialer, nil, upstreamConnectionSettings{
+				endpoint:  "ws://localhost:4320/v1/opamp",
+				headers:   tc.headers,
+				userAgent: userAgent,
+			}, "upstream-0", zap.NewNop())
+
+			h := c.header("upstream-0")
+			require.Equal(t, "upstream-0", h.Get("X-Opamp-Gateway-Connection-Id"))
+			require.Equal(t, tc.expectUserAgent, h.Get("User-Agent"))
+
+			// the configured headers must not be modified
+			require.Equal(t, tc.headers, c.settings.headers)
+		})
+	}
+}

--- a/extension/opampgateway/internal/version/version.go
+++ b/extension/opampgateway/internal/version/version.go
@@ -1,0 +1,141 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package version reports the version of the opampgateway extension module and
+// builds the User-Agent value derived from it.
+package version
+
+import (
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+const (
+	// modulePath is the Go module path of the opampgateway extension. The module
+	// version is tagged as extension/opampgateway/vX.Y.Z, so the version
+	// recorded in build info is the extension's own version.
+	modulePath = "github.com/observiq/bindplane-otel-contrib/extension/opampgateway"
+
+	// product is the User-Agent product token for the gateway.
+	product = "opamp-gateway"
+
+	// unknown is reported when the module version cannot be determined, which is
+	// the case for builds that replace the module with a local directory.
+	unknown = "unknown"
+
+	// tchars are the punctuation characters RFC 9110 allows in a token, in
+	// addition to letters and digits.
+	tchars = "!#$%&'*+-.^_`|~"
+)
+
+var moduleVersion = sync.OnceValue(func() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return unknown
+	}
+	return versionOf(info, modulePath)
+})
+
+// UserAgent returns the value the gateway sends in the User-Agent header of its
+// upstream connections. It follows the RFC 9110 product list convention, naming
+// the gateway, then the collector distribution hosting it, then the platform:
+//
+//	opamp-gateway/v1.9.0 bindplane-otel-collector/v2.0.1-beta.3 (linux/amd64)
+//
+// The collector product is omitted when the build info does not name it.
+func UserAgent(buildInfo component.BuildInfo) string {
+	agent := product + "/" + moduleVersion()
+	if collector := collectorProduct(buildInfo); collector != "" {
+		agent += " " + collector
+	}
+	return agent + " (" + runtime.GOOS + "/" + runtime.GOARCH + ")"
+}
+
+// collectorProduct renders the collector distribution as a product token.
+// BuildInfo.Command is a path in some distributions, so only its base name is
+// used. BuildInfo.Description is deliberately not used: it is prose, so it
+// cannot be a token.
+func collectorProduct(buildInfo component.BuildInfo) string {
+	name := token(strings.TrimSuffix(baseName(buildInfo.Command), ".exe"))
+	version := token(buildInfo.Version)
+	if name == "" || version == "" {
+		return ""
+	}
+	return name + "/" + version
+}
+
+// baseName returns the last element of a path. Unlike filepath.Base it treats
+// both separators on every platform, because the build info of a binary built
+// for one platform can be read on another.
+func baseName(path string) string {
+	if i := strings.LastIndexAny(path, `/\`); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+// token renders s as an RFC 9110 token, replacing the characters that are not
+// allowed in one with a hyphen so that a value carrying spaces or path
+// separators cannot split the User-Agent into extra products. It returns an
+// empty string for a value that holds nothing usable.
+func token(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case strings.ContainsRune(tchars, r):
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	// filepath.Base returns "." or a separator for a path with no base name,
+	// both of which trim away to nothing.
+	return strings.Trim(b.String(), "-.")
+}
+
+// versionOf finds the version recorded for path in info, looking at both the
+// main module and its dependencies.
+func versionOf(info *debug.BuildInfo, path string) string {
+	if info.Main.Path == path {
+		return normalize(info.Main.Version)
+	}
+	for _, dep := range info.Deps {
+		if dep == nil || dep.Path != path {
+			continue
+		}
+		// A replaced module records its version on the replacement, which is
+		// empty when the replacement is a local directory.
+		if dep.Replace != nil {
+			return normalize(dep.Replace.Version)
+		}
+		return normalize(dep.Version)
+	}
+	return unknown
+}
+
+// normalize maps the version strings that carry no useful information onto
+// "unknown".
+func normalize(version string) string {
+	if version == "" || version == "(devel)" {
+		return unknown
+	}
+	return version
+}

--- a/extension/opampgateway/internal/version/version_test.go
+++ b/extension/opampgateway/internal/version/version_test.go
@@ -1,0 +1,211 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"runtime"
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+)
+
+func TestUserAgent(t *testing.T) {
+	// under test the module is the main module, so no version is recorded
+	require.Equal(t, unknown, moduleVersion())
+
+	platform := " (" + runtime.GOOS + "/" + runtime.GOARCH + ")"
+
+	testCases := []struct {
+		name      string
+		buildInfo component.BuildInfo
+		expected  string
+	}{
+		{
+			name:      "no build info",
+			buildInfo: component.BuildInfo{},
+			expected:  "opamp-gateway/unknown" + platform,
+		},
+		{
+			name: "v2 style build info",
+			buildInfo: component.BuildInfo{
+				Command:     "bindplane-otel-collector",
+				Description: "Bindplane's custom distro for the OpenTelemetry Collector",
+				Version:     "v2.0.1-beta.3",
+			},
+			expected: "opamp-gateway/unknown bindplane-otel-collector/v2.0.1-beta.3" + platform,
+		},
+		{
+			name: "v1 style build info with a path for the command",
+			buildInfo: component.BuildInfo{
+				Command:     "/opt/observiq-otel-collector/observiq-otel-collector",
+				Description: "observIQ's opentelemetry-collector distribution",
+				Version:     "v1.85.0",
+			},
+			expected: "opamp-gateway/unknown observiq-otel-collector/v1.85.0" + platform,
+		},
+		{
+			name: "windows command",
+			buildInfo: component.BuildInfo{
+				Command: `C:\Program Files\Bindplane\collector.exe`,
+				Version: "v1.85.0",
+			},
+			expected: "opamp-gateway/unknown collector/v1.85.0" + platform,
+		},
+		{
+			name:      "command without a version",
+			buildInfo: component.BuildInfo{Command: "bindplane-otel-collector"},
+			expected:  "opamp-gateway/unknown" + platform,
+		},
+		{
+			name:      "version without a command",
+			buildInfo: component.BuildInfo{Version: "v2.0.1"},
+			expected:  "opamp-gateway/unknown" + platform,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, UserAgent(tc.buildInfo))
+		})
+	}
+}
+
+func TestBaseName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty", input: "", expected: ""},
+		{name: "no separator", input: "bindplane-otel-collector", expected: "bindplane-otel-collector"},
+		{name: "unix path", input: "/opt/observiq-otel-collector/observiq-otel-collector", expected: "observiq-otel-collector"},
+		{name: "windows path", input: `C:\Program Files\Bindplane\collector.exe`, expected: "collector.exe"},
+		{name: "relative path", input: "./build/collector", expected: "collector"},
+		{name: "trailing separator", input: "/opt/collector/", expected: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, baseName(tc.input))
+		})
+	}
+}
+
+func TestToken(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty", input: "", expected: ""},
+		{name: "already a token", input: "bindplane-otel-collector", expected: "bindplane-otel-collector"},
+		{name: "underscores are allowed", input: "collector_darwin_arm64", expected: "collector_darwin_arm64"},
+		{name: "semver with a prerelease", input: "v2.0.1-beta.3", expected: "v2.0.1-beta.3"},
+		{name: "spaces are replaced", input: "OpenTelemetry Collector", expected: "OpenTelemetry-Collector"},
+		{name: "separators are replaced", input: "a/b", expected: "a-b"},
+		{name: "parens cannot escape the comment", input: "bad(v1)", expected: "bad-v1"},
+		{name: "a lone dot trims away", input: ".", expected: ""},
+		{name: "a lone separator trims away", input: "/", expected: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, token(tc.input))
+		})
+	}
+}
+
+func TestVersionOf(t *testing.T) {
+	testCases := []struct {
+		name     string
+		info     *debug.BuildInfo
+		expected string
+	}{
+		{
+			name:     "not found",
+			info:     &debug.BuildInfo{Main: debug.Module{Path: "example.com/other"}},
+			expected: unknown,
+		},
+		{
+			name: "main module",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: modulePath, Version: "v1.2.3"},
+			},
+			expected: "v1.2.3",
+		},
+		{
+			name: "main module devel",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: modulePath, Version: "(devel)"},
+			},
+			expected: unknown,
+		},
+		{
+			name: "dependency",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.com/collector"},
+				Deps: []*debug.Module{
+					{Path: "example.com/unrelated", Version: "v9.9.9"},
+					{Path: modulePath, Version: "v1.2.3"},
+				},
+			},
+			expected: "v1.2.3",
+		},
+		{
+			name: "dependency replaced by another version",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.com/collector"},
+				Deps: []*debug.Module{
+					{
+						Path:    modulePath,
+						Version: "v1.2.3",
+						Replace: &debug.Module{Path: modulePath, Version: "v1.2.4"},
+					},
+				},
+			},
+			expected: "v1.2.4",
+		},
+		{
+			name: "dependency replaced by local directory",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.com/collector"},
+				Deps: []*debug.Module{
+					{
+						Path:    modulePath,
+						Version: "v1.2.3",
+						Replace: &debug.Module{Path: "../opampgateway"},
+					},
+				},
+			},
+			expected: unknown,
+		},
+		{
+			name: "nil dependency",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.com/collector"},
+				Deps: []*debug.Module{nil, {Path: modulePath, Version: "v1.2.3"}},
+			},
+			expected: "v1.2.3",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, versionOf(tc.info, modulePath))
+		})
+	}
+}


### PR DESCRIPTION
### Proposed Change

Upstream OpAMP connections now send a `User-Agent` header:

```
opamp-gateway/v1.9.0 bindplane-otel-collector/v2.0.1-beta.3 (linux/amd64)
```

It is an [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#field.user-agent)
product list: the gateway, the collector distribution hosting it, then the
platform.

A few notes on the implementation:

- The gateway version is the `opampgateway` module version, read from the
  binary's build info. It is `unknown` for builds that replace the module with
  a local directory, such as `make build-collector`.
- The collector product comes from `component.BuildInfo`, using the base name
  of `Command` because it is a path in the v1 distro. It is omitted when either
  half is missing. `Description` is not used — it is prose, so it cannot be a
  valid product token.
- Both halves are sanitized to RFC 9110 tokens, so a value carrying spaces or
  path separators cannot split the header into extra products.
- A `User-Agent` set in `server.headers` still takes precedence.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
