### PR TITLE
feat(restapireceiver): Add explicit offset_type parameter

### DIFF
--- a/receiver/restapireceiver/README.md
+++ b/receiver/restapireceiver/README.md
@@ -206,6 +206,7 @@ from a `request_body` template — see [Request Body Templating](#request-body-t
 | `pagination.offset_limit.limit`                  | int    | `10`    | `false`  | Value sent for `limit_field_name` on each request. Also the expected page size for the "a full page means there may be more" heuristic, so it should match the page size the API actually returns. When `limit_field_name` is unset (token-based pagination), it is used only as that heuristic threshold and should be set to the API's own page size. |
 | `pagination.offset_limit.starting_offset`        | int    | `0`     | `false`  | Starting offset value                                                                                                                                                                                                                              |
 | `pagination.offset_limit.next_offset_field_name` | string |         | `false`  | Name of the field or header containing the next offset token. When set, the receiver uses token-based (cursor) pagination instead of numeric offsets. For body sources, supports nested fields with dot notation and array indices (e.g., `pagination.next_cursor`, `cursors[0].next`). |
+| `pagination.offset_limit.offset_type`            | string | `numeric` | `false`  | What `offset_field_name` carries: `numeric` for a numeric offset, or `opaque` for a token the receiver treats as meaningless. With `opaque` the parameter is omitted entirely until the first `next_offset_field_name` value arrives, instead of falling back to `starting_offset`. Requires `next_offset_field_name`, and is incompatible with a non-zero `starting_offset`. |
 
 #### Page/Size Pagination
 
@@ -495,6 +496,7 @@ receivers:
         offset_field_name: "cursor"
         limit_field_name: "limit"
         next_offset_field_name: "next_cursor"
+        offset_type: opaque
     storage: file_storage
 ```
 
@@ -512,10 +514,14 @@ This configuration would work with an API that returns responses like:
 
 When `next_cursor` is empty, null, or missing, the receiver treats it as the end of available data.
 
-On the first request of a run there is no cursor yet, so `offset_field_name` is sent as the
-starting offset (`0` by default). In a `request_body` template, guard the cursor with
-`{{ if .Cursor }}` to omit it entirely on that first request — APIs that expect an opaque
-string token there reject `{"after": 0}`.
+On the first request of a run there is no cursor yet. By default (`offset_type: numeric`)
+`offset_field_name` is sent as the starting offset (`0` by default), which is correct for an API
+whose cursor is itself a number. APIs that expect an opaque string token reject a `0` with
+HTTP 400 — set `offset_type: opaque` so the parameter is omitted entirely until a token exists.
+
+In a `request_body` template the equivalent is guarding the cursor with `{{ if .Cursor }}`, which
+omits it on that first request; `offset_type` governs the query parameter, so a POST config that
+carries its cursor only in the body does not need it.
 
 A next offset the API returns as a JSON number is rendered as plain digits, so a token of
 `1000000` is sent as `1000000` rather than `1e+06`.

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -169,6 +169,26 @@ func (m Method) httpMethod() string {
 	return http.MethodGet
 }
 
+// OffsetType declares what kind of value the offset parameter carries.
+type OffsetType string
+
+const (
+	offsetTypeNumeric OffsetType = "numeric"
+	offsetTypeOpaque  OffsetType = "opaque"
+)
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface
+func (t *OffsetType) UnmarshalText(text []byte) error {
+	offsetType := OffsetType(text)
+	switch offsetType {
+	case offsetTypeNumeric, offsetTypeOpaque:
+		*t = offsetType
+		return nil
+	default:
+		return fmt.Errorf("invalid offset_type: %s, must be one of: numeric, opaque", text)
+	}
+}
+
 // Config defines configuration for the REST API receiver.
 type Config struct {
 	// URL is the base URL for the REST API endpoint (required).
@@ -424,6 +444,17 @@ type OffsetLimitPagination struct {
 	// When set, the receiver uses token-based (cursor) pagination instead of numeric offsets.
 	// Where the value is extracted from depends on pagination.response_source.
 	NextOffsetFieldName string `mapstructure:"next_offset_field_name"`
+
+	// OffsetType declares what OffsetFieldName carries: "numeric" (default) for a
+	// numeric offset, or "opaque" for a token whose contents mean nothing to the
+	// receiver.
+	//
+	// The distinction only matters before a token exists. A numeric offset counts
+	// from StartingOffset, so sending 0 on the first request is meaningful; an
+	// opaque token has no equivalent starting value, and an API expecting one
+	// rejects a numeric 0 with HTTP 400. With "opaque" the parameter is omitted
+	// entirely until the first NextOffsetFieldName value arrives.
+	OffsetType OffsetType `mapstructure:"offset_type"`
 }
 
 // PageSizePagination defines page/size pagination configuration.
@@ -673,6 +704,19 @@ func (c *Config) Validate() error {
 		// regardless of where the request carries its values.
 		if c.Pagination.ResponseSource == responseSourceHeader && c.Pagination.OffsetLimit.NextOffsetFieldName == "" {
 			return fmt.Errorf("next_offset_field_name is required when response_source is header")
+		}
+		// An opaque token is only ever learned from a response, and the parameter
+		// is omitted until one arrives. Without a source for it the receiver would
+		// send the same first request forever.
+		if c.Pagination.OffsetLimit.OffsetType == offsetTypeOpaque {
+			if c.Pagination.OffsetLimit.NextOffsetFieldName == "" {
+				return fmt.Errorf("next_offset_field_name is required when offset_type is opaque")
+			}
+			// starting_offset is a numeric-offset concept. Zero is indistinguishable
+			// from unset, so only a non-zero value is a real contradiction.
+			if c.Pagination.OffsetLimit.StartingOffset != 0 {
+				return fmt.Errorf("starting_offset must not be set when offset_type is opaque")
+			}
 		}
 	case paginationModePageSize:
 		if requiresQueryParams && c.Pagination.PageSize.PageNumFieldName == "" {

--- a/receiver/restapireceiver/config_test.go
+++ b/receiver/restapireceiver/config_test.go
@@ -546,6 +546,56 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: "next_offset_field_name is required when response_source is header",
 		},
 		{
+			name: "opaque offset_type requires next_offset_field_name",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeNone,
+				Pagination: PaginationConfig{
+					Mode: paginationModeOffsetLimit,
+					OffsetLimit: OffsetLimitPagination{
+						OffsetFieldName: "cursor",
+						LimitFieldName:  "limit",
+						OffsetType:      offsetTypeOpaque,
+					},
+				},
+			},
+			expectedErr: "next_offset_field_name is required when offset_type is opaque",
+		},
+		{
+			name: "opaque offset_type rejects a non-zero starting_offset",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeNone,
+				Pagination: PaginationConfig{
+					Mode: paginationModeOffsetLimit,
+					OffsetLimit: OffsetLimitPagination{
+						OffsetFieldName:     "cursor",
+						LimitFieldName:      "limit",
+						NextOffsetFieldName: "next_cursor",
+						StartingOffset:      50,
+						OffsetType:          offsetTypeOpaque,
+					},
+				},
+			},
+			expectedErr: "starting_offset must not be set when offset_type is opaque",
+		},
+		{
+			name: "valid opaque offset_type",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeNone,
+				Pagination: PaginationConfig{
+					Mode: paginationModeOffsetLimit,
+					OffsetLimit: OffsetLimitPagination{
+						OffsetFieldName:     "cursor",
+						NextOffsetFieldName: "next_cursor",
+						OffsetType:          offsetTypeOpaque,
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
 			name: "valid page_size with header response_source",
 			config: &Config{
 				URL:      "https://api.example.com/data",
@@ -1855,6 +1905,33 @@ func TestEnums_UnmarshalText(t *testing.T) {
 		require.EqualError(t, m.UnmarshalText([]byte("invalid")),
 			"invalid pagination mode: invalid, must be one of: none, offset_limit, page_size, timestamp")
 	})
+
+	t.Run("offset_type", func(t *testing.T) {
+		var o OffsetType
+		require.NoError(t, o.UnmarshalText([]byte("opaque")))
+		require.Equal(t, offsetTypeOpaque, o)
+		require.EqualError(t, o.UnmarshalText([]byte("base64")),
+			"invalid offset_type: base64, must be one of: numeric, opaque")
+	})
+}
+
+// TestOffsetType_RejectedWhenDecoded is the nested-key counterpart to
+// TestEnums_RejectedWhenDecoded: offset_type sits three levels deep, so this
+// proves the TextUnmarshaler is actually reached at that path and a bad value
+// fails at decode time rather than being silently ignored.
+func TestOffsetType_RejectedWhenDecoded(t *testing.T) {
+	cm := confmap.NewFromStringMap(map[string]any{
+		"url": "https://api.example.com/data",
+		"pagination": map[string]any{
+			"mode": "offset_limit",
+			"offset_limit": map[string]any{
+				"offset_type": "base64",
+			},
+		},
+	})
+	err := cm.Unmarshal(createDefaultConfig().(*Config))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "base64")
 }
 
 // TestEnums_RejectedWhenDecoded is the end-to-end guarantee behind dropping the

--- a/receiver/restapireceiver/pagination.go
+++ b/receiver/restapireceiver/pagination.go
@@ -155,10 +155,15 @@ func buildPaginationParams(cfg *Config, state *paginationState) url.Values {
 	switch cfg.Pagination.Mode {
 	case paginationModeOffsetLimit:
 		if cfg.Pagination.OffsetLimit.OffsetFieldName != "" {
-			if state.CurrentOffsetToken != "" {
+			switch {
+			case state.CurrentOffsetToken != "":
 				// Use token-based offset when available
 				params.Set(cfg.Pagination.OffsetLimit.OffsetFieldName, state.CurrentOffsetToken)
-			} else {
+			case cfg.Pagination.OffsetLimit.OffsetType == offsetTypeOpaque:
+				// No token yet, and there is no numeric value an opaque API would
+				// accept in its place — a 0 here draws an HTTP 400. Omit the
+				// parameter and let the API return its first page.
+			default:
 				params.Set(cfg.Pagination.OffsetLimit.OffsetFieldName, fmt.Sprintf("%d", state.CurrentOffset))
 			}
 		}

--- a/receiver/restapireceiver/pagination_test.go
+++ b/receiver/restapireceiver/pagination_test.go
@@ -619,6 +619,85 @@ func TestBuildPaginationParams_OffsetLimit_EmptyToken(t *testing.T) {
 	require.Equal(t, "10", params.Get("limit"))
 }
 
+// TestBuildPaginationParams_OffsetLimit_OpaqueEmptyToken covers the bootstrap
+// request of an opaque-cursor run: there is no token yet, and a numeric 0 in its
+// place is what strict APIs reject, so the parameter must be absent entirely
+// rather than present-and-empty.
+func TestBuildPaginationParams_OffsetLimit_OpaqueEmptyToken(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeOffsetLimit,
+			OffsetLimit: OffsetLimitPagination{
+				OffsetFieldName:     "cursor",
+				LimitFieldName:      "limit",
+				NextOffsetFieldName: "next_cursor",
+				OffsetType:          offsetTypeOpaque,
+			},
+		},
+	}
+
+	state := &paginationState{
+		CurrentOffset:      0,
+		CurrentOffsetToken: "",
+		Limit:              10,
+	}
+
+	params := buildPaginationParams(cfg, state)
+	_, present := params["cursor"]
+	require.False(t, present, "cursor must be omitted entirely, not sent as an empty value")
+	require.Equal(t, "10", params.Get("limit"), "limit is unaffected by offset_type")
+}
+
+// TestBuildPaginationParams_OffsetLimit_OpaqueWithToken is the continuation
+// request: once a token exists it is sent under the same parameter name.
+func TestBuildPaginationParams_OffsetLimit_OpaqueWithToken(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeOffsetLimit,
+			OffsetLimit: OffsetLimitPagination{
+				OffsetFieldName:     "cursor",
+				LimitFieldName:      "limit",
+				NextOffsetFieldName: "next_cursor",
+				OffsetType:          offsetTypeOpaque,
+			},
+		},
+	}
+
+	state := &paginationState{
+		CurrentOffsetToken: "eyJvZmZzZXQiOjEwfQ==",
+		Limit:              10,
+	}
+
+	params := buildPaginationParams(cfg, state)
+	require.Equal(t, "eyJvZmZzZXQiOjEwfQ==", params.Get("cursor"))
+}
+
+// TestBuildPaginationParams_OffsetLimit_NumericEmptyToken pins the explicit
+// numeric case. Together with TestBuildPaginationParams_OffsetLimit_EmptyToken,
+// which leaves OffsetType unset, it proves the numeric default is inert.
+func TestBuildPaginationParams_OffsetLimit_NumericEmptyToken(t *testing.T) {
+	cfg := &Config{
+		Pagination: PaginationConfig{
+			Mode: paginationModeOffsetLimit,
+			OffsetLimit: OffsetLimitPagination{
+				OffsetFieldName:     "offset",
+				LimitFieldName:      "limit",
+				NextOffsetFieldName: "next_offset",
+				OffsetType:          offsetTypeNumeric,
+			},
+		},
+	}
+
+	state := &paginationState{
+		CurrentOffset:      0,
+		CurrentOffsetToken: "",
+		Limit:              10,
+	}
+
+	params := buildPaginationParams(cfg, state)
+	require.Equal(t, "0", params.Get("offset"), "a numeric offset still starts at 0")
+}
+
 func TestParseOffsetLimitResponse_TokenPresent_FullPage(t *testing.T) {
 	cfg := &Config{
 		Pagination: PaginationConfig{


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Adds the `offset_type` parameter to `offset_limit` pagination mode. Valid values are `numeric` (default) or `opaque`. This allows us to have more solidly defined paths for each case, instead of trying to infer the cursor type. 
Specifically, the receiver would send `0` with the first request.  This makes sense for numeric offsets, but would error for opaque ones. This PR also addresses this issue, omitting the cursor from the first request when `offset_type: opaque` 

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed