### PR TITLE
fix(lookupprocessor): start with an unreachable Redis and bound the cost of a source outage (PIPE-1450)

### DIFF
--- a/processor/lookupprocessor/README.md
+++ b/processor/lookupprocessor/README.md
@@ -81,10 +81,22 @@ startup, and will become a configuration error in a future release.
 The processor first tries `HGETALL` on the resolved key. If no fields are
 returned, it falls back to `GET` and decodes the value as JSON `map[string]string`.
 
-On startup, the lookup source performs a `PING` (bounded by `dial_timeout`). A failed
-`PING` aborts processor start so a misconfigured Redis (bad address, auth
-failure, unreachable host) surfaces immediately rather than masking the issue
-until the first lookup.
+On startup, the lookup source performs a `PING` (bounded by `dial_timeout`). A
+failed `PING` is logged at `warn` and the processor starts anyway: enrichment
+is best-effort, so a Redis restart, network blip, or maintenance window that
+coincides with a collector start must not take the telemetry pipeline offline.
+Records pass through un-enriched until Redis is reachable; the client
+reconnects on its own with no collector restart. Startup behaviour therefore
+matches the API source, which never probes its endpoint at start.
+
+While Redis (or an API endpoint) is down, the source logs one `warn` when it
+stops answering and one `info` when it answers again. Individual failed
+lookups stay at `debug`. After a failure the source is marked down for 5s and
+lookups return immediately without touching the network; when the window
+elapses a single lookup probes the backend and either clears the mark or opens
+a new window. So an outage costs one failed dial (at most `lookup_timeout`)
+per 5s rather than one per record, and recovery is noticed within 5s. Entries
+already in the cache keep being served throughout.
 
 ### API Lookup Source
 | Field            | Type              | Default | Description |

--- a/processor/lookupprocessor/api.go
+++ b/processor/lookupprocessor/api.go
@@ -68,6 +68,7 @@ type APISource struct {
 	responseMapping map[string]string
 	client          *http.Client
 	logger          *zap.Logger
+	avail           *availability
 }
 
 // NewAPISource creates a new APISource.
@@ -116,6 +117,7 @@ func NewAPISource(cfg *APIConfig, logger *zap.Logger) (*APISource, error) {
 		responseMapping: cfg.ResponseMapping,
 		client:          client,
 		logger:          logger,
+		avail:           newAvailability(logger, "api"),
 	}, nil
 }
 
@@ -124,6 +126,10 @@ func NewAPISource(cfg *APIConfig, logger *zap.Logger) (*APISource, error) {
 // of retried slow requests cannot exceed it. Non-retryable HTTP statuses abort
 // immediately; cancellation aborts pending retry sleeps promptly.
 func (a *APISource) Lookup(ctx context.Context, key string) (map[string]string, error) {
+	if a.avail.skip() {
+		return nil, errSourceUnavailable
+	}
+
 	requestURL := a.substituteURL(key)
 
 	if _, err := url.Parse(requestURL); err != nil {
@@ -149,12 +155,15 @@ func (a *APISource) Lookup(ctx context.Context, key string) (map[string]string, 
 
 		data, err := a.makeRequest(ctx, requestURL)
 		if err == nil {
+			a.avail.markUp()
 			return data, nil
 		}
 
 		// Non-retryable status codes (e.g. 400, 401, 403, 404) abort immediately.
+		// The endpoint answered, so this is a per-key result, not an outage.
 		var nrse *nonRetryableStatusError
 		if errors.As(err, &nrse) {
+			a.avail.markUp()
 			return nil, err
 		}
 
@@ -162,6 +171,7 @@ func (a *APISource) Lookup(ctx context.Context, key string) (map[string]string, 
 		a.logger.Debug("API request failed", zap.Error(err), zap.Int("attempt", attempt+1))
 	}
 
+	a.avail.markDown(lastErr)
 	return nil, fmt.Errorf("API request failed after %d attempts: %w", a.maxRetries, lastErr)
 }
 

--- a/processor/lookupprocessor/availability_test.go
+++ b/processor/lookupprocessor/availability_test.go
@@ -31,10 +31,10 @@ import (
 func fakeAvailability(t *testing.T) (*availability, *clockwork.FakeClock, *observer.ObservedLogs) {
 	t.Helper()
 	core, logs := observer.New(zapcore.DebugLevel)
-	clock := clockwork.NewFakeClock()
+	fakeClock := clockwork.NewFakeClock()
 	a := newAvailability(zap.New(core), "test")
-	a.clock = clock
-	return a, clock, logs
+	a.clock = fakeClock
+	return a, fakeClock, logs
 }
 
 func TestAvailability_UpNeverSkips(t *testing.T) {
@@ -47,7 +47,7 @@ func TestAvailability_UpNeverSkips(t *testing.T) {
 }
 
 func TestAvailability_DownSkipsUntilWindowThenOneProbe(t *testing.T) {
-	a, clock, logs := fakeAvailability(t)
+	a, fakeClock, logs := fakeAvailability(t)
 	boom := errors.New("boom")
 
 	a.markDown(boom)
@@ -55,10 +55,10 @@ func TestAvailability_DownSkipsUntilWindowThenOneProbe(t *testing.T) {
 	require.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), 1, "one Warn per outage")
 
 	require.True(t, a.skip(), "inside the window every caller skips")
-	clock.Advance(sourceRetryInterval - time.Millisecond)
+	fakeClock.Advance(sourceRetryInterval - time.Millisecond)
 	require.True(t, a.skip())
 
-	clock.Advance(time.Millisecond)
+	fakeClock.Advance(time.Millisecond)
 	require.False(t, a.skip(), "first caller after the window probes")
 	require.True(t, a.skip(), "second caller in the same window skips")
 
@@ -66,7 +66,7 @@ func TestAvailability_DownSkipsUntilWindowThenOneProbe(t *testing.T) {
 	require.True(t, a.skip(), "a failed probe opens a fresh window")
 	require.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), 1, "still one Warn")
 
-	clock.Advance(sourceRetryInterval)
+	fakeClock.Advance(sourceRetryInterval)
 	require.False(t, a.skip())
 	a.markUp()
 	require.False(t, a.skip(), "recovered source never skips")
@@ -74,9 +74,9 @@ func TestAvailability_DownSkipsUntilWindowThenOneProbe(t *testing.T) {
 }
 
 func TestAvailability_OneProbeAcrossConcurrentCallers(t *testing.T) {
-	a, clock, _ := fakeAvailability(t)
+	a, fakeClock, _ := fakeAvailability(t)
 	a.markDown(errors.New("boom"))
-	clock.Advance(sourceRetryInterval)
+	fakeClock.Advance(sourceRetryInterval)
 
 	var probes int
 	var mu sync.Mutex

--- a/processor/lookupprocessor/availability_test.go
+++ b/processor/lookupprocessor/availability_test.go
@@ -1,0 +1,119 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lookupprocessor
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func fakeAvailability(t *testing.T) (*availability, *clockwork.FakeClock, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zapcore.DebugLevel)
+	clock := clockwork.NewFakeClock()
+	a := newAvailability(zap.New(core), "test")
+	a.clock = clock
+	return a, clock, logs
+}
+
+func TestAvailability_UpNeverSkips(t *testing.T) {
+	a, _, logs := fakeAvailability(t)
+	for i := 0; i < 3; i++ {
+		require.False(t, a.skip())
+	}
+	a.markUp()
+	require.Empty(t, logs.All(), "no transition, no log")
+}
+
+func TestAvailability_DownSkipsUntilWindowThenOneProbe(t *testing.T) {
+	a, clock, logs := fakeAvailability(t)
+	boom := errors.New("boom")
+
+	a.markDown(boom)
+	a.markDown(boom)
+	require.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), 1, "one Warn per outage")
+
+	require.True(t, a.skip(), "inside the window every caller skips")
+	clock.Advance(sourceRetryInterval - time.Millisecond)
+	require.True(t, a.skip())
+
+	clock.Advance(time.Millisecond)
+	require.False(t, a.skip(), "first caller after the window probes")
+	require.True(t, a.skip(), "second caller in the same window skips")
+
+	a.markDown(boom)
+	require.True(t, a.skip(), "a failed probe opens a fresh window")
+	require.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), 1, "still one Warn")
+
+	clock.Advance(sourceRetryInterval)
+	require.False(t, a.skip())
+	a.markUp()
+	require.False(t, a.skip(), "recovered source never skips")
+	require.Len(t, logs.FilterMessageSnippet("reachable again").All(), 1)
+}
+
+func TestAvailability_OneProbeAcrossConcurrentCallers(t *testing.T) {
+	a, clock, _ := fakeAvailability(t)
+	a.markDown(errors.New("boom"))
+	clock.Advance(sourceRetryInterval)
+
+	var probes int
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if !a.skip() {
+				mu.Lock()
+				probes++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, 1, probes, "exactly one goroutine wins the probe")
+}
+
+func TestAvailability_StartDownIsQuiet(t *testing.T) {
+	a, _, logs := fakeAvailability(t)
+	a.startDown()
+	require.True(t, a.skip())
+	require.Empty(t, logs.All(), "startup wording is the caller's; startDown itself logs nothing")
+}
+
+func TestRedisSource_SkipsNetworkWhileDown(t *testing.T) {
+	// Refused connections take ~1.7s per lookup through go-redis retries; a
+	// skipped lookup must return without touching the network at all.
+	src, err := NewRedisSource(&RedisConfig{Address: unreachableAddr}, zap.NewNop())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	start := time.Now()
+	for i := 0; i < 100; i++ {
+		_, err := src.Lookup(context.Background(), "k")
+		require.ErrorIs(t, err, errSourceUnavailable)
+	}
+	require.Less(t, time.Since(start), 500*time.Millisecond, "100 skipped lookups must not dial")
+}

--- a/processor/lookupprocessor/redis.go
+++ b/processor/lookupprocessor/redis.go
@@ -36,25 +36,27 @@ const redisDefaultLookupTimeout = 5 * time.Second
 // not set RedisConfig.DialTimeout.
 const redisDefaultDialTimeout = 2 * time.Second
 
-// redisBootPingTimeout bounds the startup Ping used to verify connectivity
-// and credentials. Failure here aborts source creation so a misconfigured
-// Redis surfaces immediately instead of after the first lookup.
+// redisBootPingTimeout bounds the startup Ping used to surface connectivity
+// and credential problems at boot. Failure is logged, not fatal: enrichment is
+// best-effort and a downed Redis must not keep the collector from starting.
 const redisBootPingTimeout = 2 * time.Second
 
 var errRedisKeyNotFound = errors.New("key not found in redis")
 
 // RedisSource implements LookupSource for Redis. Construction performs a
-// short Ping so configuration errors (bad address, auth) fail the source
-// immediately rather than masking the problem until the first lookup.
+// short Ping so configuration errors (bad address, auth) are reported at boot,
+// then the client connects lazily on the first lookup like the API source.
 type RedisSource struct {
 	client       *redis.Client
 	keyPrefix    string
 	lookupBudget time.Duration
 	logger       *zap.Logger
+	avail        *availability
 }
 
-// NewRedisSource creates a new RedisSource. Returns an error if the initial
-// Ping fails so a misconfigured Redis aborts processor start.
+// NewRedisSource creates a new RedisSource. An unreachable Redis is logged at
+// Warn and the source starts anyway; records pass through un-enriched until
+// the client can connect.
 func NewRedisSource(cfg *RedisConfig, logger *zap.Logger) (*RedisSource, error) {
 	dialTimeout := cfg.DialTimeout
 	if dialTimeout <= 0 {
@@ -80,29 +82,36 @@ func NewRedisSource(cfg *RedisConfig, logger *zap.Logger) (*RedisSource, error) 
 		}
 	}
 
-	client := redis.NewClient(opts)
-
-	pingCtx, cancel := context.WithTimeout(context.Background(), redisBootPingTimeout)
-	defer cancel()
-	if err := client.Ping(pingCtx).Err(); err != nil {
-		_ = client.Close()
-		return nil, fmt.Errorf("redis ping failed for %s: %w", cfg.Address, err)
-	}
-
-	logger.Info("redis source ready", zap.String("address", cfg.Address))
-
-	return &RedisSource{
-		client:       client,
+	logger = logger.With(zap.String("address", cfg.Address))
+	src := &RedisSource{
+		client:       redis.NewClient(opts),
 		keyPrefix:    cfg.KeyPrefix,
 		lookupBudget: lookupBudget,
 		logger:       logger,
-	}, nil
+		avail:        newAvailability(logger, "redis"),
+	}
+
+	pingCtx, cancel := context.WithTimeout(context.Background(), redisBootPingTimeout)
+	defer cancel()
+	if err := src.client.Ping(pingCtx).Err(); err != nil {
+		src.avail.startDown()
+		logger.Warn("redis unreachable at startup; collector continues and records pass through un-enriched until redis is reachable", zap.Error(err))
+	} else {
+		logger.Info("redis source ready")
+	}
+
+	return src, nil
 }
 
 // Lookup retrieves data from Redis for the given key. Tries HGETALL first,
 // then falls back to GET with JSON decode if the key holds a string value.
-// Honors the caller's context and applies a per-call timeout.
+// Honors the caller's context and applies a per-call timeout. While Redis is
+// known to be down only one probe per retry window reaches the network.
 func (r *RedisSource) Lookup(ctx context.Context, key string) (map[string]string, error) {
+	if r.avail.skip() {
+		return nil, errSourceUnavailable
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, r.lookupBudget)
 	defer cancel()
 
@@ -110,8 +119,10 @@ func (r *RedisSource) Lookup(ctx context.Context, key string) (map[string]string
 
 	hashResult, err := r.client.HGetAll(ctx, redisKey).Result()
 	if err != nil && !isWrongTypeErr(err) {
+		r.avail.markDown(err)
 		return nil, fmt.Errorf("failed to execute HGETALL: %w", err)
 	}
+	r.avail.markUp()
 
 	if err == nil && len(hashResult) > 0 {
 		r.logger.Debug("redis hash lookup successful", zap.String("key", redisKey), zap.Int("fields", len(hashResult)))
@@ -123,6 +134,7 @@ func (r *RedisSource) Lookup(ctx context.Context, key string) (map[string]string
 		if errors.Is(err, redis.Nil) {
 			return nil, errRedisKeyNotFound
 		}
+		r.avail.markDown(err)
 		return nil, fmt.Errorf("failed to execute GET: %w", err)
 	}
 

--- a/processor/lookupprocessor/redis_test.go
+++ b/processor/lookupprocessor/redis_test.go
@@ -15,8 +15,14 @@
 package lookupprocessor
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -106,4 +112,102 @@ func TestRedisSource_BuildKey(t *testing.T) {
 
 	r2 := &RedisSource{}
 	require.Equal(t, "abc", r2.buildKey("abc"))
+}
+
+// flakyRedis is a minimal RESP server that answers HGETALL with WRONGTYPE and
+// drops the connection on GET, so a lookup fails on the second command rather
+// than the first. miniredis cannot fail one command and not another.
+type flakyRedis struct {
+	ln   net.Listener
+	gets atomic.Int32
+}
+
+func startFlakyRedis(t *testing.T) *flakyRedis {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	f := &flakyRedis{ln: ln}
+	go f.serve()
+	t.Cleanup(func() { _ = ln.Close() })
+	return f
+}
+
+func (f *flakyRedis) serve() {
+	for {
+		conn, err := f.ln.Accept()
+		if err != nil {
+			return
+		}
+		go f.handle(conn)
+	}
+}
+
+func (f *flakyRedis) handle(conn net.Conn) {
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+	for {
+		args, err := readRESPArray(r)
+		if err != nil {
+			return
+		}
+		switch strings.ToUpper(args[0]) {
+		case "PING":
+			_, _ = conn.Write([]byte("+PONG\r\n"))
+		case "HGETALL":
+			_, _ = conn.Write([]byte("-WRONGTYPE Operation against a key holding the wrong kind of value\r\n"))
+		case "GET":
+			f.gets.Add(1)
+			return // drop the connection mid-lookup
+		case "HELLO":
+			_, _ = conn.Write([]byte("-ERR unknown command 'HELLO'\r\n")) // go-redis falls back to RESP2
+		default:
+			_, _ = conn.Write([]byte("+OK\r\n"))
+		}
+	}
+}
+
+// readRESPArray parses one client command: *N then N bulk strings.
+func readRESPArray(r *bufio.Reader) ([]string, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(line, "*") {
+		return nil, fmt.Errorf("expected array, got %q", line)
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(line[1:]))
+	if err != nil {
+		return nil, err
+	}
+	args := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		if _, err := r.ReadString('\n'); err != nil { // $len
+			return nil, err
+		}
+		s, err := r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, strings.TrimSuffix(s, "\r\n"))
+	}
+	return args, nil
+}
+
+func TestRedisSource_GETFailureAfterHGETALLMarksDown(t *testing.T) {
+	srv := startFlakyRedis(t)
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	src, err := NewRedisSource(&RedisConfig{Address: srv.ln.Addr().String()}, zap.New(core))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+	require.Empty(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), "PING succeeded, source starts up")
+
+	_, err = src.Lookup(context.Background(), "k")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to execute GET", "HGETALL answered WRONGTYPE, so the failure must come from GET")
+	require.Positive(t, srv.gets.Load())
+	require.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), 1, "a GET failure marks the source down")
+
+	_, err = src.Lookup(context.Background(), "k")
+	require.ErrorIs(t, err, errSourceUnavailable, "the next lookup inside the window is skipped")
 }

--- a/processor/lookupprocessor/redis_test.go
+++ b/processor/lookupprocessor/redis_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestRedisSource_HashLookup(t *testing.T) {
@@ -68,13 +70,34 @@ func TestRedisSource_NotFound(t *testing.T) {
 	require.True(t, errors.Is(err, errRedisKeyNotFound))
 }
 
-func TestRedisSource_StartPingFailIsFatal(t *testing.T) {
-	// 127.0.0.1:1 is reserved and refuses connections. Constructor must fail
-	// fast so a misconfigured Redis aborts processor start instead of leaving
-	// lookups silently broken until the first request.
-	src, err := NewRedisSource(&RedisConfig{Address: "127.0.0.1:1"}, zap.NewNop())
-	require.Error(t, err)
-	require.Nil(t, src)
+func TestRedisSource_UnreachableAtStart_WarnsAndStarts(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	// 127.0.0.1:1 is reserved and refuses connections. The constructor must
+	// still return a usable source: enrichment is best-effort and a downed
+	// Redis must not keep the collector from starting.
+	src, err := NewRedisSource(&RedisConfig{Address: "127.0.0.1:1"}, zap.New(core))
+	require.NoError(t, err)
+	require.NotNil(t, src)
+	t.Cleanup(func() { _ = src.Close() })
+
+	warns := logs.FilterLevelExact(zapcore.WarnLevel).All()
+	require.Len(t, warns, 1, "exactly one startup warning")
+	require.Contains(t, warns[0].ContextMap()["address"], "127.0.0.1:1")
+
+	_, err = src.Lookup(context.Background(), "k")
+	require.Error(t, err, "a lookup against a downed Redis fails; the processor passes the record through")
+}
+
+func TestRedisSource_ReachableAtStart_NoWarn(t *testing.T) {
+	srv := miniredis.RunT(t)
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	src, err := NewRedisSource(&RedisConfig{Address: srv.Addr()}, zap.New(core))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	require.Empty(t, logs.FilterLevelExact(zapcore.WarnLevel).All())
 }
 
 func TestRedisSource_BuildKey(t *testing.T) {

--- a/processor/lookupprocessor/source.go
+++ b/processor/lookupprocessor/source.go
@@ -14,7 +14,15 @@
 
 package lookupprocessor
 
-import "context"
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"go.uber.org/zap"
+)
 
 // LookupSource is an interface for different lookup data sources.
 type LookupSource interface {
@@ -25,4 +33,69 @@ type LookupSource interface {
 	Load() error
 	// Close cleans up resources used by the lookup source.
 	Close() error
+}
+
+// errSourceUnavailable is returned without contacting the backend while a
+// network source is known to be down and its retry window has not elapsed.
+var errSourceUnavailable = errors.New("lookup source unavailable")
+
+// sourceRetryInterval is how long a network source stays marked down after a
+// failure before one lookup is let through to probe it. It bounds the cost of
+// an outage to one failed dial (at most lookup_timeout) per interval instead
+// of one per record. Fixed rather than configurable until a deployment needs
+// a different value.
+const sourceRetryInterval = 5 * time.Second
+
+// availability is the outage state of a network source, shared by redis and
+// api. It logs one Warn when the source stops answering and one Info when it
+// answers again, and while down it lets a single probe through per retry
+// interval so records do not each pay for a failed dial. Lock-free because
+// Lookup runs on every pipeline goroutine.
+type availability struct {
+	logger  *zap.Logger
+	name    string
+	clock   clockwork.Clock
+	down    atomic.Bool
+	retryAt atomic.Int64 // unix nanos; meaningful only while down
+}
+
+func newAvailability(logger *zap.Logger, name string) *availability {
+	return &availability{logger: logger, name: name, clock: clockwork.NewRealClock()}
+}
+
+// skip reports whether a lookup should fail immediately without a network
+// call. Once the retry window has elapsed exactly one caller wins the swap and
+// probes the backend; concurrent callers keep skipping until it reports back.
+func (a *availability) skip() bool {
+	if !a.down.Load() {
+		return false
+	}
+	now := a.clock.Now().UnixNano()
+	retryAt := a.retryAt.Load()
+	if now < retryAt {
+		return true
+	}
+	return !a.retryAt.CompareAndSwap(retryAt, now+int64(sourceRetryInterval))
+}
+
+// markDown records a failed probe. retryAt is written before down so a
+// concurrent skip that observes down also observes a fresh window.
+func (a *availability) markDown(err error) {
+	a.retryAt.Store(a.clock.Now().Add(sourceRetryInterval).UnixNano())
+	if !a.down.Swap(true) {
+		a.logger.Warn(a.name+" lookup source unavailable; records pass through un-enriched until it recovers", zap.Error(err))
+	}
+}
+
+// startDown records an outage seen at startup without logging; the caller has
+// already reported it with startup-specific wording.
+func (a *availability) startDown() {
+	a.retryAt.Store(a.clock.Now().Add(sourceRetryInterval).UnixNano())
+	a.down.Store(true)
+}
+
+func (a *availability) markUp() {
+	if a.down.Swap(false) {
+		a.logger.Info(a.name + " lookup source reachable again; enrichment resumed")
+	}
 }

--- a/processor/lookupprocessor/startup_test.go
+++ b/processor/lookupprocessor/startup_test.go
@@ -1,0 +1,216 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lookupprocessor
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// unreachableAddr is a reserved port that refuses connections immediately.
+const unreachableAddr = "127.0.0.1:1"
+
+// freeAddr reserves a loopback port and releases it, so a test can start a
+// server on a known address after first exercising the "nothing listening"
+// path against it.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := l.Addr().String()
+	require.NoError(t, l.Close())
+	return addr
+}
+
+// oneRecord builds a log batch carrying a single record whose attribute
+// "ip" is set to key, ready for an attributes-context lookup.
+func oneRecord(key string) plog.Logs {
+	ld := plog.NewLogs()
+	ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Attributes().PutStr("ip", key)
+	return ld
+}
+
+func firstRecordAttrs(ld plog.Logs) map[string]any {
+	return ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw()
+}
+
+func TestStart_RedisUnreachable_StartsAndPassesThrough(t *testing.T) {
+	p, logs := startedProcessor(t, &Config{
+		Context: attributesContext, Field: "ip",
+		Redis:        &RedisConfig{Address: unreachableAddr},
+		CacheEnabled: true, CacheTTL: defaultCacheTTL, CacheMaxEntries: defaultCacheMaxEntries,
+	})
+
+	warns := logs.FilterLevelExact(zapcore.WarnLevel).All()
+	require.NotEmpty(t, warns, "an unreachable Redis at startup must be logged at Warn")
+	require.Contains(t, warns[0].Message, "redis", "warning must name the source")
+
+	out, err := p.processLogs(context.Background(), oneRecord("10.0.0.1"))
+	require.NoError(t, err, "records must flow while Redis is down")
+	require.Equal(t, map[string]any{"ip": "10.0.0.1"}, firstRecordAttrs(out), "record must pass through un-enriched")
+}
+
+func TestStart_RedisUnreachable_ReconnectsWithoutRestart(t *testing.T) {
+	addr := freeAddr(t)
+
+	p, _ := startedProcessor(t, &Config{
+		Context: attributesContext, Field: "ip",
+		Redis: &RedisConfig{Address: addr, KeyPrefix: "ip"},
+		// Cache off so the assertion below observes the source, not a cached miss.
+		CacheEnabled: false,
+	})
+
+	out, err := p.processLogs(context.Background(), oneRecord("10.0.0.1"))
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"ip": "10.0.0.1"}, firstRecordAttrs(out))
+
+	srv := miniredis.NewMiniRedis()
+	require.NoError(t, srv.StartAddr(addr))
+	t.Cleanup(srv.Close)
+	srv.HSet("ip:10.0.0.1", "host", "web-1")
+
+	require.Eventually(t, func() bool {
+		out, err := p.processLogs(context.Background(), oneRecord("10.0.0.1"))
+		return err == nil && firstRecordAttrs(out)["host"] == "web-1"
+	}, 10*time.Second, 50*time.Millisecond, "records must be enriched once Redis is reachable, without a restart")
+}
+
+func TestStart_APIUnreachable_Starts(t *testing.T) {
+	p, _ := startedProcessor(t, &Config{
+		Context: attributesContext, Field: "ip",
+		API:          &APIConfig{URL: "http://" + unreachableAddr + "/lookup/${key}", MaxRetries: 1},
+		CacheEnabled: true, CacheTTL: defaultCacheTTL, CacheMaxEntries: defaultCacheMaxEntries,
+	})
+
+	out, err := p.processLogs(context.Background(), oneRecord("10.0.0.1"))
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"ip": "10.0.0.1"}, firstRecordAttrs(out))
+}
+
+func TestStart_CSVMissing_StartsAndLogsError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.csv")
+
+	p, logs := startedProcessor(t, &Config{
+		Context: attributesContext, Field: "ip", CSV: missing,
+	})
+
+	// The reload goroutine reports the missing file; a missing CSV is a deploy
+	// error and keeps erroring rather than being downgraded.
+	require.Eventually(t, func() bool {
+		return len(logs.FilterLevelExact(zapcore.ErrorLevel).All()) > 0
+	}, 5*time.Second, 20*time.Millisecond, "missing CSV must be reported at Error")
+
+	out, err := p.processLogs(context.Background(), oneRecord("10.0.0.1"))
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"ip": "10.0.0.1"}, firstRecordAttrs(out))
+}
+
+func TestRedisSource_OutageLogsOneWarnAndOneRecovery(t *testing.T) {
+	addr := freeAddr(t)
+	srv := miniredis.NewMiniRedis()
+	require.NoError(t, srv.StartAddr(addr))
+	srv.HSet("k", "f", "v")
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	src, err := NewRedisSource(&RedisConfig{Address: addr}, zap.New(core))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	_, err = src.Lookup(context.Background(), "k")
+	require.NoError(t, err)
+	require.Empty(t, logs.FilterLevelExact(zapcore.WarnLevel).All())
+
+	srv.Close()
+	for i := 0; i < 3; i++ {
+		_, err = src.Lookup(context.Background(), "k")
+		require.Error(t, err)
+	}
+	require.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), 1, "one Warn per outage, not per record")
+
+	srv = miniredis.NewMiniRedis()
+	require.NoError(t, srv.StartAddr(addr))
+	t.Cleanup(srv.Close)
+	srv.HSet("k", "f", "v")
+	require.Eventually(t, func() bool {
+		_, err := src.Lookup(context.Background(), "k")
+		return err == nil
+	}, 10*time.Second, 50*time.Millisecond)
+
+	recovered := logs.FilterMessageSnippet("reachable again").All()
+	require.Len(t, recovered, 1)
+	require.Equal(t, zapcore.InfoLevel, recovered[0].Level)
+	require.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), 1, "recovery must not add warnings")
+}
+
+func TestAPISource_OutageLogsOneWarn_NotFoundDoesNot(t *testing.T) {
+	addr := freeAddr(t)
+	l, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	var status atomic.Int32
+	status.Store(http.StatusOK)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(int(status.Load()))
+		_, _ = w.Write([]byte(`{"host":"web-1"}`))
+	})
+	ts := httptest.NewUnstartedServer(handler)
+	ts.Listener = l
+	ts.Start()
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	src, err := NewAPISource(&APIConfig{URL: "http://" + addr + "/${key}", MaxRetries: 1}, zap.New(core))
+	require.NoError(t, err)
+
+	_, err = src.Lookup(context.Background(), "k")
+	require.NoError(t, err)
+
+	status.Store(http.StatusNotFound)
+	_, err = src.Lookup(context.Background(), "k")
+	require.Error(t, err)
+	require.Empty(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), "a 404 is a per-key miss, not an outage")
+
+	ts.Close()
+	for i := 0; i < 3; i++ {
+		_, err = src.Lookup(context.Background(), "k")
+		require.Error(t, err)
+	}
+	require.Len(t, logs.FilterLevelExact(zapcore.WarnLevel).All(), 1, "one Warn per outage, not per record")
+
+	l, err = net.Listen("tcp", addr)
+	require.NoError(t, err)
+	status.Store(http.StatusOK)
+	ts = httptest.NewUnstartedServer(handler)
+	ts.Listener = l
+	ts.Start()
+	t.Cleanup(ts.Close)
+
+	require.Eventually(t, func() bool {
+		_, err := src.Lookup(context.Background(), "k")
+		return err == nil
+	}, 10*time.Second, 50*time.Millisecond, "one probe per retry window must find the endpoint again")
+	require.Len(t, logs.FilterMessageSnippet("reachable again").All(), 1)
+}


### PR DESCRIPTION
### Proposed Change

The Redis lookup source ran a `PING` in its constructor and returned an error when it failed. That error propagated out of the processor's `Start`, so a Redis that was down when the collector started (restart, network blip, maintenance window) failed the whole collector, not just enrichment. Enrichment is best-effort: the API source never probes its endpoint at start, per-record lookup failures already pass the record through un-enriched, and a missing CSV file is a background error rather than a start failure. Redis was the only source that could take the pipeline offline.

Changes:

- **Startup is fail-soft.** The boot `PING` stays as a probe, but a failure logs one `warn` and the source starts anyway. go-redis dials lazily on the next command, so Redis is picked up when it comes back with no collector restart. Startup now behaves the same as the API source.
- **Outage transitions are logged once.** A small `availability` tracker shared by the redis and api sources logs one `warn` when the source stops answering and one `info` when it answers again. Per-record failures stay at `debug`. A 4xx from the API (including 404) is a per-key miss, not an outage.

### Describe How The Reviewer Can Validate The Changes

1. `cd processor/lookupprocessor && go test -race ./...`
2. Build a collector from this branch (`make build-linux-arm64` with `COLLECTOR_PATH` pointing at a collector checkout) and run it with a `lookup` processor whose `redis.address` points at a host that is not listening. Before this change the collector exits 1 with `redis ping failed`; after it, the collector logs `redis unreachable at startup` and reaches `Everything is ready`.
3. Send a record through; it arrives un-enriched. Start Redis on that address and seed a key; within 5s the next record is enriched and the log shows `redis lookup source reachable again`.
4. `docker pause` the Redis container and send several records: only the first blocks for `lookup_timeout`, the rest return immediately.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
