### PR TITLE
feat(restapireceiver): Add `has_more_field_name` field

### DIFF
--- a/receiver/restapireceiver/README.md
+++ b/receiver/restapireceiver/README.md
@@ -192,8 +192,9 @@ from a `request_body` template — see [Request Body Templating](#request-body-t
 | Field                                 | Type   | Default | Required | Description                                                                                                                                                                                                                              |
 | ------------------------------------- | ------ | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `pagination.mode`                     | string | `none`  | `false`  | Pagination mode: `none`, `offset_limit`, `page_size`, or `timestamp`                                                                                                                                                                     |
-| `pagination.response_source`          | string | `body`  | `false`  | Where to extract pagination response attributes from: `body` (response body or NDJSON metadata line) or `header` (HTTP response headers). Applies to `total_record_count_field`, `next_offset_field_name`, and `total_pages_field_name`. |
+| `pagination.response_source`          | string | `body`  | `false`  | Where to extract pagination response attributes from: `body` (response body or NDJSON metadata line) or `header` (HTTP response headers). Applies to `total_record_count_field`, `next_offset_field_name`, `total_pages_field_name`, and `has_more_field_name`. |
 | `pagination.total_record_count_field` | string |         | `false`  | Name of the field or header containing total record count                                                                                                                                                                                |
+| `pagination.has_more_field_name`      | string |         | `false`  | Name of the field or header containing the API's own "there is more data" boolean (e.g. `has_more`). When set and present in a response, it decides whether another page is fetched, replacing the "a full page means there may be more" heuristic — so `limit` / `page_size` no longer have to match the API's real page size. Supports nested fields with dot notation (e.g. `response_metadata.has_more`). Accepts `true`/`false`, the strings `"true"`/`"1"`, and numeric `1`/`0`. Only valid when `mode` is `offset_limit` or `page_size`. |
 | `pagination.page_limit`               | int    | `0`     | `false`  | Maximum number of pages to fetch (0 = no limit)                                                                                                                                                                                          |
 | `pagination.zero_based_index`         | bool   | `false` | `false`  | Indicates that the requested data starts at index 0                                                                                                                                                                                      |
 
@@ -203,7 +204,7 @@ from a `request_body` template — see [Request Body Templating](#request-body-t
 | ------------------------------------------------ | ------ | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `pagination.offset_limit.offset_field_name`      | string |         | `false`  | Request parameter name for offset                                                                                                                                                                                                                    |
 | `pagination.offset_limit.limit_field_name`       | string |         | `false`  | Request parameter name for limit. Required for numeric offset pagination; optional when `next_offset_field_name` is set (token-based pagination)                                                                                                     |
-| `pagination.offset_limit.limit`                  | int    | `10`    | `false`  | Value sent for `limit_field_name` on each request. Also the expected page size for the "a full page means there may be more" heuristic, so it should match the page size the API actually returns. When `limit_field_name` is unset (token-based pagination), it is used only as that heuristic threshold and should be set to the API's own page size. |
+| `pagination.offset_limit.limit`                  | int    | `10`    | `false`  | Value sent for `limit_field_name` on each request. Unless `has_more_field_name` is set, it is also the expected page size for the "a full page means there may be more" heuristic, so it should match the page size the API actually returns. When `limit_field_name` is unset (token-based pagination), it is used only as that heuristic threshold and should be set to the API's own page size. |
 | `pagination.offset_limit.starting_offset`        | int    | `0`     | `false`  | Starting offset value                                                                                                                                                                                                                              |
 | `pagination.offset_limit.next_offset_field_name` | string |         | `false`  | Name of the field or header containing the next offset token. When set, the receiver uses token-based (cursor) pagination instead of numeric offsets. For body sources, supports nested fields with dot notation and array indices (e.g., `pagination.next_cursor`, `cursors[0].next`). |
 | `pagination.offset_limit.offset_type`            | string | `numeric` | `false`  | What `offset_field_name` carries: `numeric` for a numeric offset, or `opaque` for a token the receiver treats as meaningless. With `opaque` the parameter is omitted entirely until the first `next_offset_field_name` value arrives, instead of falling back to `starting_offset`. Requires `next_offset_field_name`, and is incompatible with a non-zero `starting_offset`. |
@@ -214,7 +215,7 @@ from a `request_body` template — see [Request Body Templating](#request-body-t
 | --------------------------------------------- | ------ | ------- | -------- | ------------------------------------------------------- |
 | `pagination.page_size.page_num_field_name`    | string |         | `false`  | Request parameter name for page number                    |
 | `pagination.page_size.page_size_field_name`   | string |         | `false`  | Request parameter name for page size                      |
-| `pagination.page_size.page_size`              | int    | `20`    | `false`  | Value sent for `page_size_field_name`. Also the expected page size for the "a full page means there may be more" heuristic, so it should match the page size the API actually returns. |
+| `pagination.page_size.page_size`              | int    | `20`    | `false`  | Value sent for `page_size_field_name`. Unless `has_more_field_name` is set, it is also the expected page size for the "a full page means there may be more" heuristic, so it should match the page size the API actually returns. |
 | `pagination.page_size.starting_page`          | int    | `1`     | `false`  | Starting page number                                    |
 | `pagination.page_size.total_pages_field_name` | string |         | `false`  | Name of the field or header containing total page count |
 
@@ -442,8 +443,10 @@ receivers:
 ```
 
 `limit` should match the page size the API actually returns — it doubles as the "a full page
-means there may be more" threshold. Changing `request_body` invalidates the stored checkpoint
-by design, since a cursor obtained under a different filter is meaningless.
+means there may be more" threshold. If the API reports continuation directly, set
+`has_more_field_name` instead and `limit` goes back to being a pure throughput knob. Changing
+`request_body` invalidates the stored checkpoint by design, since a cursor obtained under a
+different filter is meaningless.
 
 ### Datadog Logs Search (POST, nested body)
 
@@ -528,6 +531,65 @@ carries its cursor only in the body does not need it.
 
 A next offset the API returns as a JSON number is rendered as plain digits, so a token of
 `1000000` is sent as `1000000` rather than `1e+06`.
+
+### Explicit `has_more` Continuation
+
+By default the receiver infers whether to fetch another page from how many records came back: a
+full page (`limit` or `page_size` items) means there may be more, a short page means the backlog is
+drained. That makes `limit` load-bearing for correctness — set it larger than the API's real page
+size and every page looks short, so pagination stops after page one; set it smaller and every page
+looks full, costing a wasted request per cycle.
+
+Many APIs answer the question outright. Point `has_more_field_name` at that field and it decides
+instead, leaving `limit` as a pure throughput knob.
+
+```yaml
+receivers:
+  restapi:
+    url: "https://api.example.com/v1/audit_logs"
+    response_field: "data"
+    max_poll_interval: 5m
+    auth_mode: bearer
+    bearer:
+      token: "your-bearer-token-here"
+    pagination:
+      mode: offset_limit
+      has_more_field_name: "has_more"
+      offset_limit:
+        offset_field_name: "after"
+        limit_field_name: "limit"
+        limit: 100
+        next_offset_field_name: "last_id"
+        offset_type: opaque
+    storage: file_storage
+```
+
+Matching a response like:
+
+```json
+{
+  "data": [{ "id": "audit_log-1" }, { "id": "audit_log-2" }],
+  "has_more": true,
+  "last_id": "audit_log-2"
+}
+```
+
+Details worth knowing:
+
+- **Nested fields** work through the same dot notation as the other response fields — Slack-style
+  APIs put it at `response_metadata.has_more`.
+- **Header sources** are supported: with `response_source: header` the value is read from the named
+  header, where `true` arrives as a string. Booleans, the strings `"true"`/`"false"`/`"1"`/`"0"`,
+  and numeric `1`/`0` are all accepted.
+- **A response that omits the field** falls back to the page-count heuristic rather than assuming
+  the stream ended, so an API that only emits `has_more` on some responses still paginates.
+- **A cursor still wins over `has_more`.** In token-based pagination, a response with no
+  `next_offset_field_name` value ends the cycle even if `has_more` is `true` — there is no cursor to
+  advance with, so continuing would re-request the same page forever. The stored cursor is preserved
+  and the next poll resumes from it.
+- Only valid for `offset_limit` and `page_size` modes. Timestamp pagination advances by the newest
+  record it has seen rather than by page counts, so the receiver rejects the setting there instead
+  of silently ignoring it.
 
 ### Header-Based Cursor Pagination
 

--- a/receiver/restapireceiver/config.go
+++ b/receiver/restapireceiver/config.go
@@ -398,7 +398,7 @@ type PaginationConfig struct {
 	// "body" (default): extract from the response body (or NDJSON metadata line).
 	// "header": extract from HTTP response headers.
 	// Affects all response-based pagination fields: next_offset_field_name,
-	// total_record_count_field, and total_pages_field_name.
+	// total_record_count_field, total_pages_field_name, and has_more_field_name.
 	ResponseSource ResponseSource `mapstructure:"response_source"`
 
 	// OffsetLimit defines offset/limit pagination.
@@ -412,6 +412,21 @@ type PaginationConfig struct {
 
 	// TotalRecordCountField is the name of the field or header that contains the total record count.
 	TotalRecordCountField string `mapstructure:"total_record_count_field"`
+
+	// HasMoreFieldName is the name of the field or header holding the API's own
+	// "there is more data" boolean (e.g. Stripe's and OpenAI's has_more, Slack's
+	// has_more). Dot notation addresses a nested field; where the value is read
+	// from depends on pagination.response_source.
+	//
+	// When set and present in a response, it decides whether the receiver fetches
+	// another page, in place of the "a full page means there may be more" count
+	// heuristic — so limit / page_size stop being load-bearing for correctness
+	// and go back to being throughput knobs. When unset, or when a response omits
+	// the field, the heuristic applies unchanged.
+	//
+	// Only meaningful for the offset_limit and page_size modes: timestamp
+	// pagination advances by the newest record seen rather than by page counts.
+	HasMoreFieldName string `mapstructure:"has_more_field_name"`
 
 	// PageLimit is the maximum number of pages to fetch (0 = no limit).
 	PageLimit int `mapstructure:"page_limit"`
@@ -733,6 +748,14 @@ func (c *Config) Validate() error {
 		if c.Pagination.Timestamp.TimestampFieldName == "" {
 			return fmt.Errorf("timestamp_field_name is required when pagination.mode is timestamp")
 		}
+	}
+
+	// has_more_field_name replaces the page-count heuristic, which only the
+	// offset_limit and page_size modes have. Reject it elsewhere rather than
+	// accept a setting that would never be read.
+	if c.Pagination.HasMoreFieldName != "" &&
+		c.Pagination.Mode != paginationModeOffsetLimit && c.Pagination.Mode != paginationModePageSize {
+		return fmt.Errorf("has_more_field_name is only supported when pagination.mode is offset_limit or page_size")
 	}
 
 	if c.Pagination.OffsetLimit.Limit < 0 {

--- a/receiver/restapireceiver/config_test.go
+++ b/receiver/restapireceiver/config_test.go
@@ -596,6 +596,69 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			// Timestamp pagination advances by the newest record seen, so it has
+			// no page-count heuristic for has_more to replace. Reject rather
+			// than accept a setting that would never be read.
+			name: "has_more_field_name rejected in timestamp mode",
+			config: &Config{
+				URL:                "https://api.example.com/data",
+				AuthMode:           authModeNone,
+				StartTimeParamName: "since",
+				Pagination: PaginationConfig{
+					Mode:             paginationModeTimestamp,
+					HasMoreFieldName: "has_more",
+					Timestamp: TimestampPagination{
+						TimestampFieldName: "created_at",
+					},
+				},
+			},
+			expectedErr: "has_more_field_name is only supported when pagination.mode is offset_limit or page_size",
+		},
+		{
+			name: "has_more_field_name rejected when pagination is disabled",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeNone,
+				Pagination: PaginationConfig{
+					Mode:             paginationModeNone,
+					HasMoreFieldName: "has_more",
+				},
+			},
+			expectedErr: "has_more_field_name is only supported when pagination.mode is offset_limit or page_size",
+		},
+		{
+			name: "valid has_more_field_name with offset_limit",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeNone,
+				Pagination: PaginationConfig{
+					Mode:             paginationModeOffsetLimit,
+					HasMoreFieldName: "has_more",
+					OffsetLimit: OffsetLimitPagination{
+						OffsetFieldName: "offset",
+						LimitFieldName:  "limit",
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "valid nested has_more_field_name with page_size",
+			config: &Config{
+				URL:      "https://api.example.com/data",
+				AuthMode: authModeNone,
+				Pagination: PaginationConfig{
+					Mode:             paginationModePageSize,
+					HasMoreFieldName: "response_metadata.has_more",
+					PageSize: PageSizePagination{
+						PageNumFieldName:  "page",
+						PageSizeFieldName: "size",
+					},
+				},
+			},
+			expectedErr: "",
+		},
+		{
 			name: "valid page_size with header response_source",
 			config: &Config{
 				URL:      "https://api.example.com/data",
@@ -1636,6 +1699,8 @@ func TestLoadConfigFromYAML(t *testing.T) {
 	require.Equal(t, methodPOST, restapiCfg.Method)
 	require.Contains(t, restapiCfg.RequestBody, `"filter": "status:'new'"`)
 	require.Contains(t, restapiCfg.RequestBody, "{{ .PageSize }}")
+
+	require.Equal(t, "response_metadata.has_more", restapiCfg.Pagination.HasMoreFieldName)
 }
 
 func TestConfig_MethodDefault(t *testing.T) {

--- a/receiver/restapireceiver/pagination.go
+++ b/receiver/restapireceiver/pagination.go
@@ -41,6 +41,59 @@ func toInt(v any) (int, bool) {
 	}
 }
 
+// toBool coerces a value to bool, handling native JSON booleans plus the string
+// spelling a header source always produces ("true") and the numeric spelling
+// some APIs use (1/0).
+// Returns (value, true) on success, (false, false) if the value cannot be converted.
+func toBool(v any) (bool, bool) {
+	switch val := v.(type) {
+	case bool:
+		return val, true
+	case string:
+		b, err := strconv.ParseBool(strings.TrimSpace(val))
+		return b, err == nil
+	case float64:
+		return val != 0, true
+	case int:
+		return val != 0, true
+	default:
+		return false, false
+	}
+}
+
+// explicitHasMore reads the API's own "there is more data" boolean, named by
+// pagination.has_more_field_name.
+//
+// Returns (value, true) only when the field is configured, present in this
+// response, and coercible to a bool. Every other case returns ok=false, leaving
+// the caller on the page-count heuristic: a response that omits the field says
+// nothing, and inventing a false there would end pagination early.
+func explicitHasMore(cfg *Config, response any, logger *zap.Logger) (bool, bool) {
+	if cfg.Pagination.HasMoreFieldName == "" {
+		return false, false
+	}
+
+	responseMap, ok := response.(map[string]any)
+	if !ok {
+		return false, false
+	}
+
+	val, exists := getNestedField(responseMap, cfg.Pagination.HasMoreFieldName)
+	if !exists || val == nil {
+		return false, false
+	}
+
+	hasMore, ok := toBool(val)
+	if !ok {
+		logger.Warn("has_more_field_name value is not a boolean, falling back to the page-size heuristic",
+			zap.String("field", cfg.Pagination.HasMoreFieldName),
+			zap.Any("value", val))
+		return false, false
+	}
+
+	return hasMore, true
+}
+
 // paginationState tracks the current state of pagination.
 type paginationState struct {
 	// For offset/limit pagination
@@ -213,10 +266,10 @@ func buildPaginationParams(cfg *Config, state *paginationState) url.Values {
 func parsePaginationResponse(cfg *Config, response any, extractedData []map[string]any, state *paginationState, logger *zap.Logger) (bool, error) {
 	switch cfg.Pagination.Mode {
 	case paginationModeOffsetLimit:
-		return parseOffsetLimitResponse(cfg, response, extractedData, state)
+		return parseOffsetLimitResponse(cfg, response, extractedData, state, logger)
 
 	case paginationModePageSize:
-		return parsePageSizeResponse(cfg, response, extractedData, state)
+		return parsePageSizeResponse(cfg, response, extractedData, state, logger)
 
 	case paginationModeTimestamp:
 		return parseTimestampResponse(cfg, extractedData, state, logger)
@@ -230,7 +283,7 @@ func parsePaginationResponse(cfg *Config, response any, extractedData []map[stri
 }
 
 // parseOffsetLimitResponse parses the response for offset/limit pagination.
-func parseOffsetLimitResponse(cfg *Config, response any, extractedData []map[string]any, state *paginationState) (bool, error) {
+func parseOffsetLimitResponse(cfg *Config, response any, extractedData []map[string]any, state *paginationState, logger *zap.Logger) (bool, error) {
 	// If NextOffsetFieldName is configured, use token-based offset extraction.
 	//
 	// Every "no next token" path below leaves CurrentOffsetToken untouched rather
@@ -271,9 +324,18 @@ func parseOffsetLimitResponse(cfg *Config, response any, extractedData []map[str
 		state.CurrentOffsetToken = tokenStr
 		state.PagesFetched++
 
-		// The token is a bookmark for resuming — always save it.
-		// But hasMore is determined by data count: a partial/empty page means
-		// we're caught up, even though the API returned a valid token.
+		// The token is a bookmark for resuming — always save it. Whether to
+		// follow it now is a separate question: an explicit has_more answers it,
+		// and otherwise data count stands in for the answer, a partial or empty
+		// page meaning we're caught up even though the token is valid.
+		//
+		// This sits below the "no next token" returns above on purpose. Those
+		// leave CurrentOffsetToken and PagesFetched untouched, so honoring a
+		// has_more of true there would re-request the same page forever.
+		if hasMore, ok := explicitHasMore(cfg, response, logger); ok {
+			return hasMore, nil
+		}
+
 		dataCount := len(extractedData)
 		return dataCount >= state.Limit, nil
 	}
@@ -287,6 +349,12 @@ func parseOffsetLimitResponse(cfg *Config, response any, extractedData []map[str
 				}
 			}
 		}
+	}
+
+	// An explicit has_more is the API's own answer — prefer it to both estimates
+	// below.
+	if hasMore, ok := explicitHasMore(cfg, response, logger); ok {
+		return hasMore, nil
 	}
 
 	// Determine if there are more records
@@ -309,7 +377,7 @@ func parseOffsetLimitResponse(cfg *Config, response any, extractedData []map[str
 }
 
 // parsePageSizeResponse parses the response for page/size pagination.
-func parsePageSizeResponse(cfg *Config, response any, extractedData []map[string]any, state *paginationState) (bool, error) {
+func parsePageSizeResponse(cfg *Config, response any, extractedData []map[string]any, state *paginationState, logger *zap.Logger) (bool, error) {
 	// Try to extract total pages if configured
 	if cfg.Pagination.PageSize.TotalPagesFieldName != "" {
 		if responseMap, ok := response.(map[string]any); ok {
@@ -319,6 +387,12 @@ func parsePageSizeResponse(cfg *Config, response any, extractedData []map[string
 				}
 			}
 		}
+	}
+
+	// An explicit has_more is the API's own answer — prefer it to both estimates
+	// below.
+	if hasMore, ok := explicitHasMore(cfg, response, logger); ok {
+		return hasMore, nil
 	}
 
 	// Determine if there are more pages

--- a/receiver/restapireceiver/pagination_test.go
+++ b/receiver/restapireceiver/pagination_test.go
@@ -722,7 +722,7 @@ func TestParseOffsetLimitResponse_TokenPresent_FullPage(t *testing.T) {
 	}
 
 	state := &paginationState{Limit: 10}
-	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state)
+	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state, zap.NewNop())
 	require.NoError(t, err)
 	require.True(t, hasMore)
 	require.Equal(t, "abc123", state.CurrentOffsetToken)
@@ -748,7 +748,7 @@ func TestParseOffsetLimitResponse_TokenPresent_PartialPage(t *testing.T) {
 	}
 
 	state := &paginationState{Limit: 10}
-	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state)
+	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state, zap.NewNop())
 	require.NoError(t, err)
 	require.False(t, hasMore)
 	require.Equal(t, "abc123", state.CurrentOffsetToken)
@@ -773,7 +773,7 @@ func TestParseOffsetLimitResponse_TokenPresent_EmptyPage(t *testing.T) {
 	}
 
 	state := &paginationState{Limit: 10}
-	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state)
+	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state, zap.NewNop())
 	require.NoError(t, err)
 	require.False(t, hasMore)
 	require.Equal(t, "bookmark123", state.CurrentOffsetToken)
@@ -797,7 +797,7 @@ func TestParseOffsetLimitResponse_TokenEmpty(t *testing.T) {
 	}
 
 	state := &paginationState{Limit: 10, CurrentOffsetToken: "previous"}
-	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state)
+	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state, zap.NewNop())
 	require.NoError(t, err)
 	require.False(t, hasMore)
 	require.Equal(t, "previous", state.CurrentOffsetToken,
@@ -821,7 +821,7 @@ func TestParseOffsetLimitResponse_TokenMissing(t *testing.T) {
 	}
 
 	state := &paginationState{Limit: 10, CurrentOffsetToken: "previous"}
-	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state)
+	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state, zap.NewNop())
 	require.NoError(t, err)
 	require.False(t, hasMore)
 	require.Equal(t, "previous", state.CurrentOffsetToken,
@@ -846,7 +846,7 @@ func TestParseOffsetLimitResponse_TokenNull(t *testing.T) {
 	}
 
 	state := &paginationState{Limit: 10, CurrentOffsetToken: "previous"}
-	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state)
+	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state, zap.NewNop())
 	require.NoError(t, err)
 	require.False(t, hasMore)
 	require.Equal(t, "previous", state.CurrentOffsetToken,
@@ -872,7 +872,7 @@ func TestParseOffsetLimitResponse_NonMapResponse(t *testing.T) {
 	extracted := []map[string]any{{"id": "1"}}
 
 	state := &paginationState{Limit: 10, CurrentOffsetToken: "previous"}
-	hasMore, err := parseOffsetLimitResponse(cfg, response, extracted, state)
+	hasMore, err := parseOffsetLimitResponse(cfg, response, extracted, state, zap.NewNop())
 	require.NoError(t, err)
 	require.False(t, hasMore)
 	require.Equal(t, "previous", state.CurrentOffsetToken,
@@ -904,7 +904,7 @@ func TestParseOffsetLimitResponse_TokenNested(t *testing.T) {
 	}
 
 	state := &paginationState{Limit: 10}
-	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state)
+	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state, zap.NewNop())
 	require.NoError(t, err)
 	require.True(t, hasMore)
 	require.Equal(t, "cursor_xyz", state.CurrentOffsetToken)
@@ -935,7 +935,7 @@ func TestParseOffsetLimitResponse_TokenNumeric(t *testing.T) {
 			"next_offset": float64(42),
 		}
 		state := &paginationState{Limit: 10}
-		hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state)
+		hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state, zap.NewNop())
 		require.NoError(t, err)
 		require.True(t, hasMore)
 		require.Equal(t, "42", state.CurrentOffsetToken)
@@ -947,7 +947,7 @@ func TestParseOffsetLimitResponse_TokenNumeric(t *testing.T) {
 			"next_offset": 99,
 		}
 		state := &paginationState{Limit: 10}
-		hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state)
+		hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state, zap.NewNop())
 		require.NoError(t, err)
 		require.True(t, hasMore)
 		require.Equal(t, "99", state.CurrentOffsetToken)
@@ -976,7 +976,7 @@ func TestParseOffsetLimitResponse_NoTokenFieldConfigured(t *testing.T) {
 		Limit:         10,
 	}
 
-	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state)
+	hasMore, err := parseOffsetLimitResponse(cfg, response, testExtractData(response), state, zap.NewNop())
 	require.NoError(t, err)
 	require.True(t, hasMore)
 	require.Equal(t, 10, state.TotalRecords)
@@ -1933,7 +1933,7 @@ func TestParseOffsetLimitResponse_NumericTokenFormatting(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			state := &paginationState{Limit: 10}
-			_, err := parseOffsetLimitResponse(cfg, map[string]any{"next_offset": tc.tokenVal}, []map[string]any{}, state)
+			_, err := parseOffsetLimitResponse(cfg, map[string]any{"next_offset": tc.tokenVal}, []map[string]any{}, state, zap.NewNop())
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, state.CurrentOffsetToken)
 			require.Equal(t, tc.expected, buildPaginationParams(cfg, state).Get("offset"))
@@ -2041,9 +2041,312 @@ func TestNewPaginationState_PageSize_ConfiguredPageSize(t *testing.T) {
 			// The value sent and the full-page threshold are the same variable.
 			require.Equal(t, strconv.Itoa(tc.expected), buildPaginationParams(cfg, state).Get("size"))
 			full := make([]map[string]any, tc.expected)
-			more, err := parsePageSizeResponse(cfg, map[string]any{}, full, state)
+			more, err := parsePageSizeResponse(cfg, map[string]any{}, full, state, zap.NewNop())
 			require.NoError(t, err)
 			require.True(t, more, "a full page should report more pages")
+		})
+	}
+}
+
+func TestToBool(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  any
+		want   bool
+		wantOK bool
+	}{
+		{name: "native true", input: true, want: true, wantOK: true},
+		{name: "native false", input: false, want: false, wantOK: true},
+		{name: "string true", input: "true", want: true, wantOK: true},
+		{name: "string false", input: "false", want: false, wantOK: true},
+		{name: "string capitalized", input: "True", want: true, wantOK: true},
+		{name: "string uppercase", input: "TRUE", want: true, wantOK: true},
+		{name: "string one", input: "1", want: true, wantOK: true},
+		{name: "string zero", input: "0", want: false, wantOK: true},
+		{name: "string padded by a header source", input: " true ", want: true, wantOK: true},
+		{name: "json number one", input: float64(1), want: true, wantOK: true},
+		{name: "json number zero", input: float64(0), want: false, wantOK: true},
+		{name: "int one", input: 1, want: true, wantOK: true},
+		{name: "int zero", input: 0, want: false, wantOK: true},
+		{name: "unparseable string", input: "yes please", want: false, wantOK: false},
+		{name: "empty string", input: "", want: false, wantOK: false},
+		{name: "map", input: map[string]any{}, want: false, wantOK: false},
+		{name: "slice", input: []any{}, want: false, wantOK: false},
+		{name: "nil", input: nil, want: false, wantOK: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := toBool(tc.input)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// items builds a data array of n records for the pagination heuristics, which
+// only ever look at its length.
+func items(n int) []map[string]any {
+	data := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		data = append(data, map[string]any{"id": fmt.Sprintf("%d", i)})
+	}
+	return data
+}
+
+func offsetLimitHasMoreConfig(hasMoreField string, ol OffsetLimitPagination) *Config {
+	return &Config{
+		Pagination: PaginationConfig{
+			Mode:             paginationModeOffsetLimit,
+			HasMoreFieldName: hasMoreField,
+			OffsetLimit:      ol,
+		},
+	}
+}
+
+// TestHasMoreFieldName covers pagination.has_more_field_name: when the API
+// states continuation outright it replaces the "a full page means there may be
+// more" count heuristic, so limit / page_size no longer have to match the API's
+// real page size. Each case pairs a has_more value with a data count the
+// heuristic would read the opposite way, so a regression that ignored the field
+// would flip the expectation.
+func TestHasMoreFieldName(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *Config
+		response    map[string]any
+		state       *paginationState
+		wantHasMore bool
+		wantToken   string
+	}{
+		{
+			// The headline fix: a short page no longer ends the cycle when the
+			// API says otherwise, so limit may exceed the real page size.
+			name: "token pagination continues on a short page when has_more is true",
+			cfg:  offsetLimitHasMoreConfig("has_more", OffsetLimitPagination{NextOffsetFieldName: "next_cursor"}),
+			response: map[string]any{
+				"data":        items(2),
+				"next_cursor": "cursor-2",
+				"has_more":    true,
+			},
+			state:       &paginationState{Limit: 100},
+			wantHasMore: true,
+			wantToken:   "cursor-2",
+		},
+		{
+			// The other direction: a full page no longer costs a wasted request
+			// when the API says the backlog is drained.
+			name: "token pagination stops on a full page when has_more is false",
+			cfg:  offsetLimitHasMoreConfig("has_more", OffsetLimitPagination{NextOffsetFieldName: "next_cursor"}),
+			response: map[string]any{
+				"data":        items(3),
+				"next_cursor": "cursor-2",
+				"has_more":    false,
+			},
+			state:       &paginationState{Limit: 3},
+			wantHasMore: false,
+			// Still recorded: the token is the bookmark the next poll resumes from.
+			wantToken: "cursor-2",
+		},
+		{
+			// A has_more of true with no cursor to advance with would re-request
+			// the same page forever, so the missing token wins.
+			name: "token pagination stops when has_more is true but no cursor is returned",
+			cfg:  offsetLimitHasMoreConfig("has_more", OffsetLimitPagination{NextOffsetFieldName: "next_cursor"}),
+			response: map[string]any{
+				"data":     items(3),
+				"has_more": true,
+			},
+			state:       &paginationState{Limit: 3, CurrentOffsetToken: "cursor-1"},
+			wantHasMore: false,
+			// The stored cursor is preserved rather than discarded.
+			wantToken: "cursor-1",
+		},
+		{
+			name: "numeric offset stops when has_more is false despite a full page",
+			cfg: offsetLimitHasMoreConfig("has_more", OffsetLimitPagination{
+				OffsetFieldName: "offset",
+				LimitFieldName:  "limit",
+			}),
+			response: map[string]any{
+				"data":     items(10),
+				"has_more": false,
+			},
+			state:       &paginationState{Limit: 10},
+			wantHasMore: false,
+		},
+		{
+			name: "numeric offset continues when has_more is true despite a short page",
+			cfg: offsetLimitHasMoreConfig("has_more", OffsetLimitPagination{
+				OffsetFieldName: "offset",
+				LimitFieldName:  "limit",
+			}),
+			response: map[string]any{
+				"data":     items(2),
+				"has_more": true,
+			},
+			state:       &paginationState{Limit: 10},
+			wantHasMore: true,
+		},
+		{
+			// has_more is the API's own answer, so it outranks the derived
+			// offset-vs-total comparison too.
+			name: "has_more outranks total_record_count_field",
+			cfg: func() *Config {
+				cfg := offsetLimitHasMoreConfig("has_more", OffsetLimitPagination{
+					OffsetFieldName: "offset",
+					LimitFieldName:  "limit",
+				})
+				cfg.Pagination.TotalRecordCountField = "total"
+				return cfg
+			}(),
+			response: map[string]any{
+				"data":     items(2),
+				"total":    float64(1000),
+				"has_more": false,
+			},
+			state:       &paginationState{Limit: 10},
+			wantHasMore: false,
+		},
+		{
+			name: "nested has_more field",
+			cfg: offsetLimitHasMoreConfig("response_metadata.has_more", OffsetLimitPagination{
+				NextOffsetFieldName: "response_metadata.next_cursor",
+			}),
+			response: map[string]any{
+				"data": items(2),
+				"response_metadata": map[string]any{
+					"next_cursor": "cursor-2",
+					"has_more":    true,
+				},
+			},
+			state:       &paginationState{Limit: 100},
+			wantHasMore: true,
+			wantToken:   "cursor-2",
+		},
+		{
+			// A header source yields strings, never JSON booleans.
+			name: "string true from a header source",
+			cfg: offsetLimitHasMoreConfig("X-Has-More", OffsetLimitPagination{
+				OffsetFieldName: "offset",
+				LimitFieldName:  "limit",
+			}),
+			response: map[string]any{
+				"data":       items(2),
+				"X-Has-More": "true",
+			},
+			state:       &paginationState{Limit: 10},
+			wantHasMore: true,
+		},
+		{
+			name: "string false from a header source",
+			cfg: offsetLimitHasMoreConfig("X-Has-More", OffsetLimitPagination{
+				OffsetFieldName: "offset",
+				LimitFieldName:  "limit",
+			}),
+			response: map[string]any{
+				"data":       items(10),
+				"X-Has-More": "false",
+			},
+			state:       &paginationState{Limit: 10},
+			wantHasMore: false,
+		},
+		{
+			// An API that only emits has_more on some responses must still
+			// paginate, so a missing field falls back rather than ending the run.
+			name: "missing has_more falls back to the full-page heuristic",
+			cfg: offsetLimitHasMoreConfig("has_more", OffsetLimitPagination{
+				OffsetFieldName: "offset",
+				LimitFieldName:  "limit",
+			}),
+			response:    map[string]any{"data": items(10)},
+			state:       &paginationState{Limit: 10},
+			wantHasMore: true,
+		},
+		{
+			name: "null has_more falls back to the full-page heuristic",
+			cfg: offsetLimitHasMoreConfig("has_more", OffsetLimitPagination{
+				OffsetFieldName: "offset",
+				LimitFieldName:  "limit",
+			}),
+			response:    map[string]any{"data": items(2), "has_more": nil},
+			state:       &paginationState{Limit: 10},
+			wantHasMore: false,
+		},
+		{
+			name: "uncoercible has_more falls back to the full-page heuristic",
+			cfg: offsetLimitHasMoreConfig("has_more", OffsetLimitPagination{
+				OffsetFieldName: "offset",
+				LimitFieldName:  "limit",
+			}),
+			response:    map[string]any{"data": items(10), "has_more": map[string]any{"nested": true}},
+			state:       &paginationState{Limit: 10},
+			wantHasMore: true,
+		},
+		{
+			name: "unset has_more_field_name leaves the heuristic in charge",
+			cfg: offsetLimitHasMoreConfig("", OffsetLimitPagination{
+				OffsetFieldName: "offset",
+				LimitFieldName:  "limit",
+			}),
+			// has_more present but not configured, so it is ignored.
+			response:    map[string]any{"data": items(10), "has_more": false},
+			state:       &paginationState{Limit: 10},
+			wantHasMore: true,
+		},
+		{
+			name: "page_size stops when has_more is false despite a full page",
+			cfg: &Config{
+				Pagination: PaginationConfig{
+					Mode:             paginationModePageSize,
+					HasMoreFieldName: "has_more",
+					PageSize:         PageSizePagination{PageNumFieldName: "page", PageSizeFieldName: "size"},
+				},
+			},
+			response:    map[string]any{"data": items(20), "has_more": false},
+			state:       &paginationState{CurrentPage: 1, PageSize: 20},
+			wantHasMore: false,
+		},
+		{
+			name: "page_size continues when has_more is true despite a short page",
+			cfg: &Config{
+				Pagination: PaginationConfig{
+					Mode:             paginationModePageSize,
+					HasMoreFieldName: "has_more",
+					PageSize:         PageSizePagination{PageNumFieldName: "page", PageSizeFieldName: "size"},
+				},
+			},
+			response:    map[string]any{"data": items(3), "has_more": true},
+			state:       &paginationState{CurrentPage: 1, PageSize: 20},
+			wantHasMore: true,
+		},
+		{
+			name: "has_more outranks total_pages_field_name",
+			cfg: &Config{
+				Pagination: PaginationConfig{
+					Mode:             paginationModePageSize,
+					HasMoreFieldName: "has_more",
+					PageSize: PageSizePagination{
+						PageNumFieldName:    "page",
+						PageSizeFieldName:   "size",
+						TotalPagesFieldName: "total_pages",
+					},
+				},
+			},
+			response:    map[string]any{"data": items(20), "total_pages": float64(50), "has_more": false},
+			state:       &paginationState{CurrentPage: 1, PageSize: 20},
+			wantHasMore: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hasMore, err := parsePaginationResponse(tc.cfg, tc.response, testExtractData(tc.response), tc.state, zap.NewNop())
+			require.NoError(t, err)
+			require.Equal(t, tc.wantHasMore, hasMore)
+			if tc.wantToken != "" {
+				require.Equal(t, tc.wantToken, tc.state.CurrentOffsetToken)
+			}
 		})
 	}
 }

--- a/receiver/restapireceiver/receiver.go
+++ b/receiver/restapireceiver/receiver.go
@@ -414,6 +414,9 @@ func (b *baseReceiver) paginationResponseFields() []string {
 	if b.cfg.Pagination.TotalRecordCountField != "" {
 		fields = append(fields, b.cfg.Pagination.TotalRecordCountField)
 	}
+	if b.cfg.Pagination.HasMoreFieldName != "" {
+		fields = append(fields, b.cfg.Pagination.HasMoreFieldName)
+	}
 
 	switch b.cfg.Pagination.Mode {
 	case paginationModeOffsetLimit:

--- a/receiver/restapireceiver/receiver_test.go
+++ b/receiver/restapireceiver/receiver_test.go
@@ -2061,3 +2061,161 @@ func TestMetricsPoll_TailPreservesAndPersistsCursor(t *testing.T) {
 	require.Equal(t, "cursor-from-earlier-poll", saved.PaginationState.CurrentOffsetToken,
 		"the persisted checkpoint must carry the cursor the next poll resumes from")
 }
+
+// TestRESTAPILogsReceiver_HasMoreDrainsBacklogInOneCycle is the end-to-end case
+// pagination.has_more_field_name exists for: limit is deliberately set far above
+// the page size the API actually returns, which under the count heuristic makes
+// every page look partial and stops pagination after page one. With the API's
+// own has_more honored, the whole backlog drains within a single poll cycle.
+//
+// The poll intervals are long enough that only the initial poll can run inside
+// the assertion window, so three requests means three pages in one cycle rather
+// than one page across three cycles.
+func TestRESTAPILogsReceiver_HasMoreDrainsBacklogInOneCycle(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		cursor := r.URL.Query().Get("cursor")
+
+		// Two records per page — well under the configured limit of 100.
+		var response map[string]any
+		switch cursor {
+		case "":
+			response = map[string]any{
+				"data":        []map[string]any{{"id": "1"}, {"id": "2"}},
+				"next_cursor": "cursor-2",
+				"has_more":    true,
+			}
+		case "cursor-2":
+			response = map[string]any{
+				"data":        []map[string]any{{"id": "3"}, {"id": "4"}},
+				"next_cursor": "cursor-3",
+				"has_more":    true,
+			}
+		default:
+			response = map[string]any{
+				"data":        []map[string]any{{"id": "5"}, {"id": "6"}},
+				"next_cursor": "cursor-4",
+				"has_more":    false,
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:           server.URL,
+		AuthMode:      authModeNone,
+		ResponseField: "data",
+		Pagination: PaginationConfig{
+			Mode:             paginationModeOffsetLimit,
+			HasMoreFieldName: "has_more",
+			OffsetLimit: OffsetLimitPagination{
+				OffsetFieldName:     "cursor",
+				LimitFieldName:      "limit",
+				Limit:               100,
+				NextOffsetFieldName: "next_cursor",
+				OffsetType:          offsetTypeOpaque,
+			},
+		},
+		MinPollInterval: 30 * time.Second,
+		MaxPollInterval: 30 * time.Second,
+		ClientConfig:    confighttp.ClientConfig{},
+	}
+
+	// Validate applies the production defaults, notably backoff_multiplier. Left
+	// at its zero value the backoff would drive the poll interval to 0 and
+	// busy-loop, making the request counts below a race.
+	require.NoError(t, cfg.Validate())
+
+	sink := new(consumertest.LogsSink)
+	params := receivertest.NewNopSettings(metadata.Type)
+	receiver, err := newRESTAPILogsReceiver(params, cfg, sink)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, receiver.Start(ctx, componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, receiver.Shutdown(ctx))
+	}()
+
+	require.Eventually(t, func() bool {
+		return logRecordCount(sink) >= 6
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Exactly three requests: the cycle followed has_more twice and stopped when
+	// it went false, rather than paging on against a valid cursor.
+	require.Equal(t, int32(3), requestCount.Load())
+	require.Equal(t, 6, logRecordCount(sink))
+}
+
+// TestRESTAPILogsReceiver_HasMoreFromHeader covers has_more_field_name under
+// response_source: header, where the value arrives as the string "true" and has
+// to be injected alongside the cursor header for the pagination logic to see it.
+func TestRESTAPILogsReceiver_HasMoreFromHeader(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		cursor := r.URL.Query().Get("cursor")
+
+		w.Header().Set("Content-Type", "application/json")
+		if cursor == "" {
+			w.Header().Set("X-Next-Cursor", "page-2")
+			w.Header().Set("X-Has-More", "true")
+			json.NewEncoder(w).Encode([]map[string]any{{"id": "1"}, {"id": "2"}})
+			return
+		}
+
+		w.Header().Set("X-Next-Cursor", "page-3")
+		w.Header().Set("X-Has-More", "false")
+		json.NewEncoder(w).Encode([]map[string]any{{"id": "3"}})
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		URL:      server.URL,
+		AuthMode: authModeNone,
+		Pagination: PaginationConfig{
+			Mode:             paginationModeOffsetLimit,
+			ResponseSource:   responseSourceHeader,
+			HasMoreFieldName: "X-Has-More",
+			OffsetLimit: OffsetLimitPagination{
+				OffsetFieldName:     "cursor",
+				LimitFieldName:      "limit",
+				Limit:               50,
+				NextOffsetFieldName: "X-Next-Cursor",
+				OffsetType:          offsetTypeOpaque,
+			},
+		},
+		MinPollInterval: 30 * time.Second,
+		MaxPollInterval: 30 * time.Second,
+		ClientConfig:    confighttp.ClientConfig{},
+	}
+
+	// Validate applies the production defaults, notably backoff_multiplier. Left
+	// at its zero value the backoff would drive the poll interval to 0 and
+	// busy-loop, making the request counts below a race.
+	require.NoError(t, cfg.Validate())
+
+	sink := new(consumertest.LogsSink)
+	params := receivertest.NewNopSettings(metadata.Type)
+	receiver, err := newRESTAPILogsReceiver(params, cfg, sink)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, receiver.Start(ctx, componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, receiver.Shutdown(ctx))
+	}()
+
+	require.Eventually(t, func() bool {
+		return logRecordCount(sink) >= 3
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// The string "true" in the header carried page one to page two; "false"
+	// stopped it there, despite a short page under a limit of 50.
+	require.Equal(t, int32(2), requestCount.Load())
+	require.Equal(t, 3, logRecordCount(sink))
+}

--- a/receiver/restapireceiver/testdata/test-config.yaml
+++ b/receiver/restapireceiver/testdata/test-config.yaml
@@ -17,6 +17,7 @@ receivers:
       value: test-key
     pagination:
       mode: page_size
+      has_more_field_name: "response_metadata.has_more"
       page_size:
         page_num_field_name: "page"
         page_size_field_name: "size"


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Previously, the REST receiver relied on the `limit` field to determine whether an API had returned a full response and had more telemetry to query. Some APIs operate this way, but others will include a field that explicitly says if there is more information to query.
This PR adds a `pagination.has_more_field_name` field to the receiver's configuration to simplify the logic and enable the `limit` field to act as a throughput control.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed